### PR TITLE
Remove extra calls to FdbTuple.Pack

### DIFF
--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
@@ -948,8 +948,8 @@ namespace FoundationDB.Layers.Directories
 
 			return await tr
 				.GetRange(
-					this.NodeSubspace.Pack(FdbTuple.Pack(prefix)),
-					this.NodeSubspace.Pack(FdbTuple.Pack(FdbKey.Increment(prefix)))
+					this.NodeSubspace.Pack(prefix),
+					this.NodeSubspace.Pack(FdbKey.Increment(prefix))
 				)
 				.NoneAsync()
 				.ConfigureAwait(false);


### PR DESCRIPTION
I found one more place where tuples were double-packed
