### PR TITLE
Add MoveToAsync and TryMoveToAsync to IFdbDirectory. 

### DIFF
--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
@@ -306,6 +306,20 @@ namespace FoundationDB.Layers.Directories
 
 		#endregion
 
+		#region MoveTo / TryMoveTo
+
+		public Task<FdbDirectorySubspace> MoveToAsync(IFdbTransaction trans, IEnumerable<string> newAbsolutePath)
+		{
+			throw new NotSupportedException("The root directory cannot be moved");
+		}
+
+		public Task<FdbDirectorySubspace> TryMoveToAsync(IFdbTransaction trans, IEnumerable<string> newAbsolutePath)
+		{
+			throw new NotSupportedException("The root directory cannot be moved");
+		}
+
+		#endregion
+
 		#region Remove / TryRemove
 
 		/// <summary>Removes the directory, its contents, and all subdirectories.

--- a/FoundationDB.Client/Layers/Directories/IFdbDirectory.cs
+++ b/FoundationDB.Client/Layers/Directories/IFdbDirectory.cs
@@ -108,8 +108,26 @@ namespace FoundationDB.Layers.Directories
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="oldPath">Relative path under this directory of the subdirectory to be moved</param>
 		/// <param name="newPath">Relative path under this directory where the subdirectory will be moved to</param>
-		/// <returns>Returns the directory at its new location if successful. If the directory cannot be moved, then null is returned.</returns>
+		/// <returns>Returns the directory at its new location if successful. If the directory doesn't exist, then null is returned.</returns>
 		Task<FdbDirectorySubspace> TryMoveAsync(IFdbTransaction trans, IEnumerable<string> oldPath, IEnumerable<string> newPath);
+
+		/// <summary>Moves the current directory to <paramref name="newAbsolutePath"/>.
+		/// There is no effect on the physical prefix of the given directory, or on clients that already have the directory open.
+		/// An error is raised if a directory already exists at `new_path`, or if the new path points to a child of the current directory.
+		/// </summary>
+		/// <param name="trans">Transaction to use for the operation</param>
+		/// <param name="newAbsolutePath">Full path (from the root) where this directory will be moved</param>
+		/// <returns>Returns the directory at its new location if successful.</returns>
+		Task<FdbDirectorySubspace> MoveToAsync(IFdbTransaction trans, IEnumerable<string> newAbsolutePath);
+
+		/// <summary>Attempts to move the current directory to <paramref name="newPath"/>.
+		/// There is no effect on the physical prefix of the given directory, or on clients that already have the directory open.
+		/// An error is raised if a directory already exists at `new_path`, or if the new path points to a child of the current directory.
+		/// </summary>
+		/// <param name="trans">Transaction to use for the operation</param>
+		/// <param name="newPath">Full path (from the root) where this directory will be moved</param>
+		/// <returns>Returns the directory at its new location if successful. If the directory doesn't exist, then null is returned.</returns>
+		Task<FdbDirectorySubspace> TryMoveToAsync(IFdbTransaction trans, IEnumerable<string> newAbsolutePath);
 
 		/// <summary>Removes the directory, its contents, and all subdirectories.
 		/// Warning: Clients that have already opened the directory might still insert data into its contents after it is removed.

--- a/FoundationDB.Client/Subspaces/FdbDatabasePartition.cs
+++ b/FoundationDB.Client/Subspaces/FdbDatabasePartition.cs
@@ -253,6 +253,24 @@ namespace FoundationDB.Client
 
 		#endregion
 
+		#region MoveTo...
+
+		public Task<FdbDirectorySubspace> MoveToAsync(IFdbTransaction trans, IEnumerable<string> newAbsolutePath)
+		{
+			throw new NotSupportedException("Database partitions cannot be moved");
+		}
+
+		#endregion
+
+		#region TryMoveTo...
+
+		public Task<FdbDirectorySubspace> TryMoveToAsync(IFdbTransaction trans, IEnumerable<string> newAbsolutePath)
+		{
+			throw new NotSupportedException("Database partitions cannot be moved");
+		}
+
+		#endregion
+
 		#region Remove...
 
 		public Task RemoveAsync(string name, CancellationToken cancellationToken)


### PR DESCRIPTION
This method throws an error in FdbDirectoryLayer and FdbDatabasePartition.

Also correct the documentation of TryMoveAsync in FdbDirectorySubspace.
