### PR TITLE
Add support for VersionStamps

### DIFF
--- a/FoundationDB.Client/Core/IFdbTransactionHandler.cs
+++ b/FoundationDB.Client/Core/IFdbTransactionHandler.cs
@@ -61,6 +61,9 @@ namespace FoundationDB.Client.Core
 		/// </remarks>
 		long GetCommittedVersion();
 
+		/// <summary>Returns the <see cref="VersionStamp"/> which was used by versionstamps operations in this transaction.</summary>
+		Task<VersionStamp> GetVersionStampAsync(CancellationToken ct);
+
 		/// <summary>Sets the snapshot read version used by a transaction. This is not needed in simple cases.</summary>
 		/// <param name="version">Read version to use in this transaction</param>
 		/// <remarks>

--- a/FoundationDB.Client/FdbMutationType.cs
+++ b/FoundationDB.Client/FdbMutationType.cs
@@ -91,7 +91,13 @@ namespace FoundationDB.Client
 		/// If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``.
 		/// The smaller of the two values is then stored in the database.
 		/// </summary>
-		Min = 13
+		Min = 13,
+
+		//TODO: XML Comments!
+		VersionStampedKey = 14,
+
+		//TODO: XML Comments!
+		VersionStampedValue = 15,
 
 	}
 

--- a/FoundationDB.Client/FdbTransactionExtensions.cs
+++ b/FoundationDB.Client/FdbTransactionExtensions.cs
@@ -425,6 +425,22 @@ namespace FoundationDB.Client
 			trans.Atomic(key, value, FdbMutationType.Min);
 		}
 
+		//TODO: XML Comments!
+		public static void SetVersionStampedKey([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		{
+			Contract.NotNull(trans, nameof(trans));
+
+			trans.Atomic(key, value, FdbMutationType.VersionStampedKey);
+		}
+
+		//TODO: XML Comments!
+		public static void SetVersionStampedValue([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		{
+			Contract.NotNull(trans, nameof(trans));
+
+			trans.Atomic(key, value, FdbMutationType.VersionStampedValue);
+		}
+
 		#endregion
 
 		#region GetRange...

--- a/FoundationDB.Client/Filters/FdbTransactionFilter.cs
+++ b/FoundationDB.Client/Filters/FdbTransactionFilter.cs
@@ -257,6 +257,18 @@ namespace FoundationDB.Filters
 			return m_transaction.GetVersionStampAsync();
 		}
 
+		public virtual VersionStamp CreateVersionStamp()
+		{
+			ThrowIfDisposed();
+			return m_transaction.CreateVersionStamp();
+		}
+
+		public virtual VersionStamp CreateVersionStamp(int userVersion)
+		{
+			ThrowIfDisposed();
+			return m_transaction.CreateVersionStamp(userVersion);
+		}
+
 		public virtual void SetReadVersion(long version)
 		{
 			ThrowIfDisposed();

--- a/FoundationDB.Client/Filters/FdbTransactionFilter.cs
+++ b/FoundationDB.Client/Filters/FdbTransactionFilter.cs
@@ -251,6 +251,12 @@ namespace FoundationDB.Filters
 			return m_transaction.GetCommittedVersion();
 		}
 
+		public virtual Task<VersionStamp> GetVersionStampAsync()
+		{
+			ThrowIfDisposed();
+			return m_transaction.GetVersionStampAsync();
+		}
+
 		public virtual void SetReadVersion(long version)
 		{
 			ThrowIfDisposed();

--- a/FoundationDB.Client/Filters/Logging/FdbLoggedTransaction.cs
+++ b/FoundationDB.Client/Filters/Logging/FdbLoggedTransaction.cs
@@ -312,6 +312,14 @@ namespace FoundationDB.Filters.Logging
 			);
 		}
 
+		public override Task<VersionStamp> GetVersionStampAsync()
+		{
+			return ExecuteAsync(
+				new FdbTransactionLog.GetVersionStampCommand(),
+				(tr, cmd) => tr.GetVersionStampAsync()
+			);
+		}
+
 		public override void Set(Slice key, Slice value)
 		{
 			Execute(

--- a/FoundationDB.Client/Filters/Logging/FdbTransactionLog.Commands.cs
+++ b/FoundationDB.Client/Filters/Logging/FdbTransactionLog.Commands.cs
@@ -832,6 +832,12 @@ namespace FoundationDB.Filters.Logging
 
 		}
 
+		public sealed class GetVersionStampCommand : Command<VersionStamp>
+		{
+			public override Operation Op { get { return Operation.GetVersionStamp; } }
+
+		}
+
 		public sealed class GetReadVersionCommand : Command<long>
 		{
 			public override Operation Op { get { return Operation.GetReadVersion; } }

--- a/FoundationDB.Client/Filters/Logging/FdbTransactionLog.cs
+++ b/FoundationDB.Client/Filters/Logging/FdbTransactionLog.cs
@@ -552,6 +552,7 @@ namespace FoundationDB.Filters.Logging
 			Reset,
 			OnError,
 			SetOption,
+			GetVersionStamp,
 
 			Log,
 		}

--- a/FoundationDB.Client/IFdbTransaction.cs
+++ b/FoundationDB.Client/IFdbTransaction.cs
@@ -112,6 +112,14 @@ namespace FoundationDB.Client
 		/// </remarks>
 		long GetCommittedVersion();
 
+		/// <summary>Returns the <see cref="VersionStamp"/> which was used by versionstamps operations in this transaction.</summary>
+		/// <remarks>
+		/// The Task will be ready only after the successful completion of a call to <see cref="CommitAsync"/> on this transaction.
+		/// Read-only transactions do not modify the database when committed and will result in the Task completing with an error.
+		/// Keep in mind that a transaction which reads keys and then sets them to their current values may be optimized to a read-only transaction.
+		/// </remarks>
+		Task<VersionStamp> GetVersionStampAsync();
+
 		/// <summary>
 		/// Watch a key for any change in the database.
 		/// </summary>

--- a/FoundationDB.Client/IFdbTransaction.cs
+++ b/FoundationDB.Client/IFdbTransaction.cs
@@ -120,6 +120,24 @@ namespace FoundationDB.Client
 		/// </remarks>
 		Task<VersionStamp> GetVersionStampAsync();
 
+		/// <summary>Return a place-holder 80-bit VersionStamp, whose value is not yet known, but will be filled by the database at commit time.</summary>
+		/// <returns>This value can used to generate temporary keys or value, for use with the <see cref="FdbMutationType.VersionStampedKey"/> or <see cref="FdbMutationType.VersionStampedValue"/> mutations</returns>
+		/// <remarks>
+		/// The generate placeholder will use a random value that is unique per transaction (and changes at reach retry).
+		/// If the key contains the exact 80-bit byte signature of this token, the corresponding location will be tagged and replaced with the actual VersionStamp at commit time.
+		/// If another part of the key contains (by random chance) the same exact byte sequence, then an error will be triggered, and hopefully the transaction will retry with another byte sequence.
+		/// </remarks>
+		VersionStamp CreateVersionStamp();
+
+		/// <summary>Return a place-holder 96-bit VersionStamp with an attached user version, whose value is not yet known, but will be filled by the database at commit time.</summary>
+		/// <returns>This value can used to generate temporary keys or value, for use with the <see cref="FdbMutationType.VersionStampedKey"/> or <see cref="FdbMutationType.VersionStampedValue"/> mutations</returns>
+		/// <remarks>
+		/// The generate placeholder will use a random value that is unique per transaction (and changes at reach retry).
+		/// If the key contains the exact 80-bit byte signature of this token, the corresponding location will be tagged and replaced with the actual VersionStamp at commit time.
+		/// If another part of the key contains (by random chance) the same exact byte sequence, then an error will be triggered, and hopefully the transaction will retry with another byte sequence.
+		/// </remarks>
+		VersionStamp CreateVersionStamp(int userVersion);
+
 		/// <summary>
 		/// Watch a key for any change in the database.
 		/// </summary>

--- a/FoundationDB.Client/Layers/Tuples/Encoding/TuplePackers.cs
+++ b/FoundationDB.Client/Layers/Tuples/Encoding/TuplePackers.cs
@@ -846,6 +846,8 @@ namespace Doxense.Collections.Tuples.Encoding
 					case TupleTypes.Decimal: return TupleParser.ParseDecimal(slice);
 					case TupleTypes.Uuid128: return TupleParser.ParseGuid(slice);
 					case TupleTypes.Uuid64: return TupleParser.ParseUuid64(slice);
+					case TupleTypes.VersionStamp80: return TupleParser.ParseVersionStamp(slice);
+					case TupleTypes.VersionStamp96: return TupleParser.ParseVersionStamp(slice);
 				}
 			}
 

--- a/FoundationDB.Client/Layers/Tuples/Encoding/TupleParser.cs
+++ b/FoundationDB.Client/Layers/Tuples/Encoding/TupleParser.cs
@@ -877,6 +877,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing a byte array</summary>
+		[Pure]
 		public static Slice ParseBytes(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Bytes && slice[-1] == 0);
@@ -888,6 +889,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing an ASCII string stored as a byte array</summary>
+		[Pure]
 		public static string ParseAscii(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Bytes && slice[-1] == 0);
@@ -900,6 +902,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing a unicode string</summary>
+		[Pure]
 		public static string ParseUnicode(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Utf8 && slice[-1] == 0);
@@ -911,6 +914,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing an embedded tuple</summary>
+		[Pure]
 		public static ITuple ParseTuple(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.TupleStart && slice[-1] == 0);
@@ -920,6 +924,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing a single precision number (float32)</summary>
+		[Pure]
 		public static float ParseSingle(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Single);
@@ -950,6 +955,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing a double precision number (float64)</summary>
+		[Pure]
 		public static double ParseDouble(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Double);
@@ -981,6 +987,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing a quadruple precision number (float128)</summary>
+		[Pure]
 		public static decimal ParseDecimal(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Decimal);
@@ -994,6 +1001,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing a 128-bit GUID</summary>
+		[Pure]
 		public static Guid ParseGuid(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Uuid128);
@@ -1008,6 +1016,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing a 128-bit UUID</summary>
+		[Pure]
 		public static Uuid128 ParseUuid128(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Uuid128);
@@ -1021,6 +1030,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		/// <summary>Parse a tuple segment containing a 64-bit UUID</summary>
+		[Pure]
 		public static Uuid64 ParseUuid64(Slice slice)
 		{
 			Contract.Requires(slice.HasValue && slice[0] == TupleTypes.Uuid64);
@@ -1031,6 +1041,20 @@ namespace Doxense.Collections.Tuples.Encoding
 			}
 
 			return Uuid64.Read(slice.Substring(1, 8));
+		}
+
+		/// <summary>Parse a tuple segment containing an 80-bit or 96-bit VersionStamp</summary>
+		[Pure]
+		public static VersionStamp ParseVersionStamp(Slice slice)
+		{
+			Contract.Requires(slice.HasValue && (slice[0] == TupleTypes.VersionStamp80 || slice[0] == TupleTypes.VersionStamp96));
+
+			if (slice.Count != 11 && slice.Count != 13)
+			{
+				throw new FormatException("Slice has invalid size for a VersionStamp");
+			}
+
+			return VersionStamp.Parse(slice.Substring(1));
 		}
 
 		#endregion

--- a/FoundationDB.Client/Layers/Tuples/Encoding/TupleTypes.cs
+++ b/FoundationDB.Client/Layers/Tuples/Encoding/TupleTypes.cs
@@ -86,6 +86,11 @@ namespace Doxense.Collections.Tuples.Encoding
 		/// <summary>UUID (64 bits) [DRAFT]</summary>
 		internal const byte Uuid64 = 49; //TODO: this is not official yet! may change!
 
+		//TODO: xmldoc
+		internal const byte VersionStamp80 = 0x32;
+		//TODO: xmldoc
+		internal const byte VersionStamp96 = 0x33;
+
 		/// <summary>Standard prefix of the Directory Layer</summary>
 		/// <remarks>This is not a part of the tuple encoding itself, but helps the tuple decoder pretty-print tuples that would otherwise be unparsable.</remarks>
 		internal const byte AliasDirectory = 254;
@@ -112,6 +117,8 @@ namespace Doxense.Collections.Tuples.Encoding
 				case Decimal: return TupleSegmentType.Decimal;
 				case Uuid128: return TupleSegmentType.Uuid128;
 				case Uuid64: return TupleSegmentType.Uuid64;
+				case VersionStamp80: return TupleSegmentType.VersionStamp80;
+				case VersionStamp96: return TupleSegmentType.VersionStamp96;
 			}
 
 			if (type <= IntPos8 && type >= IntNeg8)
@@ -138,6 +145,8 @@ namespace Doxense.Collections.Tuples.Encoding
 		Decimal = 35,
 		Uuid128 = 48,
 		Uuid64 = 49,
+		VersionStamp80 = 0x32,
+		VersionStamp96 = 0x33,
 	}
 
 }

--- a/FoundationDB.Client/Native/FdbNative.cs
+++ b/FoundationDB.Client/Native/FdbNative.cs
@@ -848,10 +848,8 @@ namespace FoundationDB.Client.Native
 				stamp = default;
 				return err;
 			}
-			//note: we assume that this is a complete stamp read from the database.
-			//BUGBUG: if the code serialize an incomplete stamp into a tuple, and unpacks it (logging?) it MAY be changed into a complete one!
-			// => we could check for the 'all FF' signature, but this only works for default incomplete tokens, not custom incomplete tokens !
-			VersionStamp.ReadUnsafe(ptr, 10, /*FLAGS_NONE*/0, out stamp);
+
+			VersionStamp.ReadUnsafe(ptr, 10, out stamp);
 			return err;
 		}
 

--- a/FoundationDB.Client/Native/FdbNative.cs
+++ b/FoundationDB.Client/Native/FdbNative.cs
@@ -51,7 +51,6 @@ namespace FoundationDB.Client.Native
 		private const string FDB_C_DLL = "fdb_c.dll";
 #endif
 
-
 		/// <summary>Handle on the native FDB C API library</summary>
 		private static readonly UnmanagedLibrary FdbCLib;
 
@@ -168,6 +167,9 @@ namespace FoundationDB.Client.Native
 
 			[DllImport(FDB_C_DLL, CallingConvention = CallingConvention.Cdecl)]
 			public static extern FdbError fdb_transaction_get_committed_version(TransactionHandle transaction, out long version);
+
+			[DllImport(FDB_C_DLL, CallingConvention = CallingConvention.Cdecl)]
+			public static extern FutureHandle fdb_transaction_get_versionstamp(TransactionHandle transaction);
 
 			[DllImport(FDB_C_DLL, CallingConvention = CallingConvention.Cdecl)]
 			public static extern FutureHandle fdb_transaction_watch(TransactionHandle transaction, byte* keyName, int keyNameLength);
@@ -531,6 +533,16 @@ namespace FoundationDB.Client.Native
 			return future;
 		}
 
+		public static FutureHandle TransactionGetVersionStamp(TransactionHandle transaction)
+		{
+			var future = NativeMethods.fdb_transaction_get_versionstamp(transaction);
+			Contract.Assert(future != null);
+#if DEBUG_NATIVE_CALLS
+			Debug.WriteLine("fdb_transaction_get_versionstamp(0x" + transaction.Handle.ToString("x") + ") => 0x" + future.Handle.ToString("x"));
+#endif
+			return future;
+		}
+
 		public static FutureHandle TransactionWatch(TransactionHandle transaction, Slice key)
 		{
 			if (key.IsNullOrEmpty) throw new ArgumentException("Key cannot be null or empty", "key");
@@ -819,6 +831,27 @@ namespace FoundationDB.Client.Native
 				}
 			}
 
+			return err;
+		}
+
+		public static FdbError FutureGetVersionStamp(FutureHandle future, out VersionStamp stamp)
+		{
+			byte* ptr;
+			int keyLength;
+			var err = NativeMethods.fdb_future_get_key(future, out ptr, out keyLength);
+#if DEBUG_NATIVE_CALLS
+			Debug.WriteLine("fdb_future_get_key(0x" + future.Handle.ToString("x") + ") => err=" + err + ", keyLength=" + keyLength);
+#endif
+
+			if (keyLength != 10 || ptr == null)
+			{
+				stamp = default;
+				return err;
+			}
+			//note: we assume that this is a complete stamp read from the database.
+			//BUGBUG: if the code serialize an incomplete stamp into a tuple, and unpacks it (logging?) it MAY be changed into a complete one!
+			// => we could check for the 'all FF' signature, but this only works for default incomplete tokens, not custom incomplete tokens !
+			VersionStamp.ReadUnsafe(ptr, 10, /*FLAGS_NONE*/0, out stamp);
 			return err;
 		}
 

--- a/FoundationDB.Client/Native/FdbNativeTransaction.cs
+++ b/FoundationDB.Client/Native/FdbNativeTransaction.cs
@@ -393,6 +393,25 @@ namespace FoundationDB.Client.Native
 			return version;
 		}
 
+		public Task<VersionStamp> GetVersionStampAsync(CancellationToken ct)
+		{
+			var future = FdbNative.TransactionGetVersionStamp(m_handle);
+			return FdbFuture.CreateTaskFromHandle<VersionStamp>(future, GetVersionStampResult, ct);
+		}
+
+		private static VersionStamp GetVersionStampResult(FutureHandle h)
+		{
+			Contract.Requires(h != null);
+			var err = FdbNative.FutureGetVersionStamp(h, out VersionStamp stamp);
+#if DEBUG_TRANSACTIONS
+			Debug.WriteLine("FdbTransaction[" + m_id + "].FutureGetVersionStamp() => err=" + err + ", vs=" + stamp + ")");
+#endif
+			Fdb.DieOnError(err);
+
+			return stamp;
+		}
+
+
 		/// <summary>
 		/// Attempts to commit the sets and clears previously applied to the database snapshot represented by this transaction to the actual database. 
 		/// The commit may or may not succeed – in particular, if a conflicting transaction previously committed, then the commit must fail in order to preserve transactional isolation. 

--- a/FoundationDB.Client/VersionStamp.cs
+++ b/FoundationDB.Client/VersionStamp.cs
@@ -1,0 +1,413 @@
+﻿#region BSD Licence
+/* Copyright (c) 2013-2018, Doxense SAS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of Doxense nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#endregion
+
+namespace FoundationDB.Client
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.Runtime.CompilerServices;
+	using Doxense;
+	using Doxense.Diagnostics.Contracts;
+	using Doxense.Memory;
+	using JetBrains.Annotations;
+
+	/// <summary>VersionStamp</summary>
+	/// <remarks>A versionstamp is unique, monotonically (but not sequentially) increasing value for each committed transaction.
+	/// Its size can either be 10 bytes (80-bits) or 12-bytes (96-bits).
+	/// The first 8 bytes are the committed version of the database. The next 2 bytes are monotonic in the serialization order for transactions.
+	/// The optional last 2 bytes can contain a user-provider version number used to allow multiple stamps inside the same transaction.
+	/// </remarks>
+	[DebuggerDisplay("{ToString(),nq}")]
+	public readonly struct VersionStamp : IEquatable<VersionStamp>, IComparable<VersionStamp>
+	{
+		//REVIEW: they are called "Versionstamp" in the doc, but "VersionStamp" seems more  .NETy (like 'TimeSpan').
+		// => Should we keep the uppercase 'S' or not ?
+
+		private const ulong PLACEHOLDER_VERSION = ulong.MaxValue;
+		private const ushort PLACEHOLDER_ORDER = ushort.MaxValue;
+		private const ushort NO_USER_VERSION = 0;
+
+		private const ushort FLAGS_NONE = 0x0;
+		private const ushort FLAGS_HAS_VERSION = 0x1; // unset: 80-bits, set: 96-bits
+		private const ushort FLAGS_IS_INCOMPLETE = 0x2; // unset: complete, set: incomplete
+
+		/// <summary>Commit version of the transaction</summary>
+		/// <remarks>This value is determined by the database at commit time.</remarks>
+		
+		public readonly ulong TransactionVersion; // Bytes 0..7
+
+		/// <summary>Transaction Batch Order</summary>
+		/// <remarks>This value is determined by the database at commit time.</remarks>
+		public readonly ushort TransactionOrder; // Bytes 8..9
+
+		/// <summary>User-provided version (between 0 and 65535)</summary>
+		/// <remarks>For 80-bits VersionStamps, this value will be 0 and will not be part of the serialized key. You can use <see cref="HasUserVersion"/> to distinguish between both types of stamps.</remarks>
+		public readonly ushort UserVersion; // Bytes 10..11 (if 'FLAGS_HAS_VERSION' is set)
+
+		/// <summary>Internal flags (FLAGS_xxx constants)</summary>
+		private readonly ushort Flags;
+		//note: this flag is only present in memory, and is not serialized
+
+		private VersionStamp(ulong version, ushort order, ushort user, ushort flags)
+		{
+			this.TransactionVersion = version;
+			this.TransactionOrder = order;
+			this.UserVersion = user;
+			this.Flags = flags;
+		}
+
+		/// <summary>Creates an incomplete 80-bit <see cref="VersionStamp"/> with no user version.</summary>
+		/// <returns>Placeholder that will be serialized as <code>FF FF FF FF FF FF FF FF FF FF</code> (10 bytes).</returns>
+		/// <remarks>
+		/// This stamp contains a temporary marker that will be later filled by the database with the actual VersioStamp by the database at transaction commit time.
+		/// If you need to create multiple distinct stamps within the same transaction, please use <see cref="Incomplete(int)"/> instead.
+		/// </remarks>
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static VersionStamp Incomplete()
+		{
+			return new VersionStamp(PLACEHOLDER_VERSION, PLACEHOLDER_ORDER, NO_USER_VERSION, FLAGS_IS_INCOMPLETE);
+		}
+
+		/// <summary>Creates an incomplete 96-bit <see cref="VersionStamp"/> with the given user version.</summary>
+		/// <param name="userVersion">Value between 0 and 65535 that will be appended at the end of the Versionstamp, making it unique <i>within</i> the transaction.</param>
+		/// <returns>Placeholder that will be serialized as <code>FF FF FF FF FF FF FF FF FF FF vv vv</code> (12 bytes) where 'vv vv' is the user version encoded in little-endian.</returns>
+		/// <exception cref="ArgumentException">If <paramref name="userVersion"/> is less than <c>0</c>, or greater than <c>65534</c> (0xFFFE).</exception>
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static VersionStamp Incomplete(int userVersion)
+		{
+			Contract.Between(userVersion, 0, 0xFFFF, nameof(userVersion), "Local version must fit in 16-bits.");
+			return new VersionStamp(PLACEHOLDER_VERSION, PLACEHOLDER_ORDER, (ushort) userVersion, FLAGS_IS_INCOMPLETE | FLAGS_HAS_VERSION);
+		}
+
+		/// <summary>Creates an incomplete 96-bit <see cref="VersionStamp"/> with the given user version.</summary>
+		/// <param name="userVersion">Value between 0 and 65535 that will be appended at the end of the Versionstamp, making it unique <i>within</i> the transaction.</param>
+		/// <returns>Placeholder that will be serialized as <code>FF FF FF FF FF FF FF FF FF FF vv vv</code> (12 bytes) where 'vv vv' is the user version encoded in little-endian.</returns>
+		/// <exception cref="ArgumentException">If <paramref name="userVersion"/> is less than <c>0</c>, or greater than <c>65534</c> (0xFFFE).</exception>
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static VersionStamp Incomplete(ushort userVersion)
+		{
+			return new VersionStamp(PLACEHOLDER_VERSION, PLACEHOLDER_ORDER, userVersion, FLAGS_IS_INCOMPLETE | FLAGS_HAS_VERSION);
+		}
+
+		/// <summary>Creates a 80-bit <see cref="VersionStamp"/>, obtained from the database.</summary>
+		/// <returns>Complete stamp, without user version.</returns>
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static VersionStamp Complete(ulong version, ushort order)
+		{
+			return new VersionStamp(version, order, NO_USER_VERSION, FLAGS_NONE);
+		}
+
+		/// <summary>Creates a 96-bit <see cref="VersionStamp"/>, obtained from the database.</summary>
+		/// <returns>Complete stamp, with a user version.</returns>
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static VersionStamp Complete(ulong version, ushort order, int userVersion)
+		{
+			Contract.Between(userVersion, 0, 0xFFFF, nameof(userVersion), "Local version must fit in 16-bits, and cannot be 0xFFFF.");
+			return new VersionStamp(version, order, (ushort) userVersion, FLAGS_HAS_VERSION);
+		}
+
+		/// <summary>Creates a 96-bit <see cref="VersionStamp"/>, obtained from the database.</summary>
+		/// <returns>Complete stamp, with a user version.</returns>
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static VersionStamp Complete(ulong version, ushort order, ushort userVersion)
+		{
+			return new VersionStamp(version, order, userVersion, FLAGS_HAS_VERSION);
+		}
+
+		/// <summary>Test if the stamp has a user version (96-bits) or not (80-bits)</summary>
+		public bool HasUserVersion
+		{
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			get => (this.Flags & FLAGS_HAS_VERSION) != 0;
+		}
+
+		/// <summary>Test if the stamp is marked as <i>incomplete</i> (true), or has already been resolved by the database (false)</summary>
+		public bool IsIncomplete
+		{
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			get => (this.Flags & FLAGS_IS_INCOMPLETE) != 0;
+		}
+
+		/// <summary>Return the length (in bytes) of the versionstamp when serialized in binary format</summary>
+		/// <returns>Returns 12 bytes for stamps with a user version, and 10 bytes without.</returns>
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public int GetLength() => 10 + 2 * (this.Flags & FLAGS_HAS_VERSION);
+
+		public override string ToString()
+		{
+			if (this.HasUserVersion)
+			{
+				return this.IsIncomplete
+					? $"@?#{this.UserVersion}"
+					: $"@{this.TransactionVersion}-{this.TransactionOrder}#{this.UserVersion}";
+			}
+			else
+			{
+				return this.IsIncomplete
+					? "@?"
+					: $"@{this.TransactionVersion}-{this.TransactionOrder}";
+			}
+		}
+
+		public Slice ToSlice()
+		{
+			int len = GetLength(); // 10 or 12
+			var tmp = Slice.Create(len);
+			unsafe
+			{
+				fixed (byte* ptr = &tmp.DangerousGetPinnableReference())
+				{
+					WriteUnsafe(ptr, len, in this);
+				}
+			}
+			return tmp;
+		}
+
+		public void WriteTo(in Slice buffer)
+		{
+			int len = GetLength(); // 10 or 12
+			if (buffer.Count < len) throw new ArgumentException($"The target buffer must be at least {len} bytes long.");
+			unsafe
+			{
+				fixed (byte* ptr = &buffer.DangerousGetPinnableReference())
+				{
+					WriteUnsafe(ptr, len, in this);
+				}
+			}
+		}
+
+		public void WriteTo(ref SliceWriter writer)
+		{
+			var tmp = writer.Allocate(GetLength());
+			unsafe
+			{
+				fixed (byte* ptr = &tmp.DangerousGetPinnableReference())
+				{
+					WriteUnsafe(ptr, tmp.Count, in this);
+				}
+			}
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static unsafe void WriteUnsafe(byte* ptr, int len, in VersionStamp vs)
+		{
+			Contract.Debug.Assert(len == 10 || len == 12);
+			UnsafeHelpers.StoreUInt64BE(ptr, vs.TransactionVersion);
+			UnsafeHelpers.StoreUInt16BE(ptr + 8, vs.TransactionOrder);
+			if (len == 12)
+			{
+				UnsafeHelpers.StoreUInt16BE(ptr + 10, vs.UserVersion);
+			}
+		}
+
+		/// <summary>Parse a VersionStamp from a sequence of 10 bytes</summary>
+		/// <exception cref="FormatException">If the buffer length is not exactly 12 bytes</exception>
+		[Pure]
+		public static VersionStamp Parse(Slice data)
+		{
+			return TryParse(data, out var vs) ? vs : throw new FormatException("A VersionStamp is either 10 or 12 bytes.");
+		}
+
+		/// <summary>Try parsing a VersionStamp from a sequence of bytes</summary>
+		public static bool TryParse(Slice data, out VersionStamp vs)
+		{
+			if (data.Count != 10 && data.Count != 12)
+			{
+				vs = default;
+				return false;
+			}
+			unsafe
+			{
+				fixed (byte* ptr = &data.DangerousGetPinnableReference())
+				{
+					ReadUnsafe(ptr, data.Count, FLAGS_NONE, out vs);
+					return true;
+				}
+			}
+		}
+
+		/// <summary>Parse a VersionStamp from a sequence of 10 bytes</summary>
+		/// <exception cref="FormatException">If the buffer length is not exactly 12 bytes</exception>
+		[Pure]
+		public static VersionStamp ParseIncomplete(Slice data)
+		{
+			return TryParseIncomplete(data, out var vs) ? vs : throw new FormatException("A VersionStamp is either 10 or 12 bytes.");
+		}
+
+		/// <summary>Try parsing a VersionStamp from a sequence of bytes</summary>
+		public static bool TryParseIncomplete(Slice data, out VersionStamp vs)
+		{
+			if (data.Count != 10 && data.Count != 12)
+			{
+				vs = default;
+				return false;
+			}
+			unsafe
+			{
+				fixed (byte* ptr = &data.DangerousGetPinnableReference())
+				{
+					ReadUnsafe(ptr, data.Count, FLAGS_IS_INCOMPLETE, out vs);
+					return true;
+				}
+			}
+		}
+
+		internal static unsafe void ReadUnsafe(byte* ptr, int len, ushort flags, out VersionStamp vs)
+		{
+			Contract.Debug.Assert(len == 10 || len == 12);
+			// reads a complete 12 bytes Versionstamp
+			ulong ver = UnsafeHelpers.LoadUInt64BE(ptr);
+			ushort order = UnsafeHelpers.LoadUInt16BE(ptr + 8);
+			ushort idx = len == 10 ? NO_USER_VERSION : UnsafeHelpers.LoadUInt16BE(ptr + 10);
+			flags |= len == 12 ? FLAGS_HAS_VERSION : FLAGS_NONE;
+			vs = new VersionStamp(ver, order, idx, flags);
+		}
+
+		#region Equality, Comparision, ...
+
+		public override bool Equals(object obj)
+		{
+			return obj is VersionStamp vs && Equals(vs);
+		}
+
+		public override int GetHashCode()
+		{
+			return HashCodes.Combine(this.TransactionVersion.GetHashCode(), this.TransactionOrder, this.UserVersion, this.Flags);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool Equals(VersionStamp other)
+		{
+			//PERF: could we use Unsafe and compare the next sizeof(VersionStamp) bytes at once?
+			return (this.TransactionVersion == other.TransactionVersion)
+			   & (this.TransactionOrder == other.TransactionOrder)
+			   & (this.UserVersion == other.UserVersion)
+			   & (this.Flags == other.Flags);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool operator ==(VersionStamp left, VersionStamp right)
+		{
+			return left.Equals(right);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool operator !=(VersionStamp left, VersionStamp right)
+		{
+			return !left.Equals(right);
+		}
+
+		[Pure]
+		public int CompareTo(VersionStamp other)
+		{
+			//ordering rules:
+			// - incomplete stamps are stored AFTER resolved stamps (since if they commit they would have a value higher than any other stamp already in the database)
+			// - ordered by transaction number then transaction batch order
+			// - stamps with no user version are sorted before stamps with user version if they have the same first 10 bytes, so (XXXX) is before (XXXX, 0)
+
+			if (this.IsIncomplete)
+			{ // we ignore the transaction version/order!
+				if (!other.IsIncomplete) return +1; // we are after
+			}
+			else
+			{
+				if (other.IsIncomplete) return -1; // we are before
+				int cmp = this.TransactionVersion.CompareTo(other.TransactionVersion);
+				if (cmp != 0) return cmp;
+			}
+
+			// both have same version+order, or both are incomplete
+			// => we need to decide on the (optional) user version
+			return this.HasUserVersion 
+				? (other.HasUserVersion ? this.UserVersion.CompareTo(other.UserVersion) : +1)
+				: (other.HasUserVersion ? -1 : 0);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool operator <(VersionStamp left, VersionStamp right)
+		{
+			return left.CompareTo(right) < 0;
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool operator <=(VersionStamp left, VersionStamp right)
+		{
+			return left.CompareTo(right) <= 0;
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool operator >(VersionStamp left, VersionStamp right)
+		{
+			return left.CompareTo(right) > 0;
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool operator >=(VersionStamp left, VersionStamp right)
+		{
+			return left.CompareTo(right) >= 0;
+		}
+
+		//REVIEW: does these make sense or not?
+		// VersionStamp - VersionStamp == ???
+		// VersionStamp + 123 == ???
+		// VersionStamp * 2 == ???
+
+		public sealed class Comparer : IEqualityComparer<VersionStamp>, IComparer<VersionStamp>
+		{
+			/// <summary>Default comparer for <see cref="VersionStamp"/>s</summary>
+			public static Comparer Default { get; } = new Comparer();
+
+			private Comparer()
+			{ }
+
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			public bool Equals(VersionStamp x, VersionStamp y)
+			{
+				return x.Equals(y);
+			}
+
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			public int GetHashCode(VersionStamp obj)
+			{
+				return obj.GetHashCode();
+			}
+
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			public int Compare(VersionStamp x, VersionStamp y)
+			{
+				return x.CompareTo(y);
+			}
+
+		}
+
+		#endregion
+
+	}
+
+}

--- a/FoundationDB.Client/VersionStamp.cs
+++ b/FoundationDB.Client/VersionStamp.cs
@@ -57,6 +57,9 @@ namespace FoundationDB.Client
 		private const ushort FLAGS_HAS_VERSION = 0x1; // unset: 80-bits, set: 96-bits
 		private const ushort FLAGS_IS_INCOMPLETE = 0x2; // unset: complete, set: incomplete
 
+		/// <summary>Serialized bytes of the default incomplete stamp (composed of only 0xFF)</summary>
+		internal static readonly Slice IncompleteToken = Slice.Repeat(0xFF, 10);
+
 		/// <summary>Commit version of the transaction</summary>
 		/// <remarks>This value is determined by the database at commit time.</remarks>
 		

--- a/FoundationDB.Client/VersionStamp.cs
+++ b/FoundationDB.Client/VersionStamp.cs
@@ -115,6 +115,19 @@ namespace FoundationDB.Client
 			return new VersionStamp(PLACEHOLDER_VERSION, PLACEHOLDER_ORDER, userVersion, FLAGS_IS_INCOMPLETE | FLAGS_HAS_VERSION);
 		}
 
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static VersionStamp Custom(ulong version, ushort order, bool incomplete)
+		{
+			return new VersionStamp(version, order, NO_USER_VERSION, incomplete ? FLAGS_IS_INCOMPLETE : FLAGS_NONE);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static VersionStamp Custom(ulong version, ushort order, int userVersion, bool incomplete)
+		{
+			Contract.Between(userVersion, 0, 0xFFFF, nameof(userVersion), "Local version must fit in 16-bits.");
+			return new VersionStamp(version, order, (ushort) userVersion, incomplete ? (ushort) (FLAGS_IS_INCOMPLETE | FLAGS_HAS_VERSION) : FLAGS_HAS_VERSION);
+		}
+
 		/// <summary>Creates a 80-bit <see cref="VersionStamp"/>, obtained from the database.</summary>
 		/// <returns>Complete stamp, without user version.</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/FoundationDB.Tests/FoundationDB.Tests.csproj
+++ b/FoundationDB.Tests/FoundationDB.Tests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Layers\VectorFacts.cs" />
     <Compile Include="Layers\QueuesFacts.cs" />
     <Compile Include="TransactionalFacts.cs" />
+    <Compile Include="Utils\TuPackFacts.cs" />
     <Compile Include="Utils\TypeConvertersFacts.cs" />
     <Compile Include="Utils\SliceComparerFacts.cs" />
     <Compile Include="Utils\SliceStreamFacts.cs" />

--- a/FoundationDB.Tests/FoundationDB.Tests.csproj
+++ b/FoundationDB.Tests/FoundationDB.Tests.csproj
@@ -30,6 +30,7 @@
     <WarningsAsErrors>105,108,109,114,472,660,661,628,1066</WarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -42,6 +43,7 @@
     <WarningsAsErrors>105,108,109,114,472,660,661,628,1066</WarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -122,6 +124,7 @@
     <Compile Include="Utils\SliceWriterFacts.cs" />
     <Compile Include="Utils\ConversionFacts.cs" />
     <Compile Include="Linq\AsyncEnumerableFacts.cs" />
+    <Compile Include="VersionStampFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/FoundationDB.Tests/FoundationDB.Tests.csproj.DotSettings
+++ b/FoundationDB.Tests/FoundationDB.Tests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp72</s:String></wpf:ResourceDictionary>

--- a/FoundationDB.Tests/Utils/TuPackFacts.cs
+++ b/FoundationDB.Tests/Utils/TuPackFacts.cs
@@ -1,0 +1,2210 @@
+﻿#region BSD Licence
+/* Copyright (c) 2013-2018, Doxense SAS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of Doxense nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#endregion
+
+//#define ENABLE_VALUETUPLE
+
+// ReSharper disable AccessToModifiedClosure
+namespace Doxense.Collections.Tuples.Tests
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.Linq;
+	using System.Net;
+	using Doxense.Collections.Tuples.Encoding;
+	using FoundationDB.Client;
+	using FoundationDB.Client.Tests;
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class TuPackFacts : FdbTest
+	{
+
+		#region Serialization...
+
+		[Test]
+		public void Test_TuplePack_Serialize_Bytes()
+		{
+			// Byte arrays are stored with prefix '01' followed by the bytes, and terminated by '00'. All occurences of '00' in the byte array are escaped with '00 FF'
+			// - Best case:  packed_size = 2 + array_len
+			// - Worst case: packed_size = 2 + array_len * 2
+
+			Slice packed;
+
+			packed = TuPack.EncodeKey(new byte[] {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0});
+			Assert.That(packed.ToString(), Is.EqualTo("<01><12>4Vx<9A><BC><DE><F0><00>"));
+			packed = TuPack.EncodeKey(new byte[] {0x00, 0x42});
+			Assert.That(packed.ToString(), Is.EqualTo("<01><00><FF>B<00>"));
+			packed = TuPack.EncodeKey(new byte[] {0x42, 0x00});
+			Assert.That(packed.ToString(), Is.EqualTo("<01>B<00><FF><00>"));
+			packed = TuPack.EncodeKey(new byte[] {0x42, 0x00, 0x42});
+			Assert.That(packed.ToString(), Is.EqualTo("<01>B<00><FF>B<00>"));
+			packed = TuPack.EncodeKey(new byte[] {0x42, 0x00, 0x00, 0x42});
+			Assert.That(packed.ToString(), Is.EqualTo("<01>B<00><FF><00><FF>B<00>"));
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Bytes()
+		{
+			ITuple t;
+
+			t = TuPack.Unpack(Slice.Unescape("<01><01><23><45><67><89><AB><CD><EF><00>"));
+			Assert.That(t.Get<byte[]>(0), Is.EqualTo(new byte[] {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}));
+			Assert.That(t.Get<Slice>(0).ToHexaString(' '), Is.EqualTo("01 23 45 67 89 AB CD EF"));
+
+			t = TuPack.Unpack(Slice.Unescape("<01><42><00><FF><00>"));
+			Assert.That(t.Get<byte[]>(0), Is.EqualTo(new byte[] {0x42, 0x00}));
+			Assert.That(t.Get<Slice>(0).ToHexaString(' '), Is.EqualTo("42 00"));
+
+			t = TuPack.Unpack(Slice.Unescape("<01><00><FF><42><00>"));
+			Assert.That(t.Get<byte[]>(0), Is.EqualTo(new byte[] {0x00, 0x42}));
+			Assert.That(t.Get<Slice>(0).ToHexaString(' '), Is.EqualTo("00 42"));
+
+			t = TuPack.Unpack(Slice.Unescape("<01><42><00><FF><42><00>"));
+			Assert.That(t.Get<byte[]>(0), Is.EqualTo(new byte[] {0x42, 0x00, 0x42}));
+			Assert.That(t.Get<Slice>(0).ToHexaString(' '), Is.EqualTo("42 00 42"));
+
+			t = TuPack.Unpack(Slice.Unescape("<01><42><00><FF><00><FF><42><00>"));
+			Assert.That(t.Get<byte[]>(0), Is.EqualTo(new byte[] {0x42, 0x00, 0x00, 0x42}));
+			Assert.That(t.Get<Slice>(0).ToHexaString(' '), Is.EqualTo("42 00 00 42"));
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Unicode_Strings()
+		{
+			// Unicode strings are stored with prefix '02' followed by the utf8 bytes, and terminated by '00'. All occurences of '00' in the UTF8 bytes are escaped with '00 FF'
+
+			Slice packed;
+
+			// simple string
+			packed = TuPack.EncodeKey("hello world");
+			Assert.That(packed.ToString(), Is.EqualTo("<02>hello world<00>"));
+
+			// empty
+			packed = TuPack.EncodeKey(String.Empty);
+			Assert.That(packed.ToString(), Is.EqualTo("<02><00>"));
+
+			// null
+			packed = TuPack.EncodeKey(default(string));
+			Assert.That(packed.ToString(), Is.EqualTo("<00>"));
+
+			// unicode
+			packed = TuPack.EncodeKey("こんにちは世界");
+			// note: Encoding.UTF8.GetBytes("こんにちは世界") => { e3 81 93 e3 82 93 e3 81 ab e3 81 a1 e3 81 af e4 b8 96 e7 95 8c }
+			Assert.That(packed.ToString(), Is.EqualTo("<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>"));
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Unicode_Strings()
+		{
+			ITuple t;
+
+			// simple string
+			t = TuPack.Unpack(Slice.Unescape("<02>hello world<00>"));
+			Assert.That(t.Get<String>(0), Is.EqualTo("hello world"));
+			Assert.That(t[0], Is.EqualTo("hello world"));
+
+			// empty
+			t = TuPack.Unpack(Slice.Unescape("<02><00>"));
+			Assert.That(t.Get<String>(0), Is.EqualTo(String.Empty));
+			Assert.That(t[0], Is.EqualTo(String.Empty));
+
+			// null
+			t = TuPack.Unpack(Slice.Unescape("<00>"));
+			Assert.That(t.Get<String>(0), Is.EqualTo(default(string)));
+			Assert.That(t[0], Is.Null);
+
+			// unicode
+			t = TuPack.Unpack(Slice.Unescape("<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>"));
+			// note: Encoding.UTF8.GetString({ e3 81 93 e3 82 93 e3 81 ab e3 81 a1 e3 81 af e4 b8 96 e7 95 8c }) => "こんにちは世界"
+			Assert.That(t.Get<String>(0), Is.EqualTo("こんにちは世界"));
+			Assert.That(t[0], Is.EqualTo("こんにちは世界"));
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Guids()
+		{
+			// 128-bit Guids are stored with prefix '30' followed by 16 bytes formatted according to RFC 4122
+
+			// System.Guid are stored in Little-Endian, but RFC 4122's UUIDs are stored in Big Endian, so per convention we will swap them
+
+			Slice packed;
+
+			// note: new Guid(bytes from 0 to 15) => "03020100-0504-0706-0809-0a0b0c0d0e0f";
+			packed = TuPack.EncodeKey(Guid.Parse("00010203-0405-0607-0809-0a0b0c0d0e0f"));
+			Assert.That(packed.ToString(), Is.EqualTo("0<00><01><02><03><04><05><06><07><08><09><0A><0B><0C><0D><0E><0F>"));
+
+			packed = TuPack.EncodeKey(Guid.Empty);
+			Assert.That(packed.ToString(), Is.EqualTo("0<00><00><00><00><00><00><00><00><00><00><00><00><00><00><00><00>"));
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Guids()
+		{
+			// 128-bit Guids are stored with prefix '30' followed by 16 bytes
+			// we also accept byte arrays (prefix '01') if they are of length 16
+
+			ITuple packed;
+
+			packed = TuPack.Unpack(Slice.Unescape("<30><00><01><02><03><04><05><06><07><08><09><0A><0B><0C><0D><0E><0F>"));
+			Assert.That(packed.Get<Guid>(0), Is.EqualTo(Guid.Parse("00010203-0405-0607-0809-0a0b0c0d0e0f")));
+			Assert.That(packed[0], Is.EqualTo(Guid.Parse("00010203-0405-0607-0809-0a0b0c0d0e0f")));
+
+			packed = TuPack.Unpack(Slice.Unescape("<30><00><00><00><00><00><00><00><00><00><00><00><00><00><00><00><00>"));
+			Assert.That(packed.Get<Guid>(0), Is.EqualTo(Guid.Empty));
+			Assert.That(packed[0], Is.EqualTo(Guid.Empty));
+
+			// unicode string
+			packed = TuPack.Unpack(Slice.Unescape("<02>03020100-0504-0706-0809-0a0b0c0d0e0f<00>"));
+			Assert.That(packed.Get<Guid>(0), Is.EqualTo(Guid.Parse("03020100-0504-0706-0809-0a0b0c0d0e0f")));
+			//note: t[0] returns a string, not a GUID
+
+			// null maps to Guid.Empty
+			packed = TuPack.Unpack(Slice.Unescape("<00>"));
+			Assert.That(packed.Get<Guid>(0), Is.EqualTo(Guid.Empty));
+			//note: t[0] returns null, not a GUID
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Uuid128s()
+		{
+			// UUID128s are stored with prefix '30' followed by 16 bytes formatted according to RFC 4122
+
+			Slice packed;
+
+			// note: new Uuid(bytes from 0 to 15) => "03020100-0504-0706-0809-0a0b0c0d0e0f";
+			packed = TuPack.EncodeKey(Uuid128.Parse("00010203-0405-0607-0809-0a0b0c0d0e0f"));
+			Assert.That(packed.ToString(), Is.EqualTo("0<00><01><02><03><04><05><06><07><08><09><0A><0B><0C><0D><0E><0F>"));
+
+			packed = TuPack.EncodeKey(Uuid128.Empty);
+			Assert.That(packed.ToString(), Is.EqualTo("0<00><00><00><00><00><00><00><00><00><00><00><00><00><00><00><00>"));
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Uuid128s()
+		{
+			// UUID128s are stored with prefix '30' followed by 16 bytes (the result of uuid.ToByteArray())
+			// we also accept byte arrays (prefix '01') if they are of length 16
+
+			ITuple packed;
+
+			// note: new Uuid(bytes from 0 to 15) => "00010203-0405-0607-0809-0a0b0c0d0e0f";
+			packed = TuPack.Unpack(Slice.Unescape("<30><00><01><02><03><04><05><06><07><08><09><0A><0B><0C><0D><0E><0F>"));
+			Assert.That(packed.Get<Uuid128>(0), Is.EqualTo(Uuid128.Parse("00010203-0405-0607-0809-0a0b0c0d0e0f")));
+			Assert.That(packed[0], Is.EqualTo(Uuid128.Parse("00010203-0405-0607-0809-0a0b0c0d0e0f")));
+
+			packed = TuPack.Unpack(Slice.Unescape("<30><00><00><00><00><00><00><00><00><00><00><00><00><00><00><00><00>"));
+			Assert.That(packed.Get<Uuid128>(0), Is.EqualTo(Uuid128.Empty));
+			Assert.That(packed[0], Is.EqualTo(Uuid128.Empty));
+
+			// unicode string
+			packed = TuPack.Unpack(Slice.Unescape("<02>00010203-0405-0607-0809-0a0b0c0d0e0f<00>"));
+			Assert.That(packed.Get<Uuid128>(0), Is.EqualTo(Uuid128.Parse("00010203-0405-0607-0809-0a0b0c0d0e0f")));
+			//note: t[0] returns a string, not a UUID
+
+			// null maps to Uuid.Empty
+			packed = TuPack.Unpack(Slice.Unescape("<00>"));
+			Assert.That(packed.Get<Uuid128>(0), Is.EqualTo(Uuid128.Empty));
+			//note: t[0] returns null, not a UUID
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Uuid64s()
+		{
+			// UUID64s are stored with prefix '31' followed by 8 bytes formatted according to RFC 4122
+
+			Slice packed;
+
+			// note: new Uuid(bytes from 0 to 7) => "00010203-04050607";
+			packed = TuPack.EncodeKey(Uuid64.Parse("00010203-04050607"));
+			Assert.That(packed.ToString(), Is.EqualTo("1<00><01><02><03><04><05><06><07>"));
+
+			packed = TuPack.EncodeKey(Uuid64.Parse("01234567-89ABCDEF"));
+			Assert.That(packed.ToString(), Is.EqualTo("1<01>#Eg<89><AB><CD><EF>"));
+
+			packed = TuPack.EncodeKey(Uuid64.Empty);
+			Assert.That(packed.ToString(), Is.EqualTo("1<00><00><00><00><00><00><00><00>"));
+
+			packed = TuPack.EncodeKey(new Uuid64(0xBADC0FFEE0DDF00DUL));
+			Assert.That(packed.ToString(), Is.EqualTo("1<BA><DC><0F><FE><E0><DD><F0><0D>"));
+
+			packed = TuPack.EncodeKey(new Uuid64(0xDEADBEEFL));
+			Assert.That(packed.ToString(), Is.EqualTo("1<00><00><00><00><DE><AD><BE><EF>"));
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Uuid64s()
+		{
+			// UUID64s are stored with prefix '31' followed by 8 bytes (the result of uuid.ToByteArray())
+			// we also accept byte arrays (prefix '01') if they are of length 8, and unicode strings (prefix '02')
+
+			ITuple packed;
+
+			// note: new Uuid(bytes from 0 to 15) => "00010203-0405-0607-0809-0a0b0c0d0e0f";
+			packed = TuPack.Unpack(Slice.Unescape("<31><01><23><45><67><89><AB><CD><EF>"));
+			Assert.That(packed.Get<Uuid64>(0), Is.EqualTo(Uuid64.Parse("01234567-89abcdef")));
+			Assert.That(packed[0], Is.EqualTo(Uuid64.Parse("01234567-89abcdef")));
+
+			packed = TuPack.Unpack(Slice.Unescape("<31><00><00><00><00><00><00><00><00>"));
+			Assert.That(packed.Get<Uuid64>(0), Is.EqualTo(Uuid64.Empty));
+			Assert.That(packed[0], Is.EqualTo(Uuid64.Empty));
+
+			// 8 bytes
+			packed = TuPack.Unpack(Slice.Unescape("<01><01><23><45><67><89><ab><cd><ef><00>"));
+			Assert.That(packed.Get<Uuid64>(0), Is.EqualTo(Uuid64.Parse("01234567-89abcdef")));
+			//note: t[0] returns a string, not a UUID
+
+			// unicode string
+			packed = TuPack.Unpack(Slice.Unescape("<02>01234567-89abcdef<00>"));
+			Assert.That(packed.Get<Uuid64>(0), Is.EqualTo(Uuid64.Parse("01234567-89abcdef")));
+			//note: t[0] returns a string, not a UUID
+
+			// null maps to Uuid.Empty
+			packed = TuPack.Unpack(Slice.Unescape("<00>"));
+			Assert.That(packed.Get<Uuid64>(0), Is.EqualTo(Uuid64.Empty));
+			//note: t[0] returns null, not a UUID
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Integers()
+		{
+			// Positive integers are stored with a variable-length encoding.
+			// - The prefix is 0x14 + the minimum number of bytes to encode the integer, from 0 to 8, so valid prefixes range from 0x14 to 0x1C
+			// - The bytes are stored in High-Endian (ie: the upper bits first)
+			// Examples:
+			// - 0 => <14>
+			// - 1..255 => <15><##>
+			// - 256..65535 .. => <16><HH><LL>
+			// - ulong.MaxValue => <1C><FF><FF><FF><FF><FF><FF><FF><FF>
+
+			Assert.That(
+				TuPack.EncodeKey(0).ToString(),
+				Is.EqualTo("<14>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(1).ToString(),
+				Is.EqualTo("<15><01>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(255).ToString(),
+				Is.EqualTo("<15><FF>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(256).ToString(),
+				Is.EqualTo("<16><01><00>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(65535).ToString(),
+				Is.EqualTo("<16><FF><FF>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(65536).ToString(),
+				Is.EqualTo("<17><01><00><00>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(int.MaxValue).ToString(),
+				Is.EqualTo("<18><7F><FF><FF><FF>")
+			);
+
+			// signed max
+			Assert.That(
+				TuPack.EncodeKey(long.MaxValue).ToString(),
+				Is.EqualTo("<1C><7F><FF><FF><FF><FF><FF><FF><FF>")
+			);
+
+			// unsigned max
+			Assert.That(
+				TuPack.EncodeKey(ulong.MaxValue).ToString(),
+				Is.EqualTo("<1C><FF><FF><FF><FF><FF><FF><FF><FF>")
+			);
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Integers()
+		{
+
+			Action<string, long> verify = (encoded, value) =>
+			{
+				var slice = Slice.Unescape(encoded);
+				Assert.That(TuplePackers.DeserializeBoxed(slice), Is.EqualTo(value), "DeserializeBoxed({0})", encoded);
+
+				// int64
+				Assert.That(TuplePackers.DeserializeInt64(slice), Is.EqualTo(value), "DeserializeInt64({0})", encoded);
+				Assert.That(TuplePacker<long>.Deserialize(slice), Is.EqualTo(value), "Deserialize<long>({0})", encoded);
+
+				// uint64
+				if (value >= 0)
+				{
+					Assert.That(TuplePackers.DeserializeUInt64(slice), Is.EqualTo((ulong) value), "DeserializeUInt64({0})", encoded);
+					Assert.That(TuplePacker<ulong>.Deserialize(slice), Is.EqualTo((ulong) value), "Deserialize<ulong>({0})", encoded);
+				}
+				else
+				{
+					Assert.That<ulong>(() => TuplePackers.DeserializeUInt64(slice), Throws.InstanceOf<OverflowException>(), "DeserializeUInt64({0})", encoded);
+				}
+
+				// int32
+				if (value <= int.MaxValue && value >= int.MinValue)
+				{
+					Assert.That(TuplePackers.DeserializeInt32(slice), Is.EqualTo((int) value), "DeserializeInt32({0})", encoded);
+					Assert.That(TuplePacker<long>.Deserialize(slice), Is.EqualTo((int) value), "Deserialize<int>({0})", encoded);
+				}
+				else
+				{
+					Assert.That<int>(() => TuplePackers.DeserializeInt32(slice), Throws.InstanceOf<OverflowException>(), "DeserializeInt32({0})", encoded);
+				}
+
+				// uint32
+				if (value <= uint.MaxValue && value >= 0)
+				{
+					Assert.That(TuplePackers.DeserializeUInt32(slice), Is.EqualTo((uint) value), "DeserializeUInt32({0})", encoded);
+					Assert.That(TuplePacker<uint>.Deserialize(slice), Is.EqualTo((uint) value), "Deserialize<uint>({0})", encoded);
+				}
+				else
+				{
+					Assert.That<uint>(() => TuplePackers.DeserializeUInt32(slice), Throws.InstanceOf<OverflowException>(), "DeserializeUInt32({0})", encoded);
+				}
+
+				// int16
+				if (value <= short.MaxValue && value >= short.MinValue)
+				{
+					Assert.That(TuplePackers.DeserializeInt16(slice), Is.EqualTo((short) value), "DeserializeInt16({0})", encoded);
+					Assert.That(TuplePacker<short>.Deserialize(slice), Is.EqualTo((short) value), "Deserialize<short>({0})", encoded);
+				}
+				else
+				{
+					Assert.That<short>(() => TuplePackers.DeserializeInt16(slice), Throws.InstanceOf<OverflowException>(), "DeserializeInt16({0})", encoded);
+				}
+
+				// uint16
+				if (value <= ushort.MaxValue && value >= 0)
+				{
+					Assert.That(TuplePackers.DeserializeUInt16(slice), Is.EqualTo((ushort) value), "DeserializeUInt16({0})", encoded);
+					Assert.That(TuplePacker<ushort>.Deserialize(slice), Is.EqualTo((ushort) value), "Deserialize<ushort>({0})", encoded);
+				}
+				else
+				{
+					Assert.That<ushort>(() => TuplePackers.DeserializeUInt16(slice), Throws.InstanceOf<OverflowException>(), "DeserializeUInt16({0})", encoded);
+				}
+
+				// sbyte
+				if (value <= sbyte.MaxValue && value >= sbyte.MinValue)
+				{
+					Assert.That(TuplePackers.DeserializeSByte(slice), Is.EqualTo((sbyte) value), "DeserializeSByte({0})", encoded);
+					Assert.That(TuplePacker<sbyte>.Deserialize(slice), Is.EqualTo((sbyte) value), "Deserialize<sbyte>({0})", encoded);
+				}
+				else
+				{
+					Assert.That<sbyte>(() => TuplePackers.DeserializeSByte(slice), Throws.InstanceOf<OverflowException>(), "DeserializeSByte({0})", encoded);
+				}
+
+				// byte
+				if (value <= 255 && value >= 0)
+				{
+					Assert.That(TuplePackers.DeserializeByte(slice), Is.EqualTo((byte) value), "DeserializeByte({0})", encoded);
+					Assert.That(TuplePacker<byte>.Deserialize(slice), Is.EqualTo((byte) value), "Deserialize<byte>({0})", encoded);
+				}
+				else
+				{
+					Assert.That<byte>(() => TuplePackers.DeserializeByte(slice), Throws.InstanceOf<OverflowException>(), "DeserializeByte({0})", encoded);
+				}
+
+			};
+			verify("<14>", 0);
+			verify("<15>{", 123);
+			verify("<15><80>", 128);
+			verify("<15><FF>", 255);
+			verify("<16><01><00>", 256);
+			verify("<16><04><D2>", 1234);
+			verify("<16><80><00>", 32768);
+			verify("<16><FF><FF>", 65535);
+			verify("<17><01><00><00>", 65536);
+			verify("<13><FE>", -1);
+			verify("<13><00>", -255);
+			verify("<12><FE><FF>", -256);
+			verify("<12><00><00>", -65535);
+			verify("<11><FE><FF><FF>", -65536);
+			verify("<18><7F><FF><FF><FF>", int.MaxValue);
+			verify("<10><7F><FF><FF><FF>", int.MinValue);
+			verify("<1C><7F><FF><FF><FF><FF><FF><FF><FF>", long.MaxValue);
+			verify("<0C><7F><FF><FF><FF><FF><FF><FF><FF>", long.MinValue);
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Negative_Integers()
+		{
+			// Negative integers are stored with a variable-length encoding.
+			// - The prefix is 0x14 - the minimum number of bytes to encode the integer, from 0 to 8, so valid prefixes range from 0x0C to 0x13
+			// - The value is encoded as the one's complement, and stored in High-Endian (ie: the upper bits first)
+			// - There is no way to encode '-0', it will be encoded as '0' (<14>)
+			// Examples:
+			// - -255..-1 => <13><00> .. <13><FE>
+			// - -65535..-256 => <12><00>00> .. <12><FE><FF>
+			// - long.MinValue => <0C><7F><FF><FF><FF><FF><FF><FF><FF>
+
+			Assert.That(
+				TuPack.EncodeKey(-1).ToString(),
+				Is.EqualTo("<13><FE>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(-255).ToString(),
+				Is.EqualTo("<13><00>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(-256).ToString(),
+				Is.EqualTo("<12><FE><FF>")
+			);
+			Assert.That(
+				TuPack.EncodeKey(-257).ToString(),
+				Is.EqualTo("<12><FE><FE>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(-65535).ToString(),
+				Is.EqualTo("<12><00><00>")
+			);
+			Assert.That(
+				TuPack.EncodeKey(-65536).ToString(),
+				Is.EqualTo("<11><FE><FF><FF>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(int.MinValue).ToString(),
+				Is.EqualTo("<10><7F><FF><FF><FF>")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(long.MinValue).ToString(),
+				Is.EqualTo("<0C><7F><FF><FF><FF><FF><FF><FF><FF>")
+			);
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Singles()
+		{
+			// 32-bit floats are stored in 5 bytes, using the prefix 0x20 followed by the High-Endian representation of their normalized form
+
+			Assert.That(TuPack.EncodeKey(0f).ToHexaString(' '), Is.EqualTo("20 80 00 00 00"));
+			Assert.That(TuPack.EncodeKey(42f).ToHexaString(' '), Is.EqualTo("20 C2 28 00 00"));
+			Assert.That(TuPack.EncodeKey(-42f).ToHexaString(' '), Is.EqualTo("20 3D D7 FF FF"));
+
+			Assert.That(TuPack.EncodeKey((float) Math.Sqrt(2)).ToHexaString(' '), Is.EqualTo("20 BF B5 04 F3"));
+
+			Assert.That(TuPack.EncodeKey(float.MinValue).ToHexaString(' '), Is.EqualTo("20 00 80 00 00"), "float.MinValue");
+			Assert.That(TuPack.EncodeKey(float.MaxValue).ToHexaString(' '), Is.EqualTo("20 FF 7F FF FF"), "float.MaxValue");
+			Assert.That(TuPack.EncodeKey(-0f).ToHexaString(' '), Is.EqualTo("20 7F FF FF FF"), "-0f");
+			Assert.That(TuPack.EncodeKey(float.NegativeInfinity).ToHexaString(' '), Is.EqualTo("20 00 7F FF FF"), "float.NegativeInfinity");
+			Assert.That(TuPack.EncodeKey(float.PositiveInfinity).ToHexaString(' '), Is.EqualTo("20 FF 80 00 00"), "float.PositiveInfinity");
+			Assert.That(TuPack.EncodeKey(float.Epsilon).ToHexaString(' '), Is.EqualTo("20 80 00 00 01"), "+float.Epsilon");
+			Assert.That(TuPack.EncodeKey(-float.Epsilon).ToHexaString(' '), Is.EqualTo("20 7F FF FF FE"), "-float.Epsilon");
+
+			// all possible variants of NaN should all be equal
+			Assert.That(TuPack.EncodeKey(float.NaN).ToHexaString(' '), Is.EqualTo("20 00 3F FF FF"), "float.NaN");
+
+			// cook up a non standard NaN (with some bits set in the fraction)
+			float f = float.NaN; // defined as 1f / 0f
+			uint nan;
+			unsafe { nan = *((uint*) &f); }
+			nan += 123;
+			unsafe { f = *((float*) &nan); }
+			Assert.That(float.IsNaN(f), Is.True);
+			Assert.That(
+				TuPack.EncodeKey(f).ToHexaString(' '),
+				Is.EqualTo("20 00 3F FF FF"),
+				"All variants of NaN must be normalized"
+				//note: if we have 20 00 3F FF 84, that means that the NaN was not normalized
+			);
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Singles()
+		{
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 80 00 00 00")), Is.EqualTo(0f), "0f");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 C2 28 00 00")), Is.EqualTo(42f), "42f");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 3D D7 FF FF")), Is.EqualTo(-42f), "-42f");
+
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 BF B5 04 F3")), Is.EqualTo((float) Math.Sqrt(2)), "Sqrt(2)");
+
+			// well known values
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 00 80 00 00")), Is.EqualTo(float.MinValue), "float.MinValue");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 FF 7F FF FF")), Is.EqualTo(float.MaxValue), "float.MaxValue");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 7F FF FF FF")), Is.EqualTo(-0f), "-0f");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 00 7F FF FF")), Is.EqualTo(float.NegativeInfinity), "float.NegativeInfinity");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 FF 80 00 00")), Is.EqualTo(float.PositiveInfinity), "float.PositiveInfinity");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 00 80 00 00")), Is.EqualTo(float.MinValue), "float.Epsilon");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 80 00 00 01")), Is.EqualTo(float.Epsilon), "+float.Epsilon");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 7F FF FF FE")), Is.EqualTo(-float.Epsilon), "-float.Epsilon");
+
+			// all possible variants of NaN should end up equal and normalized to float.NaN
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 00 3F FF FF")), Is.EqualTo(float.NaN), "float.NaN");
+			Assert.That(TuPack.DecodeKey<float>(Slice.FromHexa("20 00 3F FF FF")), Is.EqualTo(float.NaN), "float.NaN");
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Doubles()
+		{
+			// 64-bit floats are stored in 9 bytes, using the prefix 0x21 followed by the High-Endian representation of their normalized form
+
+			Assert.That(TuPack.EncodeKey(0d).ToHexaString(' '), Is.EqualTo("21 80 00 00 00 00 00 00 00"));
+			Assert.That(TuPack.EncodeKey(42d).ToHexaString(' '), Is.EqualTo("21 C0 45 00 00 00 00 00 00"));
+			Assert.That(TuPack.EncodeKey(-42d).ToHexaString(' '), Is.EqualTo("21 3F BA FF FF FF FF FF FF"));
+
+			Assert.That(TuPack.EncodeKey(Math.PI).ToHexaString(' '), Is.EqualTo("21 C0 09 21 FB 54 44 2D 18"));
+			Assert.That(TuPack.EncodeKey(Math.E).ToHexaString(' '), Is.EqualTo("21 C0 05 BF 0A 8B 14 57 69"));
+
+			Assert.That(TuPack.EncodeKey(double.MinValue).ToHexaString(' '), Is.EqualTo("21 00 10 00 00 00 00 00 00"), "double.MinValue");
+			Assert.That(TuPack.EncodeKey(double.MaxValue).ToHexaString(' '), Is.EqualTo("21 FF EF FF FF FF FF FF FF"), "double.MaxValue");
+			Assert.That(TuPack.EncodeKey(-0d).ToHexaString(' '), Is.EqualTo("21 7F FF FF FF FF FF FF FF"), "-0d");
+			Assert.That(TuPack.EncodeKey(double.NegativeInfinity).ToHexaString(' '), Is.EqualTo("21 00 0F FF FF FF FF FF FF"), "double.NegativeInfinity");
+			Assert.That(TuPack.EncodeKey(double.PositiveInfinity).ToHexaString(' '), Is.EqualTo("21 FF F0 00 00 00 00 00 00"), "double.PositiveInfinity");
+			Assert.That(TuPack.EncodeKey(double.Epsilon).ToHexaString(' '), Is.EqualTo("21 80 00 00 00 00 00 00 01"), "+double.Epsilon");
+			Assert.That(TuPack.EncodeKey(-double.Epsilon).ToHexaString(' '), Is.EqualTo("21 7F FF FF FF FF FF FF FE"), "-double.Epsilon");
+
+			// all possible variants of NaN should all be equal
+
+			Assert.That(TuPack.EncodeKey(double.NaN).ToHexaString(' '), Is.EqualTo("21 00 07 FF FF FF FF FF FF"), "double.NaN");
+
+			// cook up a non standard NaN (with some bits set in the fraction)
+			double d = double.NaN; // defined as 1d / 0d
+			ulong nan;
+			unsafe { nan = *((ulong*) &d); }
+			nan += 123;
+			unsafe { d = *((double*) &nan); }
+			Assert.That(double.IsNaN(d), Is.True);
+			Assert.That(
+				TuPack.EncodeKey(d).ToHexaString(' '),
+				Is.EqualTo("21 00 07 FF FF FF FF FF FF")
+				//note: if we have 21 00 07 FF FF FF FF FF 84, that means that the NaN was not normalized
+			);
+
+			// roundtripping vectors of doubles
+			var tuple = STuple.Create(Math.PI, Math.E, Math.Log(1), Math.Log(2));
+			Assert.That(TuPack.Unpack(TuPack.EncodeKey(Math.PI, Math.E, Math.Log(1), Math.Log(2))), Is.EqualTo(tuple));
+			Assert.That(TuPack.Unpack(TuPack.Pack(STuple.Create(Math.PI, Math.E, Math.Log(1), Math.Log(2)))), Is.EqualTo(tuple));
+			Assert.That(TuPack.Unpack(TuPack.Pack(STuple.Empty.Append(Math.PI).Append(Math.E).Append(Math.Log(1)).Append(Math.Log(2)))), Is.EqualTo(tuple));
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Doubles()
+		{
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 80 00 00 00 00 00 00 00")), Is.EqualTo(0d), "0d");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 C0 45 00 00 00 00 00 00")), Is.EqualTo(42d), "42d");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 3F BA FF FF FF FF FF FF")), Is.EqualTo(-42d), "-42d");
+
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 C0 09 21 FB 54 44 2D 18")), Is.EqualTo(Math.PI), "Math.PI");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 C0 05 BF 0A 8B 14 57 69")), Is.EqualTo(Math.E), "Math.E");
+
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 00 10 00 00 00 00 00 00")), Is.EqualTo(double.MinValue), "double.MinValue");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 FF EF FF FF FF FF FF FF")), Is.EqualTo(double.MaxValue), "double.MaxValue");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 7F FF FF FF FF FF FF FF")), Is.EqualTo(-0d), "-0d");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 00 0F FF FF FF FF FF FF")), Is.EqualTo(double.NegativeInfinity), "double.NegativeInfinity");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 FF F0 00 00 00 00 00 00")), Is.EqualTo(double.PositiveInfinity), "double.PositiveInfinity");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 80 00 00 00 00 00 00 01")), Is.EqualTo(double.Epsilon), "+double.Epsilon");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 7F FF FF FF FF FF FF FE")), Is.EqualTo(-double.Epsilon), "-double.Epsilon");
+
+			// all possible variants of NaN should end up equal and normalized to double.NaN
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 00 07 FF FF FF FF FF FF")), Is.EqualTo(double.NaN), "double.NaN");
+			Assert.That(TuPack.DecodeKey<double>(Slice.FromHexa("21 00 07 FF FF FF FF FF 84")), Is.EqualTo(double.NaN), "double.NaN");
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Booleans()
+		{
+			// Booleans are stored as interger 0 (<14>) for false, and integer 1 (<15><01>) for true
+
+			Slice packed;
+
+			// bool
+			packed = TuPack.EncodeKey(false);
+			Assert.That(packed.ToString(), Is.EqualTo("<14>"));
+			packed = TuPack.EncodeKey(true);
+			Assert.That(packed.ToString(), Is.EqualTo("<15><01>"));
+
+			// bool?
+			packed = TuPack.EncodeKey(default(bool?));
+			Assert.That(packed.ToString(), Is.EqualTo("<00>"));
+			packed = TuPack.EncodeKey((bool?) false);
+			Assert.That(packed.ToString(), Is.EqualTo("<14>"));
+			packed = TuPack.EncodeKey((bool?) true);
+			Assert.That(packed.ToString(), Is.EqualTo("<15><01>"));
+
+			// tuple containing bools
+			packed = TuPack.EncodeKey(true);
+			Assert.That(packed.ToString(), Is.EqualTo("<15><01>"));
+			packed = TuPack.EncodeKey(true, default(string), false);
+			Assert.That(packed.ToString(), Is.EqualTo("<15><01><00><14>"));
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Booleans()
+		{
+			// Null, 0, and empty byte[]/strings are equivalent to False. All others are equivalent to True
+
+			// Falsy...
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<00>")), Is.False, "Null => False");
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<14>")), Is.False, "0 => False");
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<01><00>")), Is.False, "byte[0] => False");
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<02><00>")), Is.False, "String.Empty => False");
+
+			// Truthy
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<15><01>")), Is.True, "1 => True");
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<13><FE>")), Is.True, "-1 => True");
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<01>Hello<00>")), Is.True, "'Hello' => True");
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<02>Hello<00>")), Is.True, "\"Hello\" => True");
+			Assert.That(TuPack.DecodeKey<bool>(TuPack.EncodeKey(123456789)), Is.True, "random int => True");
+
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<02>True<00>")), Is.True, "\"True\" => True");
+			Assert.That(TuPack.DecodeKey<bool>(Slice.Unescape("<02>False<00>")), Is.True, "\"False\" => True ***");
+			// note: even though it would be tempting to convert the string "false" to False, it is not a standard behavior accross all bindings
+
+			// When decoded to object, though, they should return 0 and 1
+			Assert.That(TuplePackers.DeserializeBoxed(TuPack.EncodeKey(false)), Is.EqualTo(0));
+			Assert.That(TuplePackers.DeserializeBoxed(TuPack.EncodeKey(true)), Is.EqualTo(1));
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_VersionStamps()
+		{
+			// incomplete, 80 bits
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Incomplete()).ToHexaString(' '),
+				Is.EqualTo("33 FF FF FF FF FF FF FF FF FF FF")
+			);
+
+			// incomplete, 96 bits
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Incomplete(0)).ToHexaString(' '),
+				Is.EqualTo("33 FF FF FF FF FF FF FF FF FF FF 00 00")
+			);
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Incomplete(42)).ToHexaString(' '),
+				Is.EqualTo("33 FF FF FF FF FF FF FF FF FF FF 00 2A")
+			);
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Incomplete(456)).ToHexaString(' '),
+				Is.EqualTo("33 FF FF FF FF FF FF FF FF FF FF 01 C8")
+			);
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Incomplete(65535)).ToHexaString(' '),
+				Is.EqualTo("33 FF FF FF FF FF FF FF FF FF FF FF FF")
+			);
+
+			// complete, 80 bits
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Complete(0x0123456789ABCDEF, 1234)).ToHexaString(' '),
+				Is.EqualTo("33 01 23 45 67 89 AB CD EF 04 D2")
+			);
+
+			// complete, 96 bits
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Complete(0x0123456789ABCDEF, 1234, 0)).ToHexaString(' '),
+				Is.EqualTo("33 01 23 45 67 89 AB CD EF 04 D2 00 00")
+			);
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Complete(0x0123456789ABCDEF, 1234, 42)).ToHexaString(' '),
+				Is.EqualTo("33 01 23 45 67 89 AB CD EF 04 D2 00 2A")
+			);
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Complete(0x0123456789ABCDEF, 65535, 42)).ToHexaString(' '),
+				Is.EqualTo("33 01 23 45 67 89 AB CD EF FF FF 00 2A")
+			);
+			Assert.That(
+				TuPack.EncodeKey(VersionStamp.Complete(0x0123456789ABCDEF, 1234, 65535)).ToHexaString(' '),
+				Is.EqualTo("33 01 23 45 67 89 AB CD EF 04 D2 FF FF")
+			);
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserailize_VersionStamps()
+		{
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("32 FF FF FF FF FF FF FF FF FF FF")), Is.EqualTo(VersionStamp.Incomplete()), "Incomplete()");
+
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("33 FF FF FF FF FF FF FF FF FF FF 00 00")), Is.EqualTo(VersionStamp.Incomplete()), "Incomplete(0)");
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("33 FF FF FF FF FF FF FF FF FF FF 00 2A")), Is.EqualTo(VersionStamp.Incomplete(42)), "Incomplete(42)");
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("33 FF FF FF FF FF FF FF FF FF FF 01 C8")), Is.EqualTo(VersionStamp.Incomplete(456)), "Incomplete(456)");
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("33 FF FF FF FF FF FF FF FF FF FF FF FF")), Is.EqualTo(VersionStamp.Incomplete(65535)), "Incomplete(65535)");
+
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("32 01 23 45 67 89 AB CD EF 04 D2")), Is.EqualTo(VersionStamp.Complete(0x0123456789ABCDEF, 1234)), "Complete(..., 1234)");
+
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("33 01 23 45 67 89 AB CD EF 04 D2 00 00")), Is.EqualTo(VersionStamp.Complete(0x0123456789ABCDEF, 1234, 0)), "Complete(..., 1234, 0)");
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("33 01 23 45 67 89 AB CD EF 04 D2 00 2A")), Is.EqualTo(VersionStamp.Complete(0x0123456789ABCDEF, 1234, 42)), "Complete(..., 1234, 42)");
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("33 01 23 45 67 89 AB CD EF FF FF 00 2A")), Is.EqualTo(VersionStamp.Complete(0x0123456789ABCDEF, 65535, 42)), "Complete(..., 65535, 42)");
+			Assert.That(TuPack.DecodeKey<VersionStamp>(Slice.FromHexa("33 01 23 45 67 89 AB CD EF 04 D2 FF FF")), Is.EqualTo(VersionStamp.Complete(0x0123456789ABCDEF, 1234, 65535)), "Complete(..., 1234, 65535)");
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_IPAddress()
+		{
+			// IP Addresses are stored as a byte array (<01>..<00>), in network order (big-endian)
+			// They will take from 6 to 10 bytes, depending on the number of '.0' in them.
+
+			Assert.That(
+				TuPack.EncodeKey(IPAddress.Loopback).ToHexaString(' '),
+				Is.EqualTo("01 7F 00 FF 00 FF 01 00")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(IPAddress.Any).ToHexaString(' '),
+				Is.EqualTo("01 00 FF 00 FF 00 FF 00 FF 00")
+			);
+
+			Assert.That(
+				TuPack.EncodeKey(IPAddress.Parse("1.2.3.4")).ToHexaString(' '),
+				Is.EqualTo("01 01 02 03 04 00")
+			);
+
+		}
+
+
+		[Test]
+		public void Test_TuplePack_Deserialize_IPAddress()
+		{
+			Assert.That(TuPack.DecodeKey<IPAddress>(Slice.Unescape("<01><7F><00><FF><00><FF><01><00>")), Is.EqualTo(IPAddress.Parse("127.0.0.1")));
+			Assert.That(TuPack.DecodeKey<IPAddress>(Slice.Unescape("<01><00><FF><00><FF><00><FF><00><FF><00>")), Is.EqualTo(IPAddress.Parse("0.0.0.0")));
+			Assert.That(TuPack.DecodeKey<IPAddress>(Slice.Unescape("<01><01><02><03><04><00>")), Is.EqualTo(IPAddress.Parse("1.2.3.4")));
+
+			Assert.That(TuPack.DecodeKey<IPAddress>(TuPack.EncodeKey("127.0.0.1")), Is.EqualTo(IPAddress.Loopback));
+
+			var ip = IPAddress.Parse("192.168.0.1");
+			Assert.That(TuPack.DecodeKey<IPAddress>(TuPack.EncodeKey(ip.ToString())), Is.EqualTo(ip));
+			Assert.That(TuPack.DecodeKey<IPAddress>(TuPack.EncodeKey(ip.GetAddressBytes())), Is.EqualTo(ip));
+#pragma warning disable 618
+			Assert.That(TuPack.DecodeKey<IPAddress>(TuPack.EncodeKey(ip.Address)), Is.EqualTo(ip));
+#pragma warning restore 618
+		}
+
+		[Test]
+		public void Test_TuplePack_NullableTypes()
+		{
+			// Nullable types will either be encoded as <14> for null, or their regular encoding if not null
+
+			// serialize
+
+			Assert.That(TuPack.EncodeKey<int?>(0), Is.EqualTo(Slice.Unescape("<14>")));
+			Assert.That(TuPack.EncodeKey<int?>(123), Is.EqualTo(Slice.Unescape("<15>{")));
+			Assert.That(TuPack.EncodeKey<int?>(null), Is.EqualTo(Slice.Unescape("<00>")));
+
+			Assert.That(TuPack.EncodeKey<long?>(0L), Is.EqualTo(Slice.Unescape("<14>")));
+			Assert.That(TuPack.EncodeKey<long?>(123L), Is.EqualTo(Slice.Unescape("<15>{")));
+			Assert.That(TuPack.EncodeKey<long?>(null), Is.EqualTo(Slice.Unescape("<00>")));
+
+			Assert.That(TuPack.EncodeKey<bool?>(true), Is.EqualTo(Slice.Unescape("<15><01>")));
+			Assert.That(TuPack.EncodeKey<bool?>(false), Is.EqualTo(Slice.Unescape("<14>")));
+			Assert.That(TuPack.EncodeKey<bool?>(null), Is.EqualTo(Slice.Unescape("<00>")), "Maybe it was File Not Found?");
+
+			Assert.That(TuPack.EncodeKey<Guid?>(Guid.Empty), Is.EqualTo(Slice.Unescape("0<00><00><00><00><00><00><00><00><00><00><00><00><00><00><00><00>")));
+			Assert.That(TuPack.EncodeKey<Guid?>(null), Is.EqualTo(Slice.Unescape("<00>")));
+
+			Assert.That(TuPack.EncodeKey<TimeSpan?>(TimeSpan.Zero), Is.EqualTo(Slice.Unescape("!<80><00><00><00><00><00><00><00>")));
+			Assert.That(TuPack.EncodeKey<TimeSpan?>(null), Is.EqualTo(Slice.Unescape("<00>")));
+
+			// deserialize
+
+			Assert.That(TuPack.DecodeKey<int?>(Slice.Unescape("<14>")), Is.EqualTo(0));
+			Assert.That(TuPack.DecodeKey<int?>(Slice.Unescape("<15>{")), Is.EqualTo(123));
+			Assert.That(TuPack.DecodeKey<int?>(Slice.Unescape("<00>")), Is.Null);
+
+			Assert.That(TuPack.DecodeKey<int?>(Slice.Unescape("<14>")), Is.EqualTo(0L));
+			Assert.That(TuPack.DecodeKey<long?>(Slice.Unescape("<15>{")), Is.EqualTo(123L));
+			Assert.That(TuPack.DecodeKey<long?>(Slice.Unescape("<00>")), Is.Null);
+
+			Assert.That(TuPack.DecodeKey<bool?>(Slice.Unescape("<15><01>")), Is.True);
+			Assert.That(TuPack.DecodeKey<bool?>(Slice.Unescape("<14>")), Is.False);
+			Assert.That(TuPack.DecodeKey<bool?>(Slice.Unescape("<00>")), Is.Null);
+
+			Assert.That(TuPack.DecodeKey<Guid?>(Slice.Unescape("0<00><00><00><00><00><00><00><00><00><00><00><00><00><00><00><00>")), Is.EqualTo(Guid.Empty));
+			Assert.That(TuPack.DecodeKey<Guid?>(Slice.Unescape("<00>")), Is.Null);
+
+			Assert.That(TuPack.DecodeKey<TimeSpan?>(Slice.Unescape("<14>")), Is.EqualTo(TimeSpan.Zero));
+			Assert.That(TuPack.DecodeKey<TimeSpan?>(Slice.Unescape("<00>")), Is.Null);
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_Embedded_Tuples()
+		{
+			Action<ITuple, string> verify = (t, expected) =>
+			{
+				var key = TuPack.Pack(t);
+				Assert.That(key.ToHexaString(' '), Is.EqualTo(expected));
+				var t2 = TuPack.Unpack(key);
+				Assert.That(t2, Is.Not.Null);
+				Assert.That(t2.Count, Is.EqualTo(t.Count), "{0}", t2);
+				Assert.That(t2, Is.EqualTo(t));
+			};
+
+			// Index composite key
+			ITuple value = STuple.Create(2014, 11, 6); // Indexing a date value (Y, M, D)
+			string docId = "Doc123";
+			// key would be "(..., value, id)"
+
+			verify(
+				STuple.Create(42, value, docId),
+				"15 2A 03 16 07 DE 15 0B 15 06 00 02 44 6F 63 31 32 33 00"
+			);
+			verify(
+				STuple.Create(new object[] {42, value, docId}),
+				"15 2A 03 16 07 DE 15 0B 15 06 00 02 44 6F 63 31 32 33 00"
+			);
+			verify(
+				STuple.Create(42).Append(value).Append(docId),
+				"15 2A 03 16 07 DE 15 0B 15 06 00 02 44 6F 63 31 32 33 00"
+			);
+			verify(
+				STuple.Create(42).Append(value, docId),
+				"15 2A 03 16 07 DE 15 0B 15 06 00 02 44 6F 63 31 32 33 00"
+			);
+
+			// multiple depth
+			verify(
+				STuple.Create(1, STuple.Create(2, 3), STuple.Create(STuple.Create(4, 5, 6)), 7),
+				"15 01 03 15 02 15 03 00 03 03 15 04 15 05 15 06 00 00 15 07"
+			);
+
+			// corner cases
+			verify(
+				STuple.Create(STuple.Empty),
+				"03 00" // empty tumple should have header and footer
+			);
+			verify(
+				STuple.Create(STuple.Empty, default(string)),
+				"03 00 00" // outer null should not be escaped
+			);
+			verify(
+				STuple.Create(STuple.Create(default(string)), default(string)),
+				"03 00 FF 00 00" // inner null should be escaped, but not outer
+			);
+			verify(
+				STuple.Create(STuple.Create(0x100, 0x10000, 0x1000000)),
+				"03 16 01 00 17 01 00 00 18 01 00 00 00 00"
+			);
+			verify(
+				STuple.Create(default(string), STuple.Empty, default(string), STuple.Create(default(string)), default(string)),
+				"00 03 00 00 03 00 FF 00 00"
+			);
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_Embedded_Tuples()
+		{
+			// ((42, (2014, 11, 6), "Hello", true), )
+			var packed = TuPack.EncodeKey(STuple.Create(42, STuple.Create(2014, 11, 6), "Hello", true));
+			Log($"t = {TuPack.Unpack(packed)}");
+			Assert.That(packed[0], Is.EqualTo(TupleTypes.TupleStart), "Missing Embedded Tuple marker");
+			{
+				var t = TuPack.DecodeKey<ITuple>(packed);
+				Assert.That(t, Is.Not.Null);
+				Assert.That(t.Count, Is.EqualTo(4));
+				Assert.That(t.Get<int>(0), Is.EqualTo(42));
+				Assert.That(t.Get<ITuple>(1), Is.EqualTo(STuple.Create(2014, 11, 6)));
+				Assert.That(t.Get<string>(2), Is.EqualTo("Hello"));
+				Assert.That(t.Get<bool>(3), Is.True);
+			}
+			{
+				var t = TuPack.DecodeKey<STuple<int, ITuple, string, bool>>(packed);
+				Assert.That(t, Is.Not.Null);
+				Assert.That(t.Item1, Is.EqualTo(42));
+				Assert.That(t.Item2, Is.EqualTo(STuple.Create(2014, 11, 6)));
+				Assert.That(t.Item3, Is.EqualTo("Hello"));
+				Assert.That(t.Item4, Is.True);
+			}
+			{
+				var t = TuPack.DecodeKey<STuple<int, STuple<int, int, int>, string, bool>>(packed);
+				Assert.That(t, Is.Not.Null);
+				Assert.That(t.Item1, Is.EqualTo(42));
+				Assert.That(t.Item2, Is.EqualTo(STuple.Create(2014, 11, 6)));
+				Assert.That(t.Item3, Is.EqualTo("Hello"));
+				Assert.That(t.Item4, Is.True);
+			}
+
+			// (null,)
+			packed = TuPack.EncodeKey(default(string));
+			Log($"t = {TuPack.Unpack(packed)}");
+			{
+				var t = TuPack.DecodeKey<ITuple>(packed);
+				Assert.That(t, Is.Null);
+			}
+			{
+				var t = TuPack.DecodeKey<STuple<int, STuple<int, int, int>, string, bool>>(packed);
+				Assert.That(t.Item1, Is.EqualTo(0));
+				Assert.That(t.Item2, Is.EqualTo(default(STuple<int, int, int>)));
+				Assert.That(t.Item3, Is.Null);
+				Assert.That(t.Item4, Is.False);
+			}
+
+			//fallback if encoded as slice
+			packed = TuPack.EncodeKey(TuPack.EncodeKey(42, STuple.Create(2014, 11, 6), "Hello", true));
+			Log($"t = {TuPack.Unpack(packed)}");
+			Assert.That(packed[0], Is.EqualTo(TupleTypes.Bytes), "Missing Slice marker");
+			{
+				var t = TuPack.DecodeKey<STuple<int, STuple<int, int, int>, string, bool>>(packed);
+				Assert.That(t, Is.Not.Null);
+				Assert.That(t.Item1, Is.EqualTo(42));
+				Assert.That(t.Item2, Is.EqualTo(STuple.Create(2014, 11, 6)));
+				Assert.That(t.Item3, Is.EqualTo("Hello"));
+				Assert.That(t.Item4, Is.True);
+			}
+		}
+
+		[Test]
+		public void Test_TuplePack_SameBytes()
+		{
+			// two ways on packing the "same" tuple yield the same binary output
+			{
+				var expected = TuPack.EncodeKey("Hello World");
+				Assert.That(TuPack.Pack(STuple.Create("Hello World")), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(((ITuple) STuple.Create("Hello World"))), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(STuple.Create(new object[] {"Hello World"})), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(STuple.Create("Hello World", 1234).Substring(0, 1)), Is.EqualTo(expected));
+			}
+			{
+				var expected = TuPack.EncodeKey("Hello World", 1234);
+				Assert.That(TuPack.Pack(STuple.Create("Hello World", 1234)), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(((ITuple) STuple.Create("Hello World", 1234))), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(STuple.Create("Hello World").Append(1234)), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(((ITuple) STuple.Create("Hello World")).Append(1234)), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(STuple.Create(new object[] {"Hello World", 1234})), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(STuple.Create("Hello World", 1234, "Foo").Substring(0, 2)), Is.EqualTo(expected));
+			}
+			{
+				var expected = TuPack.EncodeKey("Hello World", 1234, "Foo");
+				Assert.That(TuPack.Pack(STuple.Create("Hello World", 1234, "Foo")), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(((ITuple) STuple.Create("Hello World", 1234, "Foo"))), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(STuple.Create("Hello World").Append(1234).Append("Foo")), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(((ITuple) STuple.Create("Hello World")).Append(1234).Append("Foo")), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(STuple.Create(new object[] {"Hello World", 1234, "Foo"})), Is.EqualTo(expected));
+				Assert.That(TuPack.Pack(STuple.Create("Hello World", 1234, "Foo", "Bar").Substring(0, 3)), Is.EqualTo(expected));
+			}
+
+			// also, there should be no differences between int,long,uint,... if they have the same value
+			Assert.That(TuPack.Pack(STuple.Create("Hello", 123)), Is.EqualTo(TuPack.Pack(STuple.Create("Hello", 123L))));
+			Assert.That(TuPack.Pack(STuple.Create("Hello", -123)), Is.EqualTo(TuPack.Pack(STuple.Create("Hello", -123L))));
+
+			// GUID / UUID128 should pack the same way
+			var g = Guid.NewGuid();
+			Assert.That(TuPack.Pack(STuple.Create(g)), Is.EqualTo(TuPack.Pack(STuple.Create((Uuid128) g))), "GUID vs UUID128");
+		}
+
+		[Test]
+		public void Test_TuplePack_Numbers_Are_Sorted_Lexicographically()
+		{
+			// pick two numbers 'x' and 'y' at random, and check that the order of 'x' compared to 'y' is the same as 'pack(tuple(x))' compared to 'pack(tuple(y))'
+
+			// ie: ensure that x.CompareTo(y) always has the same sign as Tuple(x).CompareTo(Tuple(y))
+
+			const int N = 1 * 1000 * 1000;
+			var rnd = new Random();
+			var sw = Stopwatch.StartNew();
+
+			for (int i = 0; i < N; i++)
+			{
+				int x = rnd.Next() - 1073741824;
+				int y = x;
+				while (y == x)
+				{
+					y = rnd.Next() - 1073741824;
+				}
+
+				var t1 = TuPack.EncodeKey(x);
+				var t2 = TuPack.EncodeKey(y);
+
+				int dint = x.CompareTo(y);
+				int dtup = t1.CompareTo(t2);
+
+				if (dtup == 0) Assert.Fail("Tuples for x={0} and y={1} should not have the same packed value", x, y);
+
+				// compare signs
+				if (Math.Sign(dint) != Math.Sign(dtup))
+				{
+					Assert.Fail("Tuples for x={0} and y={1} are not sorted properly ({2} / {3}): t(x)='{4}' and t(y)='{5}'", x, y, dint, dtup, t1.ToString(), t2.ToString());
+				}
+			}
+			sw.Stop();
+			Log("Checked {0:N0} tuples in {1:N1} ms", N, sw.ElapsedMilliseconds);
+
+		}
+
+		#endregion
+
+		[Test]
+		public void Test_TuplePack_Pack()
+		{
+			Assert.That(
+				TuPack.Pack(STuple.Create()),
+				Is.EqualTo(Slice.Empty)
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world")).ToString(),
+				Is.EqualTo("<02>hello world<00>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello", "world")).ToString(),
+				Is.EqualTo("<02>hello<00><02>world<00>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world", 123)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world", 1234, -1234)).ToString(),
+				Is.EqualTo("<02>hello world<00><16><04><D2><12><FB>-")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world", 123, false)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world", 123, false, new byte[] {123, 1, 66, 0, 42})).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L, "こんにちは世界")).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L, "こんにちは世界", true)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><15><01>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.Create(new object[] {"hello world", 123, false, new byte[] {123, 1, 66, 0, 42}})).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.FromArray(new object[] {"hello world", 123, false, new byte[] {123, 1, 66, 0, 42}}, 1, 2)).ToString(),
+				Is.EqualTo("<15>{<14>")
+			);
+			Assert.That(
+				TuPack.Pack(STuple.FromEnumerable(new List<object> {"hello world", 123, false, new byte[] {123, 1, 66, 0, 42}})).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Pack_With_Prefix()
+		{
+
+			Slice prefix = Slice.FromString("ABC");
+
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create()).ToString(),
+				Is.EqualTo("ABC")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world")).ToString(),
+				Is.EqualTo("ABC<02>hello world<00>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello", "world")).ToString(),
+				Is.EqualTo("ABC<02>hello<00><02>world<00>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world", 123)).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world", 1234, -1234)).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><16><04><D2><12><FB>-")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world", 123, false)).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 })).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI)).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L)).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L, "こんにちは世界")).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L, "こんにちは世界", true)).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><15><01>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.Create(new object[] { "hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 } })).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.FromArray(new object[] { "hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 } }, 1, 2)).ToString(),
+				Is.EqualTo("ABC<15>{<14>")
+			);
+			Assert.That(
+				TuPack.Pack(prefix, STuple.FromEnumerable(new List<object> { "hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 } })).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+
+			// Nil or Empty slice should be equivalent to no prefix
+			Assert.That(
+				TuPack.Pack(Slice.Nil, STuple.Create("hello world", 123)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{")
+			);
+			Assert.That(
+				TuPack.Pack(Slice.Empty, STuple.Create("hello world", 123)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{")
+			);
+		}
+
+		[Test]
+		public void Test_TuplePack_PackTuples()
+		{
+			{
+				Slice[] slices;
+				var tuples = new ITuple[]
+				{
+					STuple.Create("hello"),
+					STuple.Create(123),
+					STuple.Create(false),
+					STuple.Create("world", 456, true)
+				};
+
+				// array version
+				slices = TuPack.PackTuples(tuples);
+				Assert.That(slices, Is.Not.Null);
+				Assert.That(slices.Length, Is.EqualTo(tuples.Length));
+				Assert.That(slices, Is.EqualTo(tuples.Select(t => TuPack.Pack(t))));
+
+				// IEnumerable version that is passed an array
+				slices = tuples.PackTuples();
+				Assert.That(slices, Is.Not.Null);
+				Assert.That(slices.Length, Is.EqualTo(tuples.Length));
+				Assert.That(slices, Is.EqualTo(tuples.Select(t => TuPack.Pack(t))));
+
+				// IEnumerable version but with a "real" enumerable
+				slices = tuples.Select(t => t).PackTuples();
+				Assert.That(slices, Is.Not.Null);
+				Assert.That(slices.Length, Is.EqualTo(tuples.Length));
+				Assert.That(slices, Is.EqualTo(tuples.Select(t => TuPack.Pack(t))));
+			}
+
+			//Optimized STuple<...> versions
+
+			{
+				var packed = TuPack.PackTuples(
+					STuple.Create("Hello"),
+					STuple.Create(123, true),
+					STuple.Create(Math.PI, -1234L)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<02>Hello<00>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<15>{<15><01>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("!<C0><09>!<FB>TD-<18><12><FB>-"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					STuple.Create(123),
+					STuple.Create(456),
+					STuple.Create(789)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<15>{"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<16><01><C8>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<16><03><15>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					STuple.Create(123, true),
+					STuple.Create(456, false),
+					STuple.Create(789, false)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<15>{<15><01>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<16><01><C8><14>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<16><03><15><14>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					STuple.Create("foo", 123, true),
+					STuple.Create("bar", 456, false),
+					STuple.Create("baz", 789, false)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<02>foo<00><15>{<15><01>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<02>bar<00><16><01><C8><14>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<02>baz<00><16><03><15><14>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					STuple.Create("foo", 123, true, "yes"),
+					STuple.Create("bar", 456, false, "yes"),
+					STuple.Create("baz", 789, false, "no")
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<02>foo<00><15>{<15><01><02>yes<00>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<02>bar<00><16><01><C8><14><02>yes<00>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<02>baz<00><16><03><15><14><02>no<00>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					STuple.Create("foo", 123, true, "yes", 7),
+					STuple.Create("bar", 456, false, "yes", 42),
+					STuple.Create("baz", 789, false, "no", 9)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<02>foo<00><15>{<15><01><02>yes<00><15><07>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<02>bar<00><16><01><C8><14><02>yes<00><15>*"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<02>baz<00><16><03><15><14><02>no<00><15><09>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					STuple.Create("foo", 123, true, "yes", 7, 1.5d),
+					STuple.Create("bar", 456, false, "yes", 42, 0.7d),
+					STuple.Create("baz", 789, false, "no", 9, 0.66d)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<02>foo<00><15>{<15><01><02>yes<00><15><07>!<BF><F8><00><00><00><00><00><00>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<02>bar<00><16><01><C8><14><02>yes<00><15>*!<BF><E6>ffffff"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<02>baz<00><16><03><15><14><02>no<00><15><09>!<BF><E5><1E><B8>Q<EB><85><1F>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+		}
+
+		[Test]
+		public void Test_TuplePack_PackTuples_With_Prefix()
+		{
+			Slice prefix = Slice.FromString("ABC");
+
+			{
+				Slice[] slices;
+				var tuples = new ITuple[]
+				{
+					STuple.Create("hello"),
+					STuple.Create(123),
+					STuple.Create(false),
+					STuple.Create("world", 456, true)
+				};
+
+				// array version
+				slices = TuPack.PackTuples(prefix, tuples);
+				Assert.That(slices, Is.Not.Null);
+				Assert.That(slices.Length, Is.EqualTo(tuples.Length));
+				Assert.That(slices, Is.EqualTo(tuples.Select(t => prefix + TuPack.Pack(t))));
+
+				// LINQ version
+				slices = TuPack.PackTuples(prefix, tuples.Select(x => x));
+				Assert.That(slices, Is.Not.Null);
+				Assert.That(slices.Length, Is.EqualTo(tuples.Length));
+				Assert.That(slices, Is.EqualTo(tuples.Select(t => prefix + TuPack.Pack(t))));
+
+			}
+
+			//Optimized STuple<...> versions
+
+			{
+				var packed = TuPack.PackTuples(
+					prefix,
+					STuple.Create("Hello"),
+					STuple.Create(123, true),
+					STuple.Create(Math.PI, -1234L)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("ABC<02>Hello<00>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("ABC<15>{<15><01>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("ABC!<C0><09>!<FB>TD-<18><12><FB>-"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					prefix,
+					STuple.Create(123),
+					STuple.Create(456),
+					STuple.Create(789)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("ABC<15>{"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("ABC<16><01><C8>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("ABC<16><03><15>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					prefix,
+					STuple.Create(123, true),
+					STuple.Create(456, false),
+					STuple.Create(789, false)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("ABC<15>{<15><01>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("ABC<16><01><C8><14>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("ABC<16><03><15><14>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.PackTuples(
+					prefix,
+					STuple.Create("foo", 123, true),
+					STuple.Create("bar", 456, false),
+					STuple.Create("baz", 789, false)
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("ABC<02>foo<00><15>{<15><01>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("ABC<02>bar<00><16><01><C8><14>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("ABC<02>baz<00><16><03><15><14>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+		}
+
+		[Test]
+		public void Test_TuplePack_EncodeKey()
+		{
+			Assert.That(
+				TuPack.EncodeKey("hello world").ToString(),
+				Is.EqualTo("<02>hello world<00>")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello", "world").ToString(),
+				Is.EqualTo("<02>hello<00><02>world<00>")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello world", 123).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello world", 1234, -1234).ToString(),
+				Is.EqualTo("<02>hello world<00><16><04><D2><12><FB>-")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello world", 123, false).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14>")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello world", 123, false, new byte[] {123, 1, 66, 0, 42}).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18>")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L, "こんにちは世界").ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>")
+			);
+			Assert.That(
+				TuPack.EncodeKey("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L, "こんにちは世界", true).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><15><01>")
+			);
+
+		}
+
+		[Test]
+		public void Test_TuplePack_EncodeKey_With_Prefix()
+		{
+			Slice prefix = Slice.FromString("ABC");
+
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world").ToString(),
+				Is.EqualTo("ABC<02>hello world<00>")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello", "world").ToString(),
+				Is.EqualTo("ABC<02>hello<00><02>world<00>")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world", 123).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world", 1234, -1234).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><16><04><D2><12><FB>-")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world", 123, false).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14>")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18>")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L, "こんにちは世界").ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>")
+			);
+			Assert.That(
+				TuPack.EncodePrefixedKey(prefix, "hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L, "こんにちは世界", true).ToString(),
+				Is.EqualTo("ABC<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><15><01>")
+			);
+
+		}
+
+		[Test]
+		public void Test_TuplePack_EncodeKey_Boxed()
+		{
+			Slice slice;
+
+			slice = TuPack.EncodeKey<object>(default(object));
+			Assert.That(slice.ToString(), Is.EqualTo("<00>"));
+
+			slice = TuPack.EncodeKey<object>(1);
+			Assert.That(slice.ToString(), Is.EqualTo("<15><01>"));
+
+			slice = TuPack.EncodeKey<object>(1L);
+			Assert.That(slice.ToString(), Is.EqualTo("<15><01>"));
+
+			slice = TuPack.EncodeKey<object>(1U);
+			Assert.That(slice.ToString(), Is.EqualTo("<15><01>"));
+
+			slice = TuPack.EncodeKey<object>(1UL);
+			Assert.That(slice.ToString(), Is.EqualTo("<15><01>"));
+
+			slice = TuPack.EncodeKey<object>(false);
+			Assert.That(slice.ToString(), Is.EqualTo("<14>"));
+
+			slice = TuPack.EncodeKey<object>(new byte[] {4, 5, 6});
+			Assert.That(slice.ToString(), Is.EqualTo("<01><04><05><06><00>"));
+
+			slice = TuPack.EncodeKey<object>("hello");
+			Assert.That(slice.ToString(), Is.EqualTo("<02>hello<00>"));
+		}
+
+		[Test]
+		public void Test_TuplePack_EncodeKeys()
+		{
+			//Optimized STuple<...> versions
+
+			{
+				var packed = TuPack.EncodeKeys(
+					"foo",
+					"bar",
+					"baz"
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<02>foo<00>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<02>bar<00>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<02>baz<00>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.EncodeKeys(
+					123,
+					456,
+					789
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<15>{"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<16><01><C8>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<16><03><15>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+
+			{
+				var packed = TuPack.EncodeKeys(Enumerable.Range(0, 3));
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<14>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<15><01>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<15><02>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.EncodeKeys(new[] {"Bonjour", "le", "Monde"}, (s) => s.Length);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("<15><07>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("<15><02>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("<15><05>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+		}
+
+		[Test]
+		public void Test_TuplePack_EncodeKeys_With_Prefix()
+		{
+			Slice prefix = Slice.FromString("ABC");
+
+			{
+				var packed = TuPack.EncodePrefixedKeys(
+					prefix,
+					"foo",
+					"bar",
+					"baz"
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("ABC<02>foo<00>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("ABC<02>bar<00>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("ABC<02>baz<00>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.EncodePrefixedKeys(
+					prefix,
+					123,
+					456,
+					789
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("ABC<15>{"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("ABC<16><01><C8>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("ABC<16><03><15>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+			{
+				var packed = TuPack.EncodePrefixedKeys(
+					prefix,
+					new[] { "Bonjour", "le", "Monde" },
+					(s) => s.Length
+				);
+				Assert.That(packed, Is.Not.Null.And.Length.EqualTo(3));
+				Assert.That(packed[0].ToString(), Is.EqualTo("ABC<15><07>"));
+				Assert.That(packed[1].ToString(), Is.EqualTo("ABC<15><02>"));
+				Assert.That(packed[2].ToString(), Is.EqualTo("ABC<15><05>"));
+				Assert.That(packed[1].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+				Assert.That(packed[2].Array, Is.SameAs(packed[0].Array), "Should share same bufer");
+			}
+
+		}
+
+		[Test]
+		public void Test_TuplePack_SerializersOfT()
+		{
+			Slice prefix = Slice.FromString("ABC");
+			{
+				var serializer = TupleSerializer<int>.Default;
+				var t = STuple.Create(123);
+				var tw = new TupleWriter();
+				tw.Output.WriteBytes(prefix);
+				serializer.PackTo(ref tw, in t);
+				Assert.That(tw.ToSlice().ToString(), Is.EqualTo("ABC<15>{"));
+			}
+			{
+				var serializer = TupleSerializer<string>.Default;
+				var t = STuple.Create("foo");
+				var tw = new TupleWriter();
+				tw.Output.WriteBytes(prefix);
+				serializer.PackTo(ref tw, in t);
+				Assert.That(tw.ToSlice().ToString(), Is.EqualTo("ABC<02>foo<00>"));
+			}
+
+			{
+				var serializer = TupleSerializer<string, int>.Default;
+				var t = STuple.Create("foo", 123);
+				var tw = new TupleWriter();
+				tw.Output.WriteBytes(prefix);
+				serializer.PackTo(ref tw, in t);
+				Assert.That(tw.ToSlice().ToString(), Is.EqualTo("ABC<02>foo<00><15>{"));
+			}
+
+			{
+				var serializer = TupleSerializer<string, bool, int>.Default;
+				var t = STuple.Create("foo", false, 123);
+				var tw = new TupleWriter();
+				tw.Output.WriteBytes(prefix);
+				serializer.PackTo(ref tw, in t);
+				Assert.That(tw.ToSlice().ToString(), Is.EqualTo("ABC<02>foo<00><14><15>{"));
+			}
+
+			{
+				var serializer = TupleSerializer<string, bool, int, long>.Default;
+				var t = STuple.Create("foo", false, 123, -1L);
+				var tw = new TupleWriter();
+				tw.Output.WriteBytes(prefix);
+				serializer.PackTo(ref tw, in t);
+				Assert.That(tw.ToSlice().ToString(), Is.EqualTo("ABC<02>foo<00><14><15>{<13><FE>"));
+			}
+
+			{
+				var serializer = TupleSerializer<string, bool, int, long, string>.Default;
+				var t = STuple.Create("foo", false, 123, -1L, "narf");
+				var tw = new TupleWriter();
+				tw.Output.WriteBytes(prefix);
+				serializer.PackTo(ref tw, in t);
+				Assert.That(tw.ToSlice().ToString(), Is.EqualTo("ABC<02>foo<00><14><15>{<13><FE><02>narf<00>"));
+			}
+
+			{
+				var serializer = TupleSerializer<string, bool, int, long, string, double>.Default;
+				var t = STuple.Create("foo", false, 123, -1L, "narf", Math.PI);
+				var tw = new TupleWriter();
+				tw.Output.WriteBytes(prefix);
+				serializer.PackTo(ref tw, in t);
+				Assert.That(tw.ToSlice().ToString(), Is.EqualTo("ABC<02>foo<00><14><15>{<13><FE><02>narf<00>!<C0><09>!<FB>TD-<18>"));
+			}
+
+		}
+		[Test]
+		public void Test_TuplePack_Unpack()
+		{
+
+			var packed = TuPack.EncodeKey("hello world");
+			Log(packed);
+
+			var tuple = TuPack.Unpack(packed);
+			Assert.That(tuple, Is.Not.Null);
+			Log(tuple);
+			Assert.That(tuple.Count, Is.EqualTo(1));
+			Assert.That(tuple.Get<string>(0), Is.EqualTo("hello world"));
+
+			packed = TuPack.EncodeKey("hello world", 123);
+			Log(packed);
+
+			tuple = TuPack.Unpack(packed);
+			Assert.That(tuple, Is.Not.Null);
+			Log(tuple);
+			Assert.That(tuple.Count, Is.EqualTo(2));
+			Assert.That(tuple.Get<string>(0), Is.EqualTo("hello world"));
+			Assert.That(tuple.Get<int>(1), Is.EqualTo(123));
+
+			packed = TuPack.EncodeKey(1, 256, 257, 65536, int.MaxValue, long.MaxValue);
+			Log(packed);
+
+			tuple = TuPack.Unpack(packed);
+			Assert.That(tuple, Is.Not.Null);
+			Assert.That(tuple.Count, Is.EqualTo(6));
+			Assert.That(tuple.Get<int>(0), Is.EqualTo(1));
+			Assert.That(tuple.Get<int>(1), Is.EqualTo(256));
+			Assert.That(tuple.Get<int>(2), Is.EqualTo(257), ((SlicedTuple) tuple).GetSlice(2).ToString());
+			Assert.That(tuple.Get<int>(3), Is.EqualTo(65536));
+			Assert.That(tuple.Get<int>(4), Is.EqualTo(int.MaxValue));
+			Assert.That(tuple.Get<long>(5), Is.EqualTo(long.MaxValue));
+
+			packed = TuPack.EncodeKey(-1, -256, -257, -65536, int.MinValue, long.MinValue);
+			Log(packed);
+
+			tuple = TuPack.Unpack(packed);
+			Assert.That(tuple, Is.Not.Null);
+			Assert.That(tuple, Is.InstanceOf<SlicedTuple>());
+			Log(tuple);
+			Assert.That(tuple.Count, Is.EqualTo(6));
+			Assert.That(tuple.Get<int>(0), Is.EqualTo(-1));
+			Assert.That(tuple.Get<int>(1), Is.EqualTo(-256));
+			Assert.That(tuple.Get<int>(2), Is.EqualTo(-257), "Slice is " + ((SlicedTuple) tuple).GetSlice(2).ToString());
+			Assert.That(tuple.Get<int>(3), Is.EqualTo(-65536));
+			Assert.That(tuple.Get<int>(4), Is.EqualTo(int.MinValue));
+			Assert.That(tuple.Get<long>(5), Is.EqualTo(long.MinValue));
+		}
+
+		[Test]
+		public void Test_TuplePack_DecodeKey()
+		{
+			Assert.That(
+				TuPack.DecodeKey<string>(Slice.Unescape("<02>hello world<00>")),
+				Is.EqualTo("hello world")
+			);
+			Assert.That(
+				TuPack.DecodeKey<int>(Slice.Unescape("<15>{")),
+				Is.EqualTo(123)
+			);
+			Assert.That(
+				TuPack.DecodeKey<string, string>(Slice.Unescape("<02>hello<00><02>world<00>")),
+				Is.EqualTo(STuple.Create("hello", "world"))
+			);
+			Assert.That(
+				TuPack.DecodeKey<string, int>(Slice.Unescape("<02>hello world<00><15>{")),
+				Is.EqualTo(STuple.Create("hello world", 123))
+			);
+			Assert.That(
+				TuPack.DecodeKey<string, int, long>(Slice.Unescape("<02>hello world<00><16><04><D2><12><FB>-")),
+				Is.EqualTo(STuple.Create("hello world", 1234, -1234L))
+			);
+			Assert.That(
+				TuPack.DecodeKey<string, int, bool>(Slice.Unescape("<02>hello world<00><15>{<14>")),
+				Is.EqualTo(STuple.Create("hello world", 123, false))
+			);
+			Assert.That(
+				TuPack.DecodeKey<string, int, bool, Slice>(Slice.Unescape("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")),
+				Is.EqualTo(STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }.AsSlice()))
+			);
+			Assert.That(
+				TuPack.DecodeKey<string, int, bool, Slice, double>(Slice.Unescape("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18>")),
+				Is.EqualTo(STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }.AsSlice(), Math.PI))
+			);
+			Assert.That(
+				TuPack.DecodeKey<string, int, bool, Slice, double, long>(Slice.Unescape("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-")),
+				Is.EqualTo(STuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }.AsSlice(), Math.PI, -1234L))
+			);
+			//TODO: if/when we have tuples with 7 or 8 items...
+			//Assert.That(
+			//	TuPack.DecodeKey<string, int, bool, Slice, double, long, string>(Slice.Unescape("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>")),
+			//	Is.EqualTo(STuple.Create("hello world", 123, false, Slice.Create(new byte[] { 123, 1, 66, 0, 42 }), Math.PI, -1234L, "こんにちは世界"))
+			//);
+			//Assert.That(
+			//	TuPack.DecodeKey<string, int, bool, Slice, double, long, string, bool>(Slice.Unescape("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><15><01>")),
+			//	Is.EqualTo(STuple.Create("hello world", 123, false, Slice.Create(new byte[] { 123, 1, 66, 0, 42 }), Math.PI, -1234L, "こんにちは世界", true))
+			//);
+		}
+
+		[Test]
+		public void Test_TuplePack_Serialize_ITupleFormattable()
+		{
+			// types that implement ITupleFormattable should be packed by calling ToTuple() and then packing the returned tuple
+
+			Slice packed;
+
+			packed = TuplePacker<Thing>.Serialize(new Thing {Foo = 123, Bar = "hello"});
+			Assert.That(packed.ToString(), Is.EqualTo("<03><15>{<02>hello<00><00>"));
+
+			packed = TuplePacker<Thing>.Serialize(new Thing());
+			Assert.That(packed.ToString(), Is.EqualTo("<03><14><00><FF><00>"));
+
+			packed = TuplePacker<Thing>.Serialize(default(Thing));
+			Assert.That(packed.ToString(), Is.EqualTo("<00>"));
+
+		}
+
+		[Test]
+		public void Test_TuplePack_Deserialize_ITupleFormattable()
+		{
+			Slice slice;
+			Thing thing;
+
+			slice = Slice.Unescape("<03><16><01><C8><02>world<00><00>");
+			thing = TuplePackers.DeserializeFormattable<Thing>(slice);
+			Assert.That(thing, Is.Not.Null);
+			Assert.That(thing.Foo, Is.EqualTo(456));
+			Assert.That(thing.Bar, Is.EqualTo("world"));
+
+			slice = Slice.Unescape("<03><14><00><FF><00>");
+			thing = TuplePackers.DeserializeFormattable<Thing>(slice);
+			Assert.That(thing, Is.Not.Null);
+			Assert.That(thing.Foo, Is.EqualTo(0));
+			Assert.That(thing.Bar, Is.EqualTo(null));
+
+			slice = Slice.Unescape("<00>");
+			thing = TuplePackers.DeserializeFormattable<Thing>(slice);
+			Assert.That(thing, Is.Null);
+		}
+
+		[Test]
+		public void Test_TuplePack_EncodeKeys_Of_T()
+		{
+			Slice[] slices;
+
+			#region PackRange(Tuple, ...)
+
+			var tuple = STuple.Create("hello");
+			int[] items = new int[] {1, 2, 3, 123, -1, int.MaxValue};
+
+			// array version
+			slices = TuPack.EncodePrefixedKeys<int>(tuple, items);
+			Assert.That(slices, Is.Not.Null);
+			Assert.That(slices.Length, Is.EqualTo(items.Length));
+			Assert.That(slices, Is.EqualTo(items.Select(x => TuPack.Pack(tuple.Append(x)))));
+
+			// IEnumerable version that is passed an array
+			slices = TuPack.EncodePrefixedKeys<int>(tuple, (IEnumerable<int>) items);
+			Assert.That(slices, Is.Not.Null);
+			Assert.That(slices.Length, Is.EqualTo(items.Length));
+			Assert.That(slices, Is.EqualTo(items.Select(x => TuPack.Pack(tuple.Append(x)))));
+
+			// IEnumerable version but with a "real" enumerable
+			slices = TuPack.EncodePrefixedKeys<int>(tuple, items.Select(t => t));
+			Assert.That(slices, Is.Not.Null);
+			Assert.That(slices.Length, Is.EqualTo(items.Length));
+			Assert.That(slices, Is.EqualTo(items.Select(x => TuPack.Pack(tuple.Append(x)))));
+
+			#endregion
+
+			#region PackRange(Slice, ...)
+
+			string[] words = {"hello", "world", "très bien", "断トツ", "abc\0def", null, String.Empty};
+
+			var merged = TuPack.EncodePrefixedKeys(Slice.FromByte(42), words);
+			Assert.That(merged, Is.Not.Null);
+			Assert.That(merged.Length, Is.EqualTo(words.Length));
+
+			for (int i = 0; i < words.Length; i++)
+			{
+				var expected = Slice.FromByte(42) + TuPack.EncodeKey(words[i]);
+				Assert.That(merged[i], Is.EqualTo(expected));
+
+				Assert.That(merged[i].Array, Is.SameAs(merged[0].Array), "All slices should be stored in the same buffer");
+				if (i > 0) Assert.That(merged[i].Offset, Is.EqualTo(merged[i - 1].Offset + merged[i - 1].Count), "All slices should be contiguous");
+			}
+
+			// corner cases
+			// ReSharper disable AssignNullToNotNullAttribute
+			Assert.That(
+				() => TuPack.EncodePrefixedKeys<int>(Slice.Empty, default(int[])),
+				Throws.InstanceOf<ArgumentNullException>().With.Property("ParamName").EqualTo("keys"));
+			Assert.That(
+				() => TuPack.EncodePrefixedKeys<int>(Slice.Empty, default(IEnumerable<int>)),
+				Throws.InstanceOf<ArgumentNullException>().With.Property("ParamName").EqualTo("keys"));
+			// ReSharper restore AssignNullToNotNullAttribute
+
+			#endregion
+		}
+
+		[Test]
+		public void Test_TuplePack_EncodeKeys_Boxed()
+		{
+			Slice[] slices;
+			var tuple = STuple.Create("hello");
+			object[] items = {"world", 123, false, Guid.NewGuid(), long.MinValue};
+
+			// array version
+			slices = TuPack.EncodePrefixedKeys<object>(tuple, items);
+			Assert.That(slices, Is.Not.Null);
+			Assert.That(slices.Length, Is.EqualTo(items.Length));
+			Assert.That(slices, Is.EqualTo(items.Select(x => TuPack.Pack(tuple.Append(x)))));
+
+			// IEnumerable version that is passed an array
+			slices = TuPack.EncodePrefixedKeys<object>(tuple, (IEnumerable<object>) items);
+			Assert.That(slices, Is.Not.Null);
+			Assert.That(slices.Length, Is.EqualTo(items.Length));
+			Assert.That(slices, Is.EqualTo(items.Select(x => TuPack.Pack(tuple.Append(x)))));
+
+			// IEnumerable version but with a "real" enumerable
+			slices = TuPack.EncodePrefixedKeys<object>(tuple, items.Select(t => t));
+			Assert.That(slices, Is.Not.Null);
+			Assert.That(slices.Length, Is.EqualTo(items.Length));
+			Assert.That(slices, Is.EqualTo(items.Select(x => TuPack.Pack(tuple.Append(x)))));
+		}
+
+		[Test]
+		public void Test_TuplePack_Unpack_First_And_Last()
+		{
+			// should only work with tuples having at least one element
+
+			Slice packed;
+
+			packed = TuPack.EncodeKey(1);
+			Assert.That(TuPack.DecodeFirst<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeFirst<string>(packed), Is.EqualTo("1"));
+			Assert.That(TuPack.DecodeLast<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeLast<string>(packed), Is.EqualTo("1"));
+
+			packed = TuPack.EncodeKey(1, 2);
+			Assert.That(TuPack.DecodeFirst<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeFirst<string>(packed), Is.EqualTo("1"));
+			Assert.That(TuPack.DecodeLast<int>(packed), Is.EqualTo(2));
+			Assert.That(TuPack.DecodeLast<string>(packed), Is.EqualTo("2"));
+
+			packed = TuPack.EncodeKey(1, 2, 3);
+			Assert.That(TuPack.DecodeFirst<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeFirst<string>(packed), Is.EqualTo("1"));
+			Assert.That(TuPack.DecodeLast<int>(packed), Is.EqualTo(3));
+			Assert.That(TuPack.DecodeLast<string>(packed), Is.EqualTo("3"));
+
+			packed = TuPack.EncodeKey(1, 2, 3, 4);
+			Assert.That(TuPack.DecodeFirst<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeFirst<string>(packed), Is.EqualTo("1"));
+			Assert.That(TuPack.DecodeLast<int>(packed), Is.EqualTo(4));
+			Assert.That(TuPack.DecodeLast<string>(packed), Is.EqualTo("4"));
+
+			packed = TuPack.EncodeKey(1, 2, 3, 4, 5);
+			Assert.That(TuPack.DecodeFirst<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeFirst<string>(packed), Is.EqualTo("1"));
+			Assert.That(TuPack.DecodeLast<int>(packed), Is.EqualTo(5));
+			Assert.That(TuPack.DecodeLast<string>(packed), Is.EqualTo("5"));
+
+			packed = TuPack.EncodeKey(1, 2, 3, 4, 5, 6);
+			Assert.That(TuPack.DecodeFirst<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeFirst<string>(packed), Is.EqualTo("1"));
+			Assert.That(TuPack.DecodeLast<int>(packed), Is.EqualTo(6));
+			Assert.That(TuPack.DecodeLast<string>(packed), Is.EqualTo("6"));
+
+			packed = TuPack.EncodeKey(1, 2, 3, 4, 5, 6, 7);
+			Assert.That(TuPack.DecodeFirst<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeFirst<string>(packed), Is.EqualTo("1"));
+			Assert.That(TuPack.DecodeLast<int>(packed), Is.EqualTo(7));
+			Assert.That(TuPack.DecodeLast<string>(packed), Is.EqualTo("7"));
+
+			packed = TuPack.EncodeKey(1, 2, 3, 4, 5, 6, 7, 8);
+			Assert.That(TuPack.DecodeFirst<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeFirst<string>(packed), Is.EqualTo("1"));
+			Assert.That(TuPack.DecodeLast<int>(packed), Is.EqualTo(8));
+			Assert.That(TuPack.DecodeLast<string>(packed), Is.EqualTo("8"));
+
+			Assert.That(() => TuPack.DecodeFirst<string>(Slice.Nil), Throws.InstanceOf<InvalidOperationException>());
+			Assert.That(() => TuPack.DecodeFirst<string>(Slice.Empty), Throws.InstanceOf<InvalidOperationException>());
+			Assert.That(() => TuPack.DecodeLast<string>(Slice.Nil), Throws.InstanceOf<InvalidOperationException>());
+			Assert.That(() => TuPack.DecodeLast<string>(Slice.Empty), Throws.InstanceOf<InvalidOperationException>());
+
+		}
+
+		[Test]
+		public void Test_TuplePack_UnpackSingle()
+		{
+			// should only work with tuples having exactly one element
+
+			Slice packed;
+
+			packed = TuPack.EncodeKey(1);
+			Assert.That(TuPack.DecodeKey<int>(packed), Is.EqualTo(1));
+			Assert.That(TuPack.DecodeKey<string>(packed), Is.EqualTo("1"));
+
+			packed = TuPack.EncodeKey("Hello\0World");
+			Assert.That(TuPack.DecodeKey<string>(packed), Is.EqualTo("Hello\0World"));
+
+			Assert.That(() => TuPack.DecodeKey<string>(Slice.Nil), Throws.InstanceOf<InvalidOperationException>());
+			Assert.That(() => TuPack.DecodeKey<string>(Slice.Empty), Throws.InstanceOf<InvalidOperationException>());
+			Assert.That(() => TuPack.DecodeKey<int>(TuPack.EncodeKey(1, 2)), Throws.InstanceOf<FormatException>());
+			Assert.That(() => TuPack.DecodeKey<int>(TuPack.EncodeKey(1, 2, 3)), Throws.InstanceOf<FormatException>());
+			Assert.That(() => TuPack.DecodeKey<int>(TuPack.EncodeKey(1, 2, 3, 4)), Throws.InstanceOf<FormatException>());
+			Assert.That(() => TuPack.DecodeKey<int>(TuPack.EncodeKey(1, 2, 3, 4, 5)), Throws.InstanceOf<FormatException>());
+			Assert.That(() => TuPack.DecodeKey<int>(TuPack.EncodeKey(1, 2, 3, 4, 5, 6)), Throws.InstanceOf<FormatException>());
+			Assert.That(() => TuPack.DecodeKey<int>(TuPack.EncodeKey(1, 2, 3, 4, 5, 6, 7)), Throws.InstanceOf<FormatException>());
+			Assert.That(() => TuPack.DecodeKey<int>(TuPack.EncodeKey(1, 2, 3, 4, 5, 6, 7, 8)), Throws.InstanceOf<FormatException>());
+
+		}
+
+		[Test]
+		public void Test_TuplePack_ToRange()
+		{
+			KeyRange range;
+
+			// ToRange() should add 0x00 and 0xFF to the packed representations of the tuples
+			// note: we cannot increment the key to get the End key, because it conflicts with the Tuple Binary Encoding itself
+
+			// Slice
+			range = TuPack.ToRange(Slice.FromString("ABC"));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<00>"), "Begin key should be suffixed by 0x00");
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<FF>"), "End key should be suffixed by 0xFF");
+
+			// Tuples
+
+			range = TuPack.ToRange(STuple.Create("Hello"));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><FF>"));
+
+			range = TuPack.ToRange(STuple.Create("Hello", 123));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<FF>"));
+
+			range = TuPack.ToRange(STuple.Create("Hello", 123, true));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><FF>"));
+
+			range = TuPack.ToRange(STuple.Create("Hello", 123, true, -1234L));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<FF>"));
+
+			range = TuPack.ToRange(STuple.Create("Hello", 123, true, -1234L, "こんにちは世界"));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><FF>"));
+
+			range = TuPack.ToRange(STuple.Create("Hello", 123, true, -1234L, "こんにちは世界", Math.PI));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><FF>"));
+
+			range = TuPack.ToRange(STuple.Create("Hello", 123, true, -1234L, "こんにちは世界", Math.PI, false));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><14><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><14><FF>"));
+
+			range = TuPack.ToRange(STuple.Create("Hello", 123, true, -1234L, "こんにちは世界", Math.PI, false, "TheEnd"));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><14><02>TheEnd<00><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><14><02>TheEnd<00><FF>"));
+		}
+
+		[Test]
+		public void Test_TuplePack_ToRange_With_Prefix()
+		{
+			Slice prefix = Slice.FromString("ABC");
+			KeyRange range;
+
+			range = TuPack.ToRange(prefix, STuple.Create("Hello"));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<02>Hello<00><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<02>Hello<00><FF>"));
+
+			range = TuPack.ToRange(prefix, STuple.Create("Hello", 123));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<FF>"));
+
+			range = TuPack.ToRange(prefix, STuple.Create("Hello", 123, true));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><FF>"));
+
+			range = TuPack.ToRange(prefix, STuple.Create("Hello", 123, true, -1234L));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<FF>"));
+
+			range = TuPack.ToRange(prefix, STuple.Create("Hello", 123, true, -1234L, "こんにちは世界"));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00><FF>"));
+
+			range = TuPack.ToRange(prefix, STuple.Create("Hello", 123, true, -1234L, "こんにちは世界", Math.PI));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><FF>"));
+
+			range = TuPack.ToRange(prefix, STuple.Create("Hello", 123, true, -1234L, "こんにちは世界", Math.PI, false));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><14><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><14><FF>"));
+
+			range = TuPack.ToRange(prefix, STuple.Create("Hello", 123, true, -1234L, "こんにちは世界", Math.PI, false, "TheEnd"));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><14><02>TheEnd<00><00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("ABC<02>Hello<00><15>{<15><01><12><FB>-<02><E3><81><93><E3><82><93><E3><81><AB><E3><81><A1><E3><81><AF><E4><B8><96><E7><95><8C><00>!<C0><09>!<FB>TD-<18><14><02>TheEnd<00><FF>"));
+
+			// Nil or Empty prefix should not add anything
+
+			range = TuPack.ToRange(Slice.Nil, STuple.Create("Hello", 123));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<FF>"));
+
+			range = TuPack.ToRange(Slice.Empty, STuple.Create("Hello", 123));
+			Assert.That(range.Begin.ToString(), Is.EqualTo("<02>Hello<00><15>{<00>"));
+			Assert.That(range.End.ToString(), Is.EqualTo("<02>Hello<00><15>{<FF>"));
+
+		}
+
+		private class Thing : ITupleFormattable
+		{
+			public int Foo { get; set; }
+			public string Bar { get; set; }
+
+			ITuple ITupleFormattable.ToTuple()
+			{
+				return STuple.Create(this.Foo, this.Bar);
+			}
+
+			void ITupleFormattable.FromTuple(ITuple tuple)
+			{
+				this.Foo = tuple.Get<int>(0);
+				this.Bar = tuple.Get<string>(1);
+			}
+		}
+
+#if ENABLE_VALUETUPLES
+
+		[Test]
+		public void Test_TuPack_ValueTuple_Pack()
+		{
+			Assert.That(
+				TuPack.Pack(ValueTuple.Create("hello world")).ToString(),
+				Is.EqualTo("<02>hello world<00>")
+			);
+			Assert.That(
+				TuPack.Pack(ValueTuple.Create("hello world", 123)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{")
+			);
+			Assert.That(
+				TuPack.Pack(ValueTuple.Create("hello world", 123, false)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14>")
+			);
+			Assert.That(
+				TuPack.Pack(ValueTuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 })).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>")
+			);
+			Assert.That(
+				TuPack.Pack(ValueTuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18>")
+			);
+			Assert.That(
+				TuPack.Pack(ValueTuple.Create("hello world", 123, false, new byte[] { 123, 1, 66, 0, 42 }, Math.PI, -1234L)).ToString(),
+				Is.EqualTo("<02>hello world<00><15>{<14><01>{<01>B<00><FF>*<00>!<C0><09>!<FB>TD-<18><12><FB>-")
+			);
+
+			{ // Embedded Tuples
+				var packed = TuPack.Pack(ValueTuple.Create("hello", ValueTuple.Create(123, false), "world"));
+				Assert.That(
+					packed.ToString(),
+					Is.EqualTo("<02>hello<00><03><15>{<14><00><02>world<00>")
+				);
+				var t = TuPack.DecodeKey<string, ValueTuple<int, bool>, string>(packed);
+				Assert.That(t.Item1, Is.EqualTo("hello"));
+				Assert.That(t.Item2.Item1, Is.EqualTo(123));
+				Assert.That(t.Item2.Item2, Is.False);
+				Assert.That(t.Item3, Is.EqualTo("world"));
+			}
+
+		}
+
+#endif
+
+	}
+
+
+}

--- a/FoundationDB.Tests/VersionStampFacts.cs
+++ b/FoundationDB.Tests/VersionStampFacts.cs
@@ -1,0 +1,201 @@
+﻿#region BSD Licence
+/* Copyright (c) 2013-2018, Doxense SAS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of Doxense nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#endregion
+
+namespace FoundationDB.Client.Tests
+{
+	using System;
+	using Doxense.Memory;
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class VersionStampFacts : FdbTest
+	{
+
+		[Test]
+		public void Test_Incomplete_VersionStamp()
+		{
+			{ // 80-bits (no user version)
+				var vs = VersionStamp.Incomplete();
+				Log(vs);
+				Assert.That(vs.TransactionVersion, Is.EqualTo(ulong.MaxValue));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(ushort.MaxValue));
+				Assert.That(vs.IsIncomplete, Is.True);
+				Assert.That(vs.HasUserVersion, Is.False, "80-bits VersionStamps don't have a user version");
+				Assert.That(vs.UserVersion, Is.Zero, "80-bits VersionStamps don't have a user version");
+
+				Assert.That(vs.GetLength(), Is.EqualTo(10));
+				Assert.That(vs.ToSlice().ToHexaString(' '), Is.EqualTo("FF FF FF FF FF FF FF FF FF FF"));
+				Assert.That(vs.ToString(), Is.EqualTo("@?"));
+			}
+
+			{ // 96-bits, default user version
+				var vs = VersionStamp.Incomplete(0);
+				Log(vs);
+				Assert.That(vs.TransactionVersion, Is.EqualTo(ulong.MaxValue));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(ushort.MaxValue));
+				Assert.That(vs.IsIncomplete, Is.True);
+				Assert.That(vs.HasUserVersion, Is.True, "96-bits VersionStamps have a user version");
+				Assert.That(vs.UserVersion, Is.EqualTo(0));
+
+				Assert.That(vs.GetLength(), Is.EqualTo(12));
+				Assert.That(vs.ToSlice().ToHexaString(' '), Is.EqualTo("FF FF FF FF FF FF FF FF FF FF 00 00"));
+				Assert.That(vs.ToString(), Is.EqualTo("@?#0"));
+			}
+
+			{ // 96 bits, custom user version
+				var vs = VersionStamp.Incomplete(123);
+				Log(vs);
+				Assert.That(vs.TransactionVersion, Is.EqualTo(ulong.MaxValue));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(ushort.MaxValue));
+				Assert.That(vs.HasUserVersion, Is.True);
+				Assert.That(vs.UserVersion, Is.EqualTo(123));
+				Assert.That(vs.IsIncomplete, Is.True);
+				Assert.That(vs.ToSlice().ToHexaString(' '), Is.EqualTo("FF FF FF FF FF FF FF FF FF FF 00 7B"));
+				Assert.That(vs.ToString(), Is.EqualTo("@?#123"));
+			}
+
+			{ // 96 bits, large user version
+				var vs = VersionStamp.Incomplete(12345);
+				Log(vs);
+				Assert.That(vs.TransactionVersion, Is.EqualTo(ulong.MaxValue));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(ushort.MaxValue));
+				Assert.That(vs.HasUserVersion, Is.True);
+				Assert.That(vs.UserVersion, Is.EqualTo(12345));
+				Assert.That(vs.IsIncomplete, Is.True);
+				Assert.That(vs.ToSlice().ToHexaString(' '), Is.EqualTo("FF FF FF FF FF FF FF FF FF FF 30 39"));
+				Assert.That(vs.ToString(), Is.EqualTo("@?#12345"));
+			}
+
+			Assert.That(() => VersionStamp.Incomplete(-1), Throws.ArgumentException, "User version cannot be negative");
+			Assert.That(() => VersionStamp.Incomplete(65536), Throws.ArgumentException, "User version cannot be larger than 0xFFFF");
+
+			{
+				var writer = default(SliceWriter);
+				writer.WriteFixed24BE(0xAAAAAA);
+				VersionStamp.Incomplete(123).WriteTo(ref writer);
+				writer.WriteFixed24BE(0xAAAAAA);
+				Assert.That(writer.ToSlice().ToHexaString(' '), Is.EqualTo("AA AA AA FF FF FF FF FF FF FF FF FF FF 00 7B AA AA AA"));
+
+				var reader = new SliceReader(writer.ToSlice());
+				reader.Skip(3);
+				var vs = VersionStamp.Parse(reader.ReadBytes(12));
+				Assert.That(reader.Remaining, Is.EqualTo(3));
+
+				Assert.That(vs.TransactionVersion, Is.EqualTo(ulong.MaxValue));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(ushort.MaxValue));
+				Assert.That(vs.UserVersion, Is.EqualTo(123));
+				Assert.That(vs.IsIncomplete, Is.False, "NOTE: reading stamps is only supposed to happen for stamps already in the database!");
+			}
+
+			{
+				var buf = Slice.Repeat(0xAA, 18);
+				VersionStamp.Incomplete(123).WriteTo(buf.Substring(3, 12));
+				Assert.That(buf.ToHexaString(' '), Is.EqualTo("AA AA AA FF FF FF FF FF FF FF FF FF FF 00 7B AA AA AA"));
+			}
+		}
+
+		[Test]
+		public void Test_Complete_VersionStamp()
+		{
+			{ // 80-bits, no user version
+				var vs = VersionStamp.Complete(0x0123456789ABCDEFUL, 123);
+				Log(vs);
+				Assert.That(vs.TransactionVersion, Is.EqualTo(0x0123456789ABCDEFUL));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(123));
+				Assert.That(vs.HasUserVersion, Is.False);
+				Assert.That(vs.UserVersion, Is.Zero);
+				Assert.That(vs.IsIncomplete, Is.False);
+				Assert.That(vs.ToSlice().ToHexaString(' '), Is.EqualTo("01 23 45 67 89 AB CD EF 00 7B"));
+				Assert.That(vs.ToString(), Is.EqualTo("@81985529216486895-123"));
+			}
+
+			{ // 96 bits, default user version
+				var vs = VersionStamp.Complete(0x0123456789ABCDEFUL, 123, 0);
+				Log(vs);
+				Assert.That(vs.TransactionVersion, Is.EqualTo(0x0123456789ABCDEFUL));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(123));
+				Assert.That(vs.HasUserVersion, Is.True);
+				Assert.That(vs.UserVersion, Is.Zero);
+				Assert.That(vs.IsIncomplete, Is.False);
+				Assert.That(vs.ToSlice().ToHexaString(' '), Is.EqualTo("01 23 45 67 89 AB CD EF 00 7B 00 00"));
+				Assert.That(vs.ToString(), Is.EqualTo("@81985529216486895-123#0"));
+			}
+
+			{ // custom user version
+				var vs = VersionStamp.Complete(0x0123456789ABCDEFUL, 123, 456);
+				Log(vs);
+				Assert.That(vs.TransactionVersion, Is.EqualTo(0x0123456789ABCDEFUL));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(123));
+				Assert.That(vs.HasUserVersion, Is.True);
+				Assert.That(vs.UserVersion, Is.EqualTo(456));
+				Assert.That(vs.IsIncomplete, Is.False);
+				Assert.That(vs.ToSlice().ToHexaString(' '), Is.EqualTo("01 23 45 67 89 AB CD EF 00 7B 01 C8"));
+				Assert.That(vs.ToString(), Is.EqualTo("@81985529216486895-123#456"));
+			}
+
+			{ // two bytes user version
+				var vs = VersionStamp.Complete(0x0123456789ABCDEFUL, 12345, 6789);
+				Log(vs);
+				Assert.That(vs.TransactionVersion, Is.EqualTo(0x0123456789ABCDEFUL));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(12345));
+				Assert.That(vs.UserVersion, Is.EqualTo(6789));
+				Assert.That(vs.IsIncomplete, Is.False);
+				Assert.That(vs.ToSlice().ToHexaString(' '), Is.EqualTo("01 23 45 67 89 AB CD EF 30 39 1A 85"));
+				Assert.That(vs.ToString(), Is.EqualTo("@81985529216486895-12345#6789"));
+			}
+
+			Assert.That(() => VersionStamp.Complete(0x0123456789ABCDEFUL, 0, -1), Throws.ArgumentException, "User version cannot be negative");
+			Assert.That(() => VersionStamp.Complete(0x0123456789ABCDEFUL, 0, 65536), Throws.ArgumentException, "User version cannot be larger than 0xFFFF");
+
+			{
+				var writer = default(SliceWriter);
+				writer.WriteFixed24BE(0xAAAAAA);
+				VersionStamp.Complete(0x0123456789ABCDEFUL, 123, 456).WriteTo(ref writer);
+				writer.WriteFixed24BE(0xAAAAAA);
+				Assert.That(writer.ToSlice().ToHexaString(' '), Is.EqualTo("AA AA AA 01 23 45 67 89 AB CD EF 00 7B 01 C8 AA AA AA"));
+
+				var reader = new SliceReader(writer.ToSlice());
+				reader.Skip(3);
+				var vs = VersionStamp.Parse(reader.ReadBytes(12));
+				Assert.That(reader.Remaining, Is.EqualTo(3));
+
+				Assert.That(vs.TransactionVersion, Is.EqualTo(0x0123456789ABCDEFUL));
+				Assert.That(vs.TransactionOrder, Is.EqualTo(123));
+				Assert.That(vs.UserVersion, Is.EqualTo(456));
+				Assert.That(vs.IsIncomplete, Is.False);
+			}
+
+			{
+				var buf = Slice.Repeat(0xAA, 18);
+				VersionStamp.Complete(0x0123456789ABCDEFUL, 123, 456).WriteTo(buf.Substring(3, 12));
+				Assert.That(buf.ToHexaString(' '), Is.EqualTo("AA AA AA 01 23 45 67 89 AB CD EF 00 7B 01 C8 AA AA AA"));
+			}
+		}
+
+	}
+}

--- a/FoundationDB.Tests/VersionStampFacts.cs
+++ b/FoundationDB.Tests/VersionStampFacts.cs
@@ -109,7 +109,7 @@ namespace FoundationDB.Client.Tests
 				Assert.That(vs.TransactionVersion, Is.EqualTo(ulong.MaxValue));
 				Assert.That(vs.TransactionOrder, Is.EqualTo(ushort.MaxValue));
 				Assert.That(vs.UserVersion, Is.EqualTo(123));
-				Assert.That(vs.IsIncomplete, Is.False, "NOTE: reading stamps is only supposed to happen for stamps already in the database!");
+				Assert.That(vs.IsIncomplete, Is.True);
 			}
 
 			{


### PR DESCRIPTION
Add initial support for VersionStamps in the newest API

- [X] Add VersionStamp struct
- [X] Add support to Tuple Encoding
- [X] Implement fdb_transaction_get_versionstamp
- [X] Implement VersionStampedKey and VersionStampedValue atomic mutations
- [ ] Add unit tests
- [ ] XML Comments
- [ ] Samples / Tutorials

Open questions: see discussion at https://forums.foundationdb.org/t/implementing-versionstamps-in-bindings/250
- Should the same struct support both 80-bits and 96-bits VersionStamps ?
- Should the same struct support both "Incomplete" and "Complete" VersionStamps?
- How to expose a nicer API when using retry loops (`WriteAsync(...)`, `ReadWriterAsync(...)`)
- What should be the textual representation of a Versionstamp (for `ToString()` and `DebuggerDisplay`). Currently it is `"@VERSION-ORDER"` / `"@VERSION-ORDER#USER"` and `"@?"` / `"@?#USER"` for incomplete stamps.

Example usage:

```csharp

readonly struct VersionStamp
{
    readonly ulong TransactionVersion;
    readonly ushort TransactionOrder;
    readonly ushort UserVersion; // or 0 if 80-bit

    bool HasUserVersion { get; } // false: 80-bit, true: 96-bit
    bool IsIncomplete { get; }

    Slice ToSlice();
    void WriteTo(Slice dest);
    void WriteTo(ref SliceWriter writer);

    VersionStamp Parse(Slice packed);
    bool TryParse(Slice packed, out VersionStamp stamp);
}

VersionStamp stamp1 = VersionStamp.Incomplete(); // 80-bit, no user version
VersionStamp stamp2 = VersionStamp.Incomplete(42); // 96-bit, user version 42

Slice key1 = stamp1.ToSlice(); // => 10 bytes
Slice key2 = stamp2.ToSlice(); // => 12 bytes

Slice packedStamp = ....;
VersionStamp stamp3 = VersionStamp.Parse(packedStamp);
if (!VersionStamp.TryParse(packedStamp, out var stamp4))
{
    throw new Exception("....");
}
```

Some conventions:
- incomplete VersionStamps always have the highest 8 bits of their Transaction Version set to 1. This is what is used by deserializers to recognize them from complete stamps. The default being all bits set to 1
- transactions can create random tokens, but they still need to set the highest 8 bits to respect the point above.
- the UserVersion field of 80-bit stamps will always be 0, but should not be accessed (right now I'm not throwing, maybe it should?)