### PR TITLE
disable signing FoundationDB.Client.csproj on non-win

### DIFF
--- a/FoundationDB.Client/FoundationDB.Client.csproj
+++ b/FoundationDB.Client/FoundationDB.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>FoundationDB.Client</RootNamespace>
     <AssemblyName>FoundationDB.Client</AssemblyName>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly Condition="'$(OS)' == 'Windows_NT'">true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Common\foundationdb-net-client.snk</AssemblyOriginatorKeyFile>
     <Version>5.1.0-alpha1</Version>
     <Authors>Doxense</Authors>


### PR DESCRIPTION
problem: dotnet core doesn't support assembly sining outside of windows

solution was taken from:
https://github.com/ppekrol/ravendb/commit/20931dd79533986670c034100fd5201fbc6a189e

Once the condition is added `dotnet build FoundationDB.Client/FoundationDB.Client.csproj` passes