### PR TITLE
Drop support of dotnet 4.7.2 for libraries

### DIFF
--- a/FoundationDB.Client/FoundationDB.Client.csproj
+++ b/FoundationDB.Client/FoundationDB.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>FoundationDB.Client</RootNamespace>
     <AssemblyName>FoundationDB.Client</AssemblyName>
     <LangVersion>8.0</LangVersion>

--- a/FoundationDB.DependencyInjection/FoundationDB.DependencyInjection.csproj
+++ b/FoundationDB.DependencyInjection/FoundationDB.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>FoundationDB.DependencyInjection</RootNamespace>
     <AssemblyName>FoundationDB.DependencyInjection</AssemblyName>
     <LangVersion>7.2</LangVersion>

--- a/FoundationDB.Layers.Common/FoundationDB.Layers.Common.csproj
+++ b/FoundationDB.Layers.Common/FoundationDB.Layers.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>FoundationDB.Layers.Common</RootNamespace>
     <AssemblyName>FoundationDB.Layers.Common</AssemblyName>
     <LangVersion>7.2</LangVersion>

--- a/FoundationDB.Layers.Experimental/FoundationDB.Layers.Experimental.csproj
+++ b/FoundationDB.Layers.Experimental/FoundationDB.Layers.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>FoundationDB.Layers</RootNamespace>
     <AssemblyName>FoundationDB.Layers.Experimental</AssemblyName>
     <LangVersion>7.2</LangVersion>

--- a/FoundationDB.Linq.Providers/FoundationDB.Linq.Providers.csproj
+++ b/FoundationDB.Linq.Providers/FoundationDB.Linq.Providers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>FoundationDB.Linq.Providers</RootNamespace>
     <AssemblyName>FoundationDB.Linq.Providers</AssemblyName>
     <LangVersion>7.2</LangVersion>


### PR DESCRIPTION
Drop support for dot net 4.7.2 for libraries as dotnet-standard2.0 support .Net framework 4.6.1 .
It should allow OS X and linux users to build libraries components without mono.