### PR TITLE
Some fixes to NodeContainingKey

### DIFF
--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
@@ -814,15 +814,18 @@ namespace FoundationDB.Layers.Directories
 			var kvp = await tr
 				.GetRange(
 					this.NodeSubspace.ToRange().Begin,
-					this.NodeSubspace.Pack(FdbTuple.Pack(key)) + FdbKey.MinValue
+					this.NodeSubspace.Pack(key) + FdbKey.MinValue
 				)
 				.LastOrDefaultAsync()
 				.ConfigureAwait(false);
 
-			var k = this.NodeSubspace.Unpack(kvp.Key);
-			if (kvp.Key.HasValue && key.StartsWith(this.NodeSubspace.UnpackSingle<Slice>(kvp.Key)))
+			if (kvp.Key.HasValue) 
 			{
-				return new FdbSubspace(k);
+				var prevPrefix = this.NodeSubspace.UnpackFirst<Slice>(kvp.Key);
+				if (key.StartsWith(prevPrefix))
+				{
+					return NodeWithPrefix(prevPrefix);
+				}
 			}
 
 			return null;


### PR DESCRIPTION
I removed an extra FdbTuple.Pack and switched from UnpackSingle to UnpackFirst. I fixed an asymptomatic bug that is also present in the python directory layer, where the subspace returned has the wrong prefix (which currently is never used).

I noticed that UnpackSingle's documentation says that it will throw an error if the tuple has more than one element, but it currently doesn't. I didn't make any changes to this method.
