### PR TITLE
Add support for ValueType<T...> in the API

### DIFF
--- a/FoundationDB.Client/FdbDatabaseExtensions.cs
+++ b/FoundationDB.Client/FdbDatabaseExtensions.cs
@@ -318,18 +318,18 @@ namespace FoundationDB.Client
 			return db.WriteAsync((tr) => tr.Set(key, value), ct);
 		}
 
-		/// <summary>Set the values of a list of keys in the database, using a dedicated transaction.</summary>
+		/// <summary>Set the values of a sequence of keys in the database, using a dedicated transaction.</summary>
 		/// <param name="db">Database instance</param>
 		/// <remarks>
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync"/> or <see cref="IFdbRetryable.ReadWriteAsync"/> overrides.
 		/// </remarks>
-		public static Task SetValuesAsync([NotNull] this IFdbRetryable db, KeyValuePair<Slice, Slice>[] keyValuePairs, CancellationToken ct)
+		public static Task SetValuesAsync([NotNull] this IFdbRetryable db, IEnumerable<KeyValuePair<Slice, Slice>> items, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) =>
 			{
-				foreach (var kv in keyValuePairs)
+				foreach (var kv in items)
 				{
 					tr.Set(kv.Key, kv.Value);
 				}
@@ -342,12 +342,12 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync"/> or <see cref="IFdbRetryable.ReadWriteAsync"/> overrides.
 		/// </remarks>
-		public static Task SetValuesAsync([NotNull] this IFdbRetryable db, IEnumerable<KeyValuePair<Slice, Slice>> keyValuePairs, CancellationToken ct)
+		public static Task SetValuesAsync([NotNull] this IFdbRetryable db, IEnumerable<(Slice Key, Slice Value)> items, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) =>
 			{
-				foreach (var kv in keyValuePairs)
+				foreach (var kv in items)
 				{
 					tr.Set(kv.Key, kv.Value);
 				}

--- a/FoundationDB.Client/FoundationDB.Client.csproj
+++ b/FoundationDB.Client/FoundationDB.Client.csproj
@@ -32,4 +32,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+
 </Project>

--- a/FoundationDB.Client/Layers/Tuples/Encoding/TuplePackers.cs
+++ b/FoundationDB.Client/Layers/Tuples/Encoding/TuplePackers.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples.Encoding
 {

--- a/FoundationDB.Client/Layers/Tuples/STuple.cs
+++ b/FoundationDB.Client/Layers/Tuples/STuple.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Layers/Tuples/STuple`1.cs
+++ b/FoundationDB.Client/Layers/Tuples/STuple`1.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Layers/Tuples/STuple`2.cs
+++ b/FoundationDB.Client/Layers/Tuples/STuple`2.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Layers/Tuples/STuple`3.cs
+++ b/FoundationDB.Client/Layers/Tuples/STuple`3.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Layers/Tuples/STuple`4.cs
+++ b/FoundationDB.Client/Layers/Tuples/STuple`4.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Layers/Tuples/STuple`5.cs
+++ b/FoundationDB.Client/Layers/Tuples/STuple`5.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Layers/Tuples/STuple`6.cs
+++ b/FoundationDB.Client/Layers/Tuples/STuple`6.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Layers/Tuples/TuPack.cs
+++ b/FoundationDB.Client/Layers/Tuples/TuPack.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Layers/Tuples/TupleExtensions.cs
+++ b/FoundationDB.Client/Layers/Tuples/TupleExtensions.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace Doxense.Collections.Tuples
 {

--- a/FoundationDB.Client/Status/FdbSystemStatus.cs
+++ b/FoundationDB.Client/Status/FdbSystemStatus.cs
@@ -83,8 +83,8 @@ namespace FoundationDB.Client.Status
 
 		internal static Message From(Dictionary<string, object> data, string field)
 		{
-			var kvp = TinyJsonParser.GetStringPair(TinyJsonParser.GetMapField(data, field), "name", "description");
-			return new Message(kvp.Key ?? String.Empty, kvp.Value ?? String.Empty);
+			(var key, var value) = TinyJsonParser.GetStringPair(TinyJsonParser.GetMapField(data, field), "name", "description");
+			return new Message(key ?? string.Empty, value ?? string.Empty);
 		}
 
 		internal static Message[] FromArray(Dictionary<string, object> data, string field)
@@ -94,8 +94,8 @@ namespace FoundationDB.Client.Status
 			for (int i = 0; i < res.Length; i++)
 			{
 				var obj = (Dictionary<string, object>)array[i];
-				var kvp = TinyJsonParser.GetStringPair(obj, "name", "description");
-				res[i] = new Message(kvp.Key, kvp.Value);
+				(var key, var value) = TinyJsonParser.GetStringPair(obj, "name", "description");
+				res[i] = new Message(key, value);
 			}
 			return res;
 		}
@@ -566,7 +566,7 @@ namespace FoundationDB.Client.Status
 		private ProcessCpuMetrics m_cpu;
 		private ProcessDiskMetrics m_disk;
 		private ProcessMemoryMetrics m_memory;
-		private KeyValuePair<string, string>[] m_roles;
+		private (string Id, string Role)[] m_roles;
 
 		/// <summary>Unique identifier for this process.</summary>
 		//TODO: is it stable accross reboots? what are the conditions for a process to change its ID ?
@@ -613,7 +613,7 @@ namespace FoundationDB.Client.Status
 
 		/// <summary>List of the roles assumed by this process</summary>
 		/// <remarks>The key is the unique role ID in the cluster, and the value is the type of the role itself</remarks>
-		public KeyValuePair<string, string>[] Roles
+		public (string Id, string Role)[] Roles
 		{
 			get
 			{
@@ -622,7 +622,7 @@ namespace FoundationDB.Client.Status
 					//REVIEW: should we have (K=id, V=role) or (K=role, V=id) ?
 
 					var arr = GetArray("roles");
-					var res = new KeyValuePair<string, string>[arr.Count];
+					var res = new (string, string)[arr.Count];
 					for (int i = 0; i < res.Length; i++)
 					{
 						var obj = (Dictionary<string, object>)arr[i];

--- a/FoundationDB.Client/Subspaces/DynamicKeySubspace.cs
+++ b/FoundationDB.Client/Subspaces/DynamicKeySubspace.cs
@@ -26,10 +26,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
+#define ENABLE_VALUETUPLES
+
 namespace FoundationDB.Client
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Diagnostics;
 	using System.Runtime.CompilerServices;
 	using Doxense.Collections.Tuples;
 	using Doxense.Diagnostics.Contracts;
@@ -72,6 +75,7 @@ namespace FoundationDB.Client
 	}
 
 	/// <summary>Key helper for a dynamic TypeSystem</summary>
+	[DebuggerDisplay("{Parent.ToString(),nq)}")]
 	public sealed class DynamicKeys
 	{
 
@@ -92,6 +96,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Convert a tuple into a key of this subspace</summary>
 		/// <param name="tuple">Tuple that will be packed and appended to the subspace prefix</param>
+		[Pure]
 		public Slice Pack<TTuple>([NotNull] TTuple tuple)
 			where TTuple : ITuple
 		{
@@ -101,6 +106,46 @@ namespace FoundationDB.Client
 			this.Encoder.PackKey(ref sw, tuple);
 			return sw.ToSlice();
 		}
+
+#if ENABLE_VALUETUPLES
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Slice Pack<T1>(ValueTuple<T1> items)
+		{
+			return Encode<T1>(items.Item1);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Slice Pack<T1, T2>((T1, T2) items)
+		{
+			return Encode<T1, T2>(items.Item1, items.Item2);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Slice Pack<T1, T2, T3>((T1, T2, T3) items)
+		{
+			return Encode<T1, T2, T3>(items.Item1, items.Item2, items.Item3);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Slice Pack<T1, T2, T3, T4>((T1, T2, T3, T4) items)
+		{
+			return Encode<T1, T2, T3, T4>(items.Item1, items.Item2, items.Item3, items.Item4);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Slice Pack<T1, T2, T3, T4, T5>((T1, T2, T3, T4, T5) items)
+		{
+			return Encode<T1, T2, T3, T4, T5>(items.Item1, items.Item2, items.Item3, items.Item4, items.Item5);
+		}
+
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Slice Pack<T1, T2, T3, T4, T5, T6>((T1, T2, T3, T4, T5, T6) items)
+		{
+			return Encode<T1, T2, T3, T4, T5, T6>(items.Item1, items.Item2, items.Item3, items.Item4, items.Item5, items.Item6);
+		}
+
+#endif
 
 		/// <summary>Unpack a key of this subspace, back into a tuple</summary>
 		/// <param name="packedKey">Key that was produced by a previous call to <see cref="Pack{TTuple}"/></param>

--- a/FoundationDB.Client/Subspaces/KeySubspace.cs
+++ b/FoundationDB.Client/Subspaces/KeySubspace.cs
@@ -42,6 +42,7 @@ namespace FoundationDB.Client
 
 	/// <summary>Adds a prefix on every keys, to group them inside a common subspace</summary>
 	[PublicAPI]
+	[DebuggerDisplay("{ToString(),nq}")]
 	public class KeySubspace : IKeySubspace, IEquatable<IKeySubspace>, IComparable<IKeySubspace>
 	{
 

--- a/FoundationDB.Client/Subspaces/TypedKeySubspace`2.cs
+++ b/FoundationDB.Client/Subspaces/TypedKeySubspace`2.cs
@@ -26,11 +26,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace FoundationDB.Client
 {
 	using System;
+	using System.Diagnostics;
 	using System.Runtime.CompilerServices;
 	using Doxense.Collections.Tuples;
 	using Doxense.Diagnostics.Contracts;
@@ -66,6 +67,7 @@ namespace FoundationDB.Client
 
 	}
 
+	[DebuggerDisplay("{Parent.ToString(),nq)}")]
 	public sealed class TypedKeys<T1, T2>
 	{
 
@@ -84,6 +86,8 @@ namespace FoundationDB.Client
 			this.Encoder = encoder;
 		}
 
+		#region ToRange()
+
 		/// <summary>Return the range of all legal keys in this subpsace</summary>
 		/// <returns>A "legal" key is one that can be decoded into the original pair of values</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -100,6 +104,7 @@ namespace FoundationDB.Client
 			return ToRange(tuple.Item1, tuple.Item2);
 		}
 
+#if ENABLE_VALUETUPLES
 		/// <summary>Return the range of all legal keys in this subpsace, that start with the specified pair of values</summary>
 		/// <returns>Range that encompass all keys that start with (tuple.Item1, tuple.Item2, ..)</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -107,15 +112,20 @@ namespace FoundationDB.Client
 		{
 			return ToRange(tuple.Item1, tuple.Item2);
 		}
+#endif
 
 		/// <summary>Return the range of all legal keys in this subpsace, that start with the specified pair of values</summary>
 		/// <returns>Range that encompass all keys that start with (item1, item2, ..)</returns>
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public KeyRange ToRange(T1 item1, T2 item2)
 		{
-			//HACKHACK: add concept of "range" on  IKeyEncoder ?
-			var prefix = Encode(item1, item2);
-			return KeyRange.PrefixedBy(prefix);
+			//TODO: add concept of "range" on  IKeyEncoder ?
+			return KeyRange.PrefixedBy(Encode(item1, item2));
 		}
+
+		#endregion
+
+		#region ToRangePartial()
 
 		/// <summary>Return the range of all legal keys in this subpsace, that start with the specified first item</summary>
 		/// <returns>Range that encompass all keys that start with (tuple.Item1, ..)</returns>
@@ -133,6 +143,10 @@ namespace FoundationDB.Client
 			return KeyRange.PrefixedBy(EncodePartial(item1));
 		}
 
+		#endregion
+
+		#region Pack()
+
 		/// <summary>Pack a 2-tuple into a key in this subspace</summary>
 		/// <param name="tuple">Pair of values</param>
 		/// <returns>Encoded key in this subspace</returns>
@@ -149,8 +163,8 @@ namespace FoundationDB.Client
 		/// <summary>Pack a 2-tuple into a key in this subspace</summary>
 		/// <param name="tuple">Pair of values</param>
 		/// <returns>Encoded key in this subspace</returns>
-		[Pure]
-		public Slice Pack(ValueTuple<T1, T2> tuple)
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Slice Pack((T1, T2) tuple)
 		{
 			return Encode(tuple.Item1, tuple.Item2);
 		}
@@ -159,36 +173,37 @@ namespace FoundationDB.Client
 		/// <summary>Pack a 2-tuple into a key in this subspace</summary>
 		/// <param name="tuple">Tuple that must be of size 2</param>
 		/// <returns>Encoded key in this subspace</returns>
-		[Pure]
-		public Slice Pack([NotNull] ITuple tuple)
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Slice Pack<TTuple>([NotNull] TTuple tuple)
+			where TTuple : ITuple
 		{
 			tuple.OfSize(2);
 			return Encode(tuple.Get<T1>(0), tuple.Get<T2>(1));
 		}
 
-		/// <summary>Pack a partial key only containing the first item of a key</summary>
-		/// <param name="tuple">Tuple containing a single item</param>
-		/// <returns>Encoded partial key, to be used for generationg key ranges or key selectors</returns>
-		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public Slice PackPartial(STuple<T1> tuple)
+		#endregion
+
+		#region Encode()
+
+		public Slice this[T1 item1, T2 item2]
 		{
-			return EncodePartial(tuple.Item1);
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			get => Encode(item1, item2);
 		}
 
-		/// <summary>Pack a partial key only containing the first item of a key</summary>
-		/// <param name="tuple">Tuple containing a single item</param>
-		/// <returns>Encoded partial key, to be used for generationg key ranges or key selectors</returns>
-		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public Slice PackPartial(ValueTuple<T1> tuple)
+#if ENABLE_VALUETUPLES
+		public Slice this[(T1, T2) items]
 		{
-			return EncodePartial(tuple.Item1);
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			get => Encode(items.Item1, items.Item2);
 		}
+#endif
 
 		/// <summary>Encode a pair of values into a key in this subspace</summary>
 		/// <param name="item1">First part of the key</param>
 		/// <param name="item2">Second part of the key</param>
 		/// <returns>Encoded key in this subspace</returns>
-		/// <remarks>The key can be decoded back into its original components using <see cref="Decode(Slice)"/> or <see cref="Unpack(Slice)"/></remarks>
+		/// <remarks>The key can be decoded back into its original components using <see cref="Decode(Slice)"/> or <see cref="Decode(Slice)"/></remarks>
 		[Pure]
 		public Slice Encode(T1 item1, T2 item2)
 		{
@@ -197,6 +212,10 @@ namespace FoundationDB.Client
 			this.Encoder.WriteKeyPartsTo(ref sw, 2, ref tuple);
 			return sw.ToSlice();
 		}
+
+		#endregion
+
+		#region EncodePartial()
 
 		[Pure]
 		public Slice EncodePartial(T1 item1)
@@ -207,26 +226,36 @@ namespace FoundationDB.Client
 			return sw.ToSlice();
 		}
 
+		#endregion
+
+		#region Decode()
+
 		[Pure]
+		//REVIEW: => Unpack()?
 		//REVIEW: return ValueTuple<..> instead? (C#7)
-		public STuple<T1, T2> Decode(Slice packedKey) //REVIEW: => Unpack()
+		public STuple<T1, T2> Decode(Slice packedKey)
 		{
 			return this.Encoder.DecodeKey(this.Parent.ExtractKey(packedKey));
 		}
 
+		public void Decode(Slice packedKey, out T1 item1, out T2 item2)
+		{
+			this.Encoder
+				.DecodeKey(this.Parent.ExtractKey(packedKey))
+				.Deconstruct(out item1, out item2);
+		}
+
+		#endregion
+		
+		#region DecodePartial()
+
 		[Pure]
 		public T1 DecodePartial(Slice packedKey)
 		{
-			var parts = this.Encoder.DecodeKeyParts(1, packedKey);
-			return parts.Item1;
+			return this.Encoder.DecodeKeyParts(1, packedKey).Item1;
 		}
 
-		public void Decode(Slice packedKey, out T1 item1, out T2 item2)
-		{
-			var tuple = this.Encoder.DecodeKey(this.Parent.ExtractKey(packedKey));
-			item1 = tuple.Item1;
-			item2 = tuple.Item2;
-		}
+		#endregion
 
 		/// <summary>Return a user-friendly string representation of a key of this subspace</summary>
 		[Pure]

--- a/FoundationDB.Client/Subspaces/TypedKeySubspace`3.cs
+++ b/FoundationDB.Client/Subspaces/TypedKeySubspace`3.cs
@@ -26,11 +26,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLES
+#define ENABLE_VALUETUPLES
 
 namespace FoundationDB.Client
 {
 	using System;
+	using System.Diagnostics;
 	using System.Runtime.CompilerServices;
 	using Doxense.Collections.Tuples;
 	using Doxense.Diagnostics.Contracts;
@@ -65,6 +66,7 @@ namespace FoundationDB.Client
 
 	}
 
+	[DebuggerDisplay("{Parent.ToString(),nq)}")]
 	public sealed class TypedKeys<T1, T2, T3>
 	{
 
@@ -83,6 +85,8 @@ namespace FoundationDB.Client
 			this.Encoder = encoder;
 		}
 
+		#region ToRange()
+
 		/// <summary>Return the range of all legal keys in this subpsace</summary>
 		/// <returns>A "legal" key is one that can be decoded into the original triple of values</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -99,13 +103,15 @@ namespace FoundationDB.Client
 			return ToRange(tuple.Item1, tuple.Item2, tuple.Item3);
 		}
 
+#if ENABLE_VALUETUPLES
 		/// <summary>Return the range of all legal keys in this subpsace, that start with the specified triple of values</summary>
 		/// <returns>Range that encompass all keys that start with (tuple.Item1, tuple.Item2, tuple.Item3)</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public KeyRange ToRange(ValueTuple<T1, T2, T3> tuple)
+		public KeyRange ToRange((T1, T2, T3) tuple)
 		{
 			return ToRange(tuple.Item1, tuple.Item2, tuple.Item3);
 		}
+#endif
 
 		/// <summary>Return the range of all legal keys in this subpsace, that start with the specified triple of values</summary>
 		/// <returns>Range that encompass all keys that start with (item1, item2, item3)</returns>
@@ -115,6 +121,10 @@ namespace FoundationDB.Client
 			return KeyRange.PrefixedBy(Encode(item1, item2, item3));
 		}
 
+		#endregion
+
+		#region ToRangePartial()
+
 		/// <summary>Return the range of all legal keys in this subpsace, that start with the specified triple of values</summary>
 		/// <returns>Range that encompass all keys that start with (item1, item2, item3)</returns>
 		public KeyRange ToRangePartial(STuple<T1, T2> tuple)
@@ -123,6 +133,7 @@ namespace FoundationDB.Client
 			return KeyRange.PrefixedBy(EncodePartial(tuple.Item1, tuple.Item2));
 		}
 
+#if ENABLE_VALUETUPLES
 		/// <summary>Return the range of all legal keys in this subpsace, that start with the specified triple of values</summary>
 		/// <returns>Range that encompass all keys that start with (item1, item2, item3)</returns>
 		public KeyRange ToRangePartial(ValueTuple<T1, T2> tuple)
@@ -130,6 +141,7 @@ namespace FoundationDB.Client
 			//HACKHACK: add concept of "range" on  IKeyEncoder ?
 			return KeyRange.PrefixedBy(EncodePartial(tuple.Item1, tuple.Item2));
 		}
+#endif
 
 		/// <summary>Return the range of all legal keys in this subpsace, that start with the specified triple of values</summary>
 		/// <returns>Range that encompass all keys that start with (item1, item2, item3)</returns>
@@ -147,6 +159,10 @@ namespace FoundationDB.Client
 			return KeyRange.PrefixedBy(EncodePartial(item1));
 		}
 
+		#endregion
+
+		#region Pack()
+
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public Slice Pack(STuple<T1, T2, T3> tuple)
 		{
@@ -155,7 +171,7 @@ namespace FoundationDB.Client
 
 #if ENABLE_VALUETUPLES
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public Slice Pack(ValueTuple<T1, T2, T3> tuple)
+		public Slice Pack((T1, T2, T3) tuple)
 		{
 			return Encode(tuple.Item1, tuple.Item2, tuple.Item3);
 		}
@@ -168,6 +184,24 @@ namespace FoundationDB.Client
 			tuple.OfSize(3);
 			return Encode(tuple.Get<T1>(0), tuple.Get<T2>(1), tuple.Get<T3>(2));
 		}
+
+		#endregion
+
+		#region Encode()
+
+		public Slice this[T1 item1, T2 item2, T3 item3]
+		{
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			get => Encode(item1, item2, item3);
+		}
+
+#if ENABLE_VALUETUPLES
+		public Slice this[(T1, T2, T3) items]
+		{
+			[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+			get => Encode(items.Item1, items.Item2, items.Item3);
+		}
+#endif
 
 		[Pure]
 		public Slice Encode(T1 item1, T2 item2, T3 item3)
@@ -196,7 +230,13 @@ namespace FoundationDB.Client
 			return sw.ToSlice();
 		}
 
+		#endregion
+
+		#region Decode()
+
 		[Pure]
+		//REVIEW: => Unpack()?
+		//REVIEW: return ValueTuple<..> instead? (C#7)
 		public STuple<T1, T2, T3> Decode(Slice packedKey)
 		{
 			return this.Encoder.DecodeKey(this.Parent.ExtractKey(packedKey));
@@ -204,11 +244,14 @@ namespace FoundationDB.Client
 
 		public void Decode(Slice packedKey, out T1 item1, out T2 item2, out T3 item3)
 		{
-			var tuple = this.Encoder.DecodeKey(this.Parent.ExtractKey(packedKey));
-			item1 = tuple.Item1;
-			item2 = tuple.Item2;
-			item3 = tuple.Item3;
+			this.Encoder
+				.DecodeKey(this.Parent.ExtractKey(packedKey))
+				.Deconstruct(out item1, out item2, out item3);
 		}
+
+		#endregion
+
+		#region Dump()
 
 		/// <summary>Return a user-friendly string representation of a key of this subspace</summary>
 		[Pure]
@@ -227,6 +270,8 @@ namespace FoundationDB.Client
 				return key.PrettyPrint();
 			}
 		}
+
+		#endregion
 
 	}
 

--- a/FoundationDB.Client/Utils/TinyJsonParser.cs
+++ b/FoundationDB.Client/Utils/TinyJsonParser.cs
@@ -400,10 +400,10 @@ namespace FoundationDB.Client.Utils
 			return map != null && map.TryGetValue(field, out item) ? (bool)item : default(bool?);
 		}
 
-		internal static KeyValuePair<string, string> GetStringPair(Dictionary<string, object> map, string key, string value)
+		internal static (string Key, string Value) GetStringPair(Dictionary<string, object> map, string key, string value)
 		{
 			object item;
-			return new KeyValuePair<string, string>(
+			return (
 				map != null && map.TryGetValue(key, out item) ? (string)item : null,
 				map != null && map.TryGetValue(value, out item) ? (string)item : null
 			);

--- a/FoundationDB.Layers.Common/Collections/FdbMap`2.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbMap`2.cs
@@ -91,7 +91,7 @@ namespace FoundationDB.Layers.Collections
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 			if (id == null) throw new ArgumentNullException(nameof(id));
 
-			var data = await trans.GetAsync(this.Location.Keys.Encode(id)).ConfigureAwait(false);
+			var data = await trans.GetAsync(this.Location.Keys[id]).ConfigureAwait(false);
 
 			if (data.IsNull) throw new KeyNotFoundException("The given id was not present in the map.");
 			return this.ValueEncoder.DecodeValue(data);
@@ -106,7 +106,7 @@ namespace FoundationDB.Layers.Collections
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 			if (id == null) throw new ArgumentNullException(nameof(id));
 
-			var data = await trans.GetAsync(this.Location.Keys.Encode(id)).ConfigureAwait(false);
+			var data = await trans.GetAsync(this.Location.Keys[id]).ConfigureAwait(false);
 
 			if (data.IsNull) return default(Optional<TValue>);
 			return this.ValueEncoder.DecodeValue(data);
@@ -122,7 +122,7 @@ namespace FoundationDB.Layers.Collections
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 			if (id == null) throw new ArgumentNullException(nameof(id));
 
-			trans.Set(this.Location.Keys.Encode(id), this.ValueEncoder.EncodeValue(value));
+			trans.Set(this.Location.Keys[id], this.ValueEncoder.EncodeValue(value));
 		}
 
 		/// <summary>Remove a single entry from the map</summary>
@@ -134,7 +134,7 @@ namespace FoundationDB.Layers.Collections
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 			if (id == null) throw new ArgumentNullException(nameof(id));
 
-			trans.Clear(this.Location.Keys.Encode(id));
+			trans.Clear(this.Location.Keys[id]);
 		}
 
 		/// <summary>Create a query that will attempt to read all the entries in the map within a single transaction.</summary>
@@ -160,7 +160,7 @@ namespace FoundationDB.Layers.Collections
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 			if (ids == null) throw new ArgumentNullException(nameof(ids));
 
-			var results = await trans.GetValuesAsync(ids.Select(id => this.Location.Keys.Encode(id))).ConfigureAwait(false);
+			var results = await trans.GetValuesAsync(ids.Select(id => this.Location.Keys[id])).ConfigureAwait(false);
 
 			return Optional.DecodeRange(this.ValueEncoder, results);
 		}

--- a/FoundationDB.Layers.Common/Counters/FdbCounterMap.cs
+++ b/FoundationDB.Layers.Common/Counters/FdbCounterMap.cs
@@ -77,7 +77,7 @@ namespace FoundationDB.Layers.Counters
 
 			//REVIEW: we could no-op if value == 0 but this may change conflict behaviour for other transactions...
 			Slice param = value == 1 ? PlusOne : value == -1 ? MinusOne : Slice.FromFixed64(value);
-			transaction.AtomicAdd(this.Location.Keys.Encode(counterKey), param);
+			transaction.AtomicAdd(this.Location.Keys[counterKey], param);
 		}
 
 		/// <summary>Subtract a value from a counter in one atomic operation</summary>
@@ -117,7 +117,7 @@ namespace FoundationDB.Layers.Counters
 			if (transaction == null) throw new ArgumentNullException("transaction");
 			if (counterKey == null) throw new ArgumentNullException("counterKey");
 
-			var data = await transaction.GetAsync(this.Location.Keys.Encode(counterKey)).ConfigureAwait(false);
+			var data = await transaction.GetAsync(this.Location.Keys[counterKey]).ConfigureAwait(false);
 			if (data.IsNullOrEmpty) return default(long?);
 			return data.ToInt64();
 		}
@@ -166,7 +166,7 @@ namespace FoundationDB.Layers.Counters
 			if (transaction == null) throw new ArgumentNullException("transaction");
 			if (counterKey == null) throw new ArgumentNullException("counterKey");
 
-			var key = this.Location.Keys.Encode(counterKey);
+			var key = this.Location.Keys[counterKey];
 			var res = await transaction.GetAsync(key).ConfigureAwait(false);
 
 			long previous = res.IsNullOrEmpty ? 0 : res.ToInt64();

--- a/FoundationDB.Layers.Common/Indexes/FdbIndex`2.cs
+++ b/FoundationDB.Layers.Common/Indexes/FdbIndex`2.cs
@@ -81,7 +81,7 @@ namespace FoundationDB.Layers.Indexing
 		{
 			if (this.IndexNullValues || value != null)
 			{
-				trans.Set(this.Location.Keys.Encode(value, id), Slice.Empty);
+				trans.Set(this.Location.Keys[value, id], Slice.Empty);
 				return true;
 			}
 			return false;
@@ -101,13 +101,13 @@ namespace FoundationDB.Layers.Indexing
 				// remove previous value
 				if (this.IndexNullValues || previousValue != null)
 				{
-					trans.Clear(this.Location.Keys.Encode(previousValue, id));
+					trans.Clear(this.Location.Keys[previousValue, id]);
 				}
 
 				// add new value
 				if (this.IndexNullValues || newValue != null)
 				{
-					trans.Set(this.Location.Keys.Encode(newValue, id), Slice.Empty);
+					trans.Set(this.Location.Keys[newValue, id], Slice.Empty);
 				}
 
 				// cannot be both null, so we did at least something)
@@ -124,7 +124,7 @@ namespace FoundationDB.Layers.Indexing
 		{
 			if (trans == null) throw new ArgumentNullException("trans");
 
-			trans.Clear(this.Location.Keys.Encode(value, id));
+			trans.Clear(this.Location.Keys[value, id]);
 		}
 
 		/// <summary>Returns a list of ids matching a specific value</summary>

--- a/FoundationDB.Layers.Experimental/Documents/FdbDocumentCollection.cs
+++ b/FoundationDB.Layers.Experimental/Documents/FdbDocumentCollection.cs
@@ -123,7 +123,7 @@ namespace FoundationDB.Layers.Documents
 				while (remaining > 0)
 				{
 					int sz = Math.Max(remaining, this.ChunkSize);
-					trans.Set(this.Location.Keys.Encode(id, index), packed.Substring(p, sz));
+					trans.Set(this.Location.Keys[id, index], packed.Substring(p, sz));
 					++index;
 					p += sz;
 					remaining -= sz;

--- a/FoundationDB.Layers.Experimental/Indexes/FdbCompressedBitmapIndex.cs
+++ b/FoundationDB.Layers.Experimental/Indexes/FdbCompressedBitmapIndex.cs
@@ -87,7 +87,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 
 			if (this.IndexNullValues || value != null)
 			{
-				var key = this.Location.Keys.Encode(value);
+				var key = this.Location.Keys[value];
 				var data = await trans.GetAsync(key).ConfigureAwait(false);
 				var builder = data.HasValue ? new CompressedBitmapBuilder(data) : CompressedBitmapBuilder.Empty;
 
@@ -117,7 +117,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 				// remove previous value
 				if (this.IndexNullValues || previousValue != null)
 				{
-					var key = this.Location.Keys.Encode(previousValue);
+					var key = this.Location.Keys[previousValue];
 					var data = await trans.GetAsync(key).ConfigureAwait(false);
 					if (data.HasValue)
 					{
@@ -130,7 +130,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 				// add new value
 				if (this.IndexNullValues || newValue != null)
 				{
-					var key = this.Location.Keys.Encode(newValue);
+					var key = this.Location.Keys[newValue];
 					var data = await trans.GetAsync(key).ConfigureAwait(false);
 					var builder = data.HasValue ? new CompressedBitmapBuilder(data) : CompressedBitmapBuilder.Empty;
 					builder.Set((int)id); //BUGBUG: 64 bit id!
@@ -151,7 +151,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 
-			var key = this.Location.Keys.Encode(value);
+			var key = this.Location.Keys[value];
 			var data = await trans.GetAsync(key).ConfigureAwait(false);
 			if (data.HasValue)
 			{
@@ -170,7 +170,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <returns>List of document ids matching this value for this particular index (can be empty if no document matches)</returns>
 		public async Task<IEnumerable<long>> LookupAsync([NotNull] IFdbReadOnlyTransaction trans, TValue value, bool reverse = false)
 		{
-			var key = this.Location.Keys.Encode(value);
+			var key = this.Location.Keys[value];
 			var data = await trans.GetAsync(key).ConfigureAwait(false);
 			if (data.IsNull) return null;
 			if (data.IsEmpty) return Enumerable.Empty<long>();

--- a/FoundationDB.Tests/DatabaseBulkFacts.cs
+++ b/FoundationDB.Tests/DatabaseBulkFacts.cs
@@ -59,7 +59,7 @@ namespace FoundationDB.Client.Tests
 
 				var rnd = new Random(2403);
 				var data = Enumerable.Range(0, N)
-					.Select((x) => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x.ToString("x8")), Slice.Random(rnd, 16 + rnd.Next(240))))
+					.Select((x) => (Key: location.Keys.Encode(x.ToString("x8")), Value: Slice.Random(rnd, 16 + rnd.Next(240))))
 					.ToArray();
 
 				Log("Total data size is {0:N0} bytes", data.Sum(x => x.Key.Count + x.Value.Count));
@@ -197,7 +197,7 @@ namespace FoundationDB.Client.Tests
 
 				await Fdb.Bulk.WriteAsync(
 					db,
-					Enumerable.Range(1, N).Select((x) => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x), Slice.FromInt32(x))),
+					Enumerable.Range(1, N).Select((x) => (location.Keys.Encode(x), Slice.FromInt32(x))),
 					this.Cancellation
 				);
 
@@ -348,7 +348,7 @@ namespace FoundationDB.Client.Tests
 
 				await Fdb.Bulk.WriteAsync(
 					db,
-					Enumerable.Range(1, N).Select((x) => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x), Slice.FromInt32(x))),
+					Enumerable.Range(1, N).Select((x) => (location.Keys.Encode(x), Slice.FromInt32(x))),
 					this.Cancellation
 				);
 
@@ -413,7 +413,7 @@ namespace FoundationDB.Client.Tests
 
 				await Fdb.Bulk.WriteAsync(
 					db,
-					Enumerable.Range(1, N).Select((x) => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x), Slice.FromInt32(x))),
+					Enumerable.Range(1, N).Select((x) => (location.Keys.Encode(x), Slice.FromInt32(x))),
 					this.Cancellation
 				);
 
@@ -473,7 +473,7 @@ namespace FoundationDB.Client.Tests
 
 				await Fdb.Bulk.WriteAsync(
 					db,
-					source.Select((x) => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x.Key), Slice.FromInt32(x.Value))),
+					source.Select((x) => (location.Keys.Encode(x.Key), Slice.FromInt32(x.Value))),
 					this.Cancellation
 				);
 
@@ -534,7 +534,7 @@ namespace FoundationDB.Client.Tests
 
 				await Fdb.Bulk.WriteAsync(
 					db,
-					source.Select((x) => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x.Key), Slice.FromInt32(x.Value))),
+					source.Select((x) => (location.Keys.Encode(x.Key), Slice.FromInt32(x.Value))),
 					this.Cancellation
 				);
 
@@ -603,7 +603,7 @@ namespace FoundationDB.Client.Tests
 
 				await Fdb.Bulk.WriteAsync(
 					db.WithoutLogging(),
-					source.Select((x) => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x.Key), x.Value)),
+					source.Select((x) => (location.Keys.Encode(x.Key), x.Value)),
 					this.Cancellation
 				);
 

--- a/FoundationDB.Tests/RangeQueryFacts.cs
+++ b/FoundationDB.Tests/RangeQueryFacts.cs
@@ -360,7 +360,7 @@ namespace FoundationDB.Client.Tests
 				var location = await GetCleanDirectory(db, "Queries", "Range");
 
 				// import test data
-				var data = Enumerable.Range(0, 100).Select(x => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x), Slice.FromFixed32(x)));
+				var data = Enumerable.Range(0, 100).Select(x => (location.Keys.Encode(x), Slice.FromFixed32(x)));
 				await Fdb.Bulk.WriteAsync(db, data, this.Cancellation);
 
 				// from the start
@@ -442,7 +442,7 @@ namespace FoundationDB.Client.Tests
 				var location = await GetCleanDirectory(db, "Queries", "Range");
 
 				// import test data
-				var data = Enumerable.Range(0, 30).Select(x => new KeyValuePair<Slice, Slice>(location.Keys.Encode(x), Slice.FromFixed32(x)));
+				var data = Enumerable.Range(0, 30).Select(x => (location.Keys.Encode(x), Slice.FromFixed32(x)));
 				await Fdb.Bulk.WriteAsync(db, data, this.Cancellation);
 
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))

--- a/FoundationDB.Tests/SubspaceFacts.cs
+++ b/FoundationDB.Tests/SubspaceFacts.cs
@@ -81,6 +81,12 @@ namespace FoundationDB.Layers.Tuples.Tests
 			Assert.That(t2.Get<string>(0), Is.EqualTo("world"));
 			Assert.That(t2.Get<int>(1), Is.EqualTo(123));
 			Assert.That(t2.Get<bool>(2), Is.False);
+
+			// ValueTuple
+			Assert.That(subspace.Keys.Pack(new ValueTuple<string>("hello")).ToString(), Is.EqualTo("*<FF><00><7F><02>hello<00>"));
+			Assert.That(subspace.Keys.Pack(("hello", 123)).ToString(), Is.EqualTo("*<FF><00><7F><02>hello<00><15>{"));
+			Assert.That(subspace.Keys.Pack(("hello", 123, "world")).ToString(), Is.EqualTo("*<FF><00><7F><02>hello<00><15>{<02>world<00>"));
+			Assert.That(subspace.Keys.Pack(("hello", 123, "world", 456)).ToString(), Is.EqualTo("*<FF><00><7F><02>hello<00><15>{<02>world<00><16><01><C8>"));
 		}
 
 		[Test]
@@ -168,6 +174,177 @@ namespace FoundationDB.Layers.Tuples.Tests
 
 			// cornercase
 			Assert.That(child.Partition[Slice.Empty].GetPrefix(), Is.EqualTo(child.GetPrefix()));
+		}
+
+		[Test]
+		public void Test_DynamicKeySpace_API()
+		{
+			var location = new KeySubspace(Slice.FromString("PREFIX")).Using(TypeSystem.Tuples);
+
+			Assert.That(location[Slice.FromString("SUFFIX")].ToString(), Is.EqualTo("PREFIXSUFFIX"));
+
+			// Encode<T...>(...)
+			Assert.That(location.Keys.Encode("hello").ToString(), Is.EqualTo("PREFIX<02>hello<00>"));
+			Assert.That(location.Keys.Encode("hello", 123).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{"));
+			Assert.That(location.Keys.Encode("hello", 123, "world").ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00>"));
+			Assert.That(location.Keys.Encode("hello", 123, "world", 456).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"));
+			Assert.That(location.Keys.Encode("hello", 123, "world", 456, "!").ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00>"));
+			Assert.That(location.Keys.Encode("hello", 123, "world", 456, "!", 789).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00><16><03><15>"));
+
+			// Pack(ITuple)
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello")).ToString(), Is.EqualTo("PREFIX<02>hello<00>"));
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello", 123)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{"));
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello", 123, "world")).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00>"));
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello", 123, "world", 456)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"));
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello", 123, "world", 456, "!")).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00>"));
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello", 123, "world", 456, "!", 789)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00><16><03><15>"));
+
+			// Pack(ValueTuple)
+			Assert.That(location.Keys.Pack(ValueTuple.Create("hello")).ToString(), Is.EqualTo("PREFIX<02>hello<00>"));
+			Assert.That(location.Keys.Pack(("hello", 123)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{"));
+			Assert.That(location.Keys.Pack(("hello", 123, "world")).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00>"));
+			Assert.That(location.Keys.Pack(("hello", 123, "world", 456)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"));
+			Assert.That(location.Keys.Pack(("hello", 123, "world", 456, "!")).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00>"));
+			Assert.That(location.Keys.Pack(("hello", 123, "world", 456, "!", 789)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00><16><03><15>"));
+
+			// ITuple Unpack(Slice)
+			Assert.That(location.Keys.Unpack(Slice.Unescape("PREFIX<02>hello<00>")), Is.EqualTo(STuple.Create("hello")));
+			Assert.That(location.Keys.Unpack(Slice.Unescape("PREFIX<02>hello<00><15>{")), Is.EqualTo(STuple.Create("hello", 123)));
+			Assert.That(location.Keys.Unpack(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00>")), Is.EqualTo(STuple.Create("hello", 123, "world")));
+			Assert.That(location.Keys.Unpack(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>")), Is.EqualTo(STuple.Create("hello", 123, "world", 456)));
+			Assert.That(location.Keys.Unpack(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00>")), Is.EqualTo(STuple.Create("hello", 123, "world", 456, "!")));
+			Assert.That(location.Keys.Unpack(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00><16><03><15>")), Is.EqualTo(STuple.Create("hello", 123, "world", 456, "!", 789)));
+
+			// STuple<T...> Decode(Slice)
+			Assert.That(location.Keys.Decode<string>(Slice.Unescape("PREFIX<02>hello<00>")), Is.EqualTo("hello"));
+			Assert.That(location.Keys.Decode<string, int>(Slice.Unescape("PREFIX<02>hello<00><15>{")), Is.EqualTo(STuple.Create("hello", 123)));
+			Assert.That(location.Keys.Decode<string, int, string>(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00>")), Is.EqualTo(STuple.Create("hello", 123, "world")));
+			Assert.That(location.Keys.Decode<string, int, string, int>(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>")), Is.EqualTo(STuple.Create("hello", 123, "world", 456)));
+			Assert.That(location.Keys.Decode<string, int, string, int, string>(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00>")), Is.EqualTo(STuple.Create("hello", 123, "world", 456, "!")));
+			Assert.That(location.Keys.Decode<string, int, string, int, string, int>(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00><16><03><15>")), Is.EqualTo(STuple.Create("hello", 123, "world", 456, "!", 789)));
+
+			// DecodeFirst/DecodeLast
+			Assert.That(location.Keys.DecodeFirst<string>(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00><16><03><15>")), Is.EqualTo("hello"));
+			Assert.That(location.Keys.DecodeLast<int>(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8><02>!<00><16><03><15>")), Is.EqualTo(789));
+
+		}
+
+		[Test]
+		public void Test_TypedKeySpace_T1()
+		{
+			var location = new KeySubspace(Slice.FromString("PREFIX"))
+				.UsingEncoder(TypeSystem.Tuples.GetEncoder<string>());
+
+			// shortcuts
+			Assert.That(location[Slice.FromString("SUFFIX")].ToString(), Is.EqualTo("PREFIXSUFFIX"));
+			Assert.That(location.Keys["hello"].ToString(), Is.EqualTo("PREFIX<02>hello<00>"));
+			Assert.That(location.Keys[ValueTuple.Create("hello")].ToString(), Is.EqualTo("PREFIX<02>hello<00>"));
+
+			// Encode<T...>(...)
+			Assert.That(location.Keys.Encode("hello").ToString(), Is.EqualTo("PREFIX<02>hello<00>"));
+
+			// Pack(ITuple)
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello")).ToString(), Is.EqualTo("PREFIX<02>hello<00>"));
+
+			// Pack(ValueTuple)
+			Assert.That(location.Keys.Pack(ValueTuple.Create("hello")).ToString(), Is.EqualTo("PREFIX<02>hello<00>"));
+
+			// STuple<T...> Decode(...)
+			Assert.That(location.Keys.Decode(Slice.Unescape("PREFIX<02>hello<00>")), Is.EqualTo("hello"));
+
+			// Decode(..., out T)
+			location.Keys.Decode(Slice.Unescape("PREFIX<02>hello<00>"), out string x);
+			Assert.That(x, Is.EqualTo("hello"));
+		}
+
+		[Test]
+		public void Test_TypedKeySpace_T2()
+		{
+			var location = new KeySubspace(Slice.FromString("PREFIX"))
+				.UsingEncoder(TypeSystem.Tuples.GetEncoder<string, int>());
+
+			// shortcuts
+			Assert.That(location[Slice.FromString("SUFFIX")].ToString(), Is.EqualTo("PREFIXSUFFIX"));
+			Assert.That(location.Keys["hello", 123].ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{"));
+			Assert.That(location.Keys[("hello", 123)].ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{"));
+
+			// Encode<T...>(...)
+			Assert.That(location.Keys.Encode("hello", 123).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{"));
+
+			// Pack(ITuple)
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello", 123)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{"));
+
+			// Pack(ValueTuple)
+			Assert.That(location.Keys.Pack(("hello", 123)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{"));
+
+			// STuple<T...> Decode(...)
+			Assert.That(location.Keys.Decode(Slice.Unescape("PREFIX<02>hello<00><15>{")), Is.EqualTo(("hello", 123)));
+
+			// Decode(..., out T)
+			location.Keys.Decode(Slice.Unescape("PREFIX<02>hello<00><15>{"), out string x1, out int x2);
+			Assert.That(x1, Is.EqualTo("hello"));
+			Assert.That(x2, Is.EqualTo(123));
+		}
+
+		[Test]
+		public void Test_TypedKeySpace_T3()
+		{
+			var location = new KeySubspace(Slice.FromString("PREFIX"))
+				.UsingEncoder(TypeSystem.Tuples.GetEncoder<string, int, string>());
+
+			// shortcuts
+			Assert.That(location[Slice.FromString("SUFFIX")].ToString(), Is.EqualTo("PREFIXSUFFIX"));
+			Assert.That(location.Keys["hello", 123, "world"].ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00>"));
+			Assert.That(location.Keys[("hello", 123, "world")].ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00>"));
+
+			// Encode<T...>(...)
+			Assert.That(location.Keys.Encode("hello", 123, "world").ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00>"));
+
+			// Pack(ITuple)
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello", 123, "world")).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00>"));
+
+			// Pack(ValueTuple)
+			Assert.That(location.Keys.Pack(("hello", 123, "world")).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00>"));
+
+			// STuple<T...> Decode(...)
+			Assert.That(location.Keys.Decode(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00>")), Is.EqualTo(("hello", 123, "world")));
+
+			// Decode(..., out T)
+			location.Keys.Decode(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00>"), out string x1, out int x2, out string x3);
+			Assert.That(x1, Is.EqualTo("hello"));
+			Assert.That(x2, Is.EqualTo(123));
+			Assert.That(x3, Is.EqualTo("world"));
+		}
+
+		[Test]
+		public void Test_TypedKeySpace_T4()
+		{
+			var location = new KeySubspace(Slice.FromString("PREFIX"))
+				.UsingEncoder(TypeSystem.Tuples.GetEncoder<string, int, string, int>());
+
+			// shortcuts
+			Assert.That(location[Slice.FromString("SUFFIX")].ToString(), Is.EqualTo("PREFIXSUFFIX"));
+			Assert.That(location.Keys["hello", 123, "world", 456].ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"));
+			Assert.That(location.Keys[("hello", 123, "world", 456)].ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"));
+
+			// Encode<T...>(...)
+			Assert.That(location.Keys.Encode("hello", 123, "world", 456).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"));
+
+			// Pack(ITuple)
+			Assert.That(location.Keys.Pack((ITuple) STuple.Create("hello", 123, "world", 456)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"));
+
+			// Pack(ValueTuple)
+			Assert.That(location.Keys.Pack(("hello", 123, "world", 456)).ToString(), Is.EqualTo("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"));
+
+			// STuple<T...> Decode(...)
+			Assert.That(location.Keys.Decode(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>")), Is.EqualTo(("hello", 123, "world", 456)));
+
+			// Decode(..., out T)
+			location.Keys.Decode(Slice.Unescape("PREFIX<02>hello<00><15>{<02>world<00><16><01><C8>"), out string x1, out int x2, out string x3, out int x4);
+			Assert.That(x1, Is.EqualTo("hello"));
+			Assert.That(x2, Is.EqualTo(123));
+			Assert.That(x3, Is.EqualTo("world"));
+			Assert.That(x4, Is.EqualTo(456));
 		}
 
 	}

--- a/FoundationDB.Tests/TransactionalFacts.cs
+++ b/FoundationDB.Tests/TransactionalFacts.cs
@@ -162,7 +162,7 @@ namespace FoundationDB.Client.Tests
 				var sw = Stopwatch.StartNew();
 				Log("Inserting test data (this may take a few minutes)...");
 				var rnd = new Random();
-				await Fdb.Bulk.WriteAsync(db, Enumerable.Range(0, 100 * 1000).Select(i => new KeyValuePair<Slice, Slice>(location.Keys.Encode(i), Slice.Random(rnd, 4096))), this.Cancellation);
+				await Fdb.Bulk.WriteAsync(db, Enumerable.Range(0, 100 * 1000).Select(i => (location.Keys.Encode(i), Slice.Random(rnd, 4096))), this.Cancellation);
 				sw.Stop();
 				Log("> done in " + sw.Elapsed);
 

--- a/FoundationDB.Tests/Utils/TupleFacts.cs
+++ b/FoundationDB.Tests/Utils/TupleFacts.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-//#define ENABLE_VALUETUPLE
+#define ENABLE_VALUETUPLES
 
 // ReSharper disable AccessToModifiedClosure
 namespace Doxense.Collections.Tuples.Tests
@@ -121,7 +121,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(item1, Is.EqualTo("hello world"));
 				Assert.That(item2, Is.EqualTo(123));
 			}
-#if ENABLE_VALUETUPLE
+#if ENABLE_VALUETUPLES
 			{ // Deconstruct
 				(string item1, int item2) = t2;
 				Assert.That(item1, Is.EqualTo("hello world"));
@@ -174,7 +174,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(item2, Is.EqualTo(123));
 				Assert.That(item3, Is.False);
 			}
-#if ENABLE_VALUETUPLE
+#if ENABLE_VALUETUPLES
 			{ // Deconstruct
 				(string item1, int item2, bool item3) = t3;
 				Assert.That(item1, Is.EqualTo("hello world"));
@@ -235,7 +235,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(item3, Is.False);
 				Assert.That(item4, Is.EqualTo(1234L));
 			}
-#if ENABLE_VALUETUPLE
+#if ENABLE_VALUETUPLES
 			{ // Deconstruct
 				(string item1, int item2, bool item3, long item4) = t4;
 				Assert.That(item1, Is.EqualTo("hello world"));
@@ -287,7 +287,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(item4, Is.EqualTo(1234L));
 				Assert.That(item5, Is.EqualTo(-1234L));
 			}
-#if ENABLE_VALUETUPLE
+#if ENABLE_VALUETUPLES
 			{ // Deconstruct
 				(string item1, int item2, bool item3, long item4, long item5) = t5;
 				Assert.That(item1, Is.EqualTo("hello world"));
@@ -344,7 +344,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(item5, Is.EqualTo(-1234L));
 				Assert.That(item6, Is.EqualTo("six"));
 			}
-#if ENABLE_VALUETUPLE
+#if ENABLE_VALUETUPLES
 			{ // Deconstruct
 				(string item1, int item2, bool item3, long item4, long item5, string item6) = t6;
 				Assert.That(item1, Is.EqualTo("hello world"));
@@ -1936,7 +1936,7 @@ namespace Doxense.Collections.Tuples.Tests
 
 		#region System.ValueTuple integration...
 
-#if ENABLE_VALUETUPLE
+#if ENABLE_VALUETUPLES
 
 		[Test]
 		public void Test_Implicit_Cast_STuple_To_ValueTuple()
@@ -2096,7 +2096,7 @@ namespace Doxense.Collections.Tuples.Tests
 			}
 		}
 
-#if ENABLE_VALUETUPLE
+#if ENABLE_VALUETUPLES
 
 		[Test]
 		public void Test_Deconstruct_STuple_TupleSyntax()


### PR DESCRIPTION
Add a reference to ValueTuple, and start exposing them in the core API, cf Issue #70 

- [X] Interop with `ITuple` and `Stuple<T...>`
- [X] Supported by TuPack(...)
- [X] Supported by IKeySubspace implementations
