### PR TITLE
Fix build script NuGet packaging

### DIFF
--- a/build/FoundationDB.Client.nuspec
+++ b/build/FoundationDB.Client.nuspec
@@ -17,8 +17,8 @@
     <tags>foundationdb nosql</tags>
   </metadata>
   <files>
-    <file src="output\FoundationDB.Client\FoundationDB.Client.dll" target="lib\net45" />
-    <file src="output\FoundationDB.Client\FoundationDB.Client.XML" target="lib\net45" />
-    <file src="output\FoundationDB.Client\FoundationDB.Client.pdb" target="lib\net45" />
+    <file src="FoundationDB.Client.dll" target="lib\net45" />
+    <file src="FoundationDB.Client.XML" target="lib\net45" />
+    <file src="FoundationDB.Client.pdb" target="lib\net45" />
   </files>
 </package>

--- a/build/FoundationDB.Layers.Common.nuspec
+++ b/build/FoundationDB.Layers.Common.nuspec
@@ -20,8 +20,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output\FoundationDB.Layers.Common\FoundationDB.Layers.Common.dll" target="lib\net-45" />
-    <file src="output\FoundationDB.Layers.Common\FoundationDB.Layers.Common.XML" target="lib\net-45" />
-    <file src="output\FoundationDB.Layers.Common\FoundationDB.Layers.Common.pdb" target="lib\net-45" />
+    <file src="FoundationDB.Layers.Common.dll" target="lib\net-45" />
+    <file src="FoundationDB.Layers.Common.XML" target="lib\net-45" />
+    <file src="FoundationDB.Layers.Common.pdb" target="lib\net-45" />
   </files>
 </package>


### PR DESCRIPTION
When trying to build the NuGet packages using the supplied build script I ran into this error:

```
Starting Target: BuildNuget (==> BuildAppRelease)
Building Nuget Packages
Creating C:\Users\Jos\Source\foundationdb-dotnet-client\build\output\_packages\
Creating .nuspec file at C:\Users\Jos\Source\foundationdb-dotnet-client\build\output\FoundationDb.Client\FoundationDb.Client.0.9.9-pre.nuspec
Created nuspec file C:\Users\Jos\Source\foundationdb-dotnet-client\build\output\FoundationDb.Client\FoundationDb.Client.0.9.9-pre.nuspec
.nuget/nuget.exe pack -Version 0.9.9-pre -OutputDirectory "C:\Users\Jos\Source\foundationdb-dotnet-client\build\output\_packages" "C:\Users\Jos\Source\foundationdb-dotnet-client\build\output\FoundationDb.Client\FoundationDb.Client.0.9.9-pre.nuspec"    
Attempting to build package from 'FoundationDb.Client.0.9.9-pre.nuspec'.
.\build.bat : Could not find a part of the path 'C:\Users\Jos\Source\foundationdb-dotnet-client\build\output\FoundationDb.Client\output\FoundationDB.Client'.
At line:1 char:1
+ .\build.bat Release > build.log 2>&1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (Could not find ...tionDB.Client'.:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
Running build failed.
Error:
System.Exception: Error during NuGet package creation. .nuget/nuget.exe pack -Version 0.9.9-pre -OutputDirectory "C:\Users\Jos\Source\foundationdb-dotnet-client\build\output\_packages" "C:\Users\Jos\Source\foundationdb-dotnet-client\build\output\FoundationDb.Client\FoundationDb.Client.0.9.9-pre.nuspec"    
   at Fake.NuGetHelper.NuGetPack(FSharpFunc`2 setParams, String nuspecFile) in D:\code\fake\src\app\FakeLib\NuGet\NugetHelper.fs:line 327
   at FSI_0001.Build.clo@86-9.Invoke(String name) in C:\Users\Jos\Source\foundationdb-dotnet-client\build\build.fsx:line 90
   at Microsoft.FSharp.Primitives.Basics.List.iter[T](FSharpFunc`2 f, FSharpList`1 x)
   at FSI_0001.Build.clo@80-8.Invoke(Unit _arg1) in C:\Users\Jos\Source\foundationdb-dotnet-client\build\build.fsx:line 85
   at Fake.TargetHelper.runTarget@326(String targetName) in D:\code\fake\src\app\FakeLib\TargetHelper.fs:line 340
```

This was using FAKE 3.14.9 (installed automatically by build.bat) and a clean checkout of the current master.

The FAKE NuGet package helper seems to copy the NuSpec as a template to the working directory, thus the relative paths in the NuSpec are incorrect. After adjusting the paths in the NuSpec the packaging works as expected.