### PR TITLE
FdbKeyRange.StartsWith and FdbKeyRange.PrefixedBy both throw exceptions when passed a prefix that contains only zero or more \xFF bytes.

### DIFF
--- a/FoundationDB.Client/Fdb.Errors.cs
+++ b/FoundationDB.Client/Fdb.Errors.cs
@@ -102,7 +102,7 @@ namespace FoundationDB.Client
 
 			internal static Exception CannotIncrementKey()
 			{
-				return new OverflowException("Incremented key must contain at least one byte not equal to 0xFF");
+				return new ArgumentException("Key must contain at least one byte not equal to 0xFF");
 			}
 		}
 

--- a/FoundationDB.Client/FdbKeyRange.cs
+++ b/FoundationDB.Client/FdbKeyRange.cs
@@ -62,16 +62,6 @@ namespace FoundationDB.Client
 		{
 			if (prefix.IsNull) throw Fdb.Errors.KeyCannotBeNull("prefix");
 
-			if (prefix.Count == 0)
-			{ // "" => [ "", "\xFF\xFF" )
-				return new FdbKeyRange(Slice.Empty, Fdb.SystemKeys.MaxValue);
-			}
-
-			if (prefix.Count == 1 && prefix[0] == 0xFF)
-			{ // "\xFF" => ["\xFF", "\xFF\xFF")
-				return new FdbKeyRange(FdbKey.MaxValue, Fdb.SystemKeys.MaxValue);
-			}
-
 			// prefix => [ prefix, prefix + 1 )
 			return new FdbKeyRange(
 				prefix,
@@ -85,16 +75,6 @@ namespace FoundationDB.Client
 		public static FdbKeyRange PrefixedBy(Slice prefix)
 		{
 			if (prefix.IsNull) throw Fdb.Errors.KeyCannotBeNull("prefix");
-
-			if (prefix.Count == 0)
-			{ // "" => ["\0", "\xFF\xFF")
-				return new FdbKeyRange(FdbKey.MinValue, Fdb.SystemKeys.MaxValue);
-			}
-
-			if (prefix.Count == 1 && prefix[0] == 0xFF)
-			{ // "\xFF" => ["\xFF\x00", "\xFF\xFF")
-				return new FdbKeyRange(Fdb.SystemKeys.MinValue, Fdb.SystemKeys.MaxValue);
-			}
 
 			// prefix => [ prefix."\0", prefix + 1)
 			return new FdbKeyRange(

--- a/FoundationDB.Tests/KeyFacts.cs
+++ b/FoundationDB.Tests/KeyFacts.cs
@@ -80,8 +80,8 @@ namespace FoundationDB.Client.Tests
 
 			// corner cases
 			Assert.That(() => FdbKey.Increment(Slice.Nil), Throws.InstanceOf<ArgumentException>().With.Property("ParamName").EqualTo("slice"));
-			Assert.That(() => FdbKey.Increment(Slice.Empty), Throws.InstanceOf<OverflowException>());
-			Assert.That(() => FdbKey.Increment(Slice.FromAscii("\xFF")), Throws.InstanceOf<OverflowException>());
+			Assert.That(() => FdbKey.Increment(Slice.Empty), Throws.InstanceOf<ArgumentException>());
+			Assert.That(() => FdbKey.Increment(Slice.FromAscii("\xFF")), Throws.InstanceOf<ArgumentException>());
 
 		}
 
@@ -281,22 +281,19 @@ namespace FoundationDB.Client.Tests
 		{
 			FdbKeyRange range;
 
-			// "" => [ "", "\xFF\xFF" )
-			range = FdbKeyRange.StartsWith(Slice.Empty);
-			Assert.That(range.Begin, Is.EqualTo(Slice.Empty));
-			Assert.That(range.End, Is.EqualTo(Slice.FromAscii("\xFF\xFF")));
-
 			// "abc" => [ "abc", "abd" )
 			range = FdbKeyRange.StartsWith(Slice.FromAscii("abc"));
 			Assert.That(range.Begin, Is.EqualTo(Slice.FromAscii("abc")));
 			Assert.That(range.End, Is.EqualTo(Slice.FromAscii("abd")));
 
-			// "\xFF" => [ "\xFF", "\xFF\xFF" )
-			range = FdbKeyRange.StartsWith(Slice.FromAscii("\xFF"));
-			Assert.That(range.Begin, Is.EqualTo(Slice.FromAscii("\xFF")));
-			Assert.That(range.End, Is.EqualTo(Slice.FromAscii("\xFF\xFF")));
+			// "" => ArgumentException
+			Assert.That(() => FdbKeyRange.PrefixedBy(Slice.Empty), Throws.InstanceOf<ArgumentException>());
 
-			Assert.That(() => FdbKeyRange.StartsWith(Slice.Nil), Throws.InstanceOf<ArgumentException>());
+			// "\xFF" => ArgumentException
+			Assert.That(() => FdbKeyRange.PrefixedBy(Slice.FromAscii("\xFF")), Throws.InstanceOf<ArgumentException>());
+
+			// null => ArgumentException
+			Assert.That(() => FdbKeyRange.PrefixedBy(Slice.Nil), Throws.InstanceOf<ArgumentException>());
 		}
 
 		[Test]
@@ -304,21 +301,18 @@ namespace FoundationDB.Client.Tests
 		{
 			FdbKeyRange range;
 
-			// "" => [ "\x00", "\xFF\xFF" )
-			range = FdbKeyRange.PrefixedBy(Slice.Empty);
-			Assert.That(range.Begin, Is.EqualTo(Slice.FromAscii("\x00")));
-			Assert.That(range.End, Is.EqualTo(Slice.FromAscii("\xFF\xFF")));
-
 			// "abc" => [ "abc\x00", "abd" )
 			range = FdbKeyRange.PrefixedBy(Slice.FromAscii("abc"));
 			Assert.That(range.Begin, Is.EqualTo(Slice.FromAscii("abc\x00")));
 			Assert.That(range.End, Is.EqualTo(Slice.FromAscii("abd")));
 
-			// "\xFF" => [ "\xFF\x00", "\xFF\xFF" )
-			range = FdbKeyRange.PrefixedBy(Slice.FromAscii("\xFF"));
-			Assert.That(range.Begin, Is.EqualTo(Slice.FromAscii("\xFF\x00")));
-			Assert.That(range.End, Is.EqualTo(Slice.FromAscii("\xFF\xFF")));
+			// "" => ArgumentException
+			Assert.That(() => FdbKeyRange.PrefixedBy(Slice.Empty), Throws.InstanceOf<ArgumentException>());
 
+			// "\xFF" => ArgumentException
+			Assert.That(() => FdbKeyRange.PrefixedBy(Slice.FromAscii("\xFF")), Throws.InstanceOf<ArgumentException>());
+
+			// null => ArgumentException
 			Assert.That(() => FdbKeyRange.PrefixedBy(Slice.Nil), Throws.InstanceOf<ArgumentException>());
 		}
 

--- a/FoundationDB.Tests/TransactionFacts.cs
+++ b/FoundationDB.Tests/TransactionFacts.cs
@@ -632,7 +632,7 @@ namespace FoundationDB.Client.Tests
 
 					try
 					{
-						var _ = await tr.GetRangeStartsWith(Slice.FromAscii("\xFF"), new FdbRangeOptions { Limit = 10 }).ToListAsync();
+						var _ = await tr.GetRange(Slice.FromAscii("\xFF"), Slice.FromAscii("\xFF\xFF"), new FdbRangeOptions { Limit = 10 }).ToListAsync();
 						Assert.Fail("Should not have access to system keys by default");
 					}
 					catch (Exception e)
@@ -645,7 +645,7 @@ namespace FoundationDB.Client.Tests
 					// should succeed once system access has been requested
 					tr.WithAccessToSystemKeys();
 
-					var keys = await tr.GetRangeStartsWith(Slice.FromAscii("\xFF"), new FdbRangeOptions { Limit = 10 }).ToListAsync();
+					var keys = await tr.GetRange(Slice.FromAscii("\xFF"), Slice.FromAscii("\xFF\xFF"), new FdbRangeOptions { Limit = 10 }).ToListAsync();
 					Assert.That(keys, Is.Not.Null);
 				}
 


### PR DESCRIPTION
Here is a proposed implementation of this. I basically just call increment with these special keys and let increment throw the exception. I modified the text and type of the exception to be a little more useful hopefully, but if you think it's still bad we can tweak it.
