### PR TITLE
C# 8.0 nullable

### DIFF
--- a/FoundationDB.Client/Core/IFdbDatabaseHandler.cs
+++ b/FoundationDB.Client/Core/IFdbDatabaseHandler.cs
@@ -36,7 +36,7 @@ namespace FoundationDB.Client.Core
 	public interface IFdbDatabaseHandler : IDisposable
 	{
 
-		string ClusterFile { get; }
+		string? ClusterFile { get; }
 
 		bool IsInvalid { get; }
 
@@ -44,7 +44,6 @@ namespace FoundationDB.Client.Core
 
 		void SetOption(FdbDatabaseOption option, ReadOnlySpan<byte> data);
 
-		[NotNull]
 		IFdbTransactionHandler CreateTransaction(FdbOperationContext context);
 
 	}

--- a/FoundationDB.Client/Core/IFdbTransactionHandler.cs
+++ b/FoundationDB.Client/Core/IFdbTransactionHandler.cs
@@ -28,10 +28,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace FoundationDB.Client.Core
 {
-	using JetBrains.Annotations;
 	using System;
 	using System.Threading;
 	using System.Threading.Tasks;
+	using JetBrains.Annotations;
 
 	/// <summary>Basic API for FoundationDB transactions</summary>
 	[PublicAPI]
@@ -81,7 +81,6 @@ namespace FoundationDB.Client.Core
 		/// <param name="snapshot">Set to true for snapshot reads</param>
 		/// <param name="ct">Token used to cancel the operation from the outside</param>
 		/// <returns>Task that will return an array of values, or an exception. Each item in the array will contain the value of the key at the same index in <paramref name="keys"/>, or <see cref="Slice.Nil"/> if that key does not exist.</returns>
-		[ItemNotNull]
 		Task<Slice[]> GetValuesAsync(ReadOnlySpan<Slice> keys, bool snapshot, CancellationToken ct);
 
 		/// <summary>Resolves a key selector against the keys in the database snapshot represented by the current transaction.</summary>
@@ -96,8 +95,7 @@ namespace FoundationDB.Client.Core
 		/// <param name="snapshot">Set to true for snapshot reads</param>
 		/// <param name="ct">Token used to cancel the operation from the outside</param>
 		/// <returns>Task that will return an array of keys matching the selectors, or an exception</returns>
-		[ItemNotNull]
-		Task<Slice[]> GetKeysAsync([NotNull] KeySelector[] selectors, bool snapshot, CancellationToken ct);
+		Task<Slice[]> GetKeysAsync(KeySelector[] selectors, bool snapshot, CancellationToken ct);
 
 		/// <summary>Reads all key-value pairs in the database snapshot represented by transaction (potentially limited by Limit, TargetBytes, or Mode) which have a key lexicographically greater than or equal to the key resolved by the begin key selector and lexicographically less than the key resolved by the end key selector.</summary>
 		/// <param name="beginInclusive">key selector defining the beginning of the range</param>
@@ -107,13 +105,12 @@ namespace FoundationDB.Client.Core
 		/// <param name="snapshot">Set to true for snapshot reads</param>
 		/// <param name="ct">Token used to cancel the operation from the outside</param>
 		/// <returns></returns>
-		Task<FdbRangeChunk> GetRangeAsync(KeySelector beginInclusive, KeySelector endExclusive, [NotNull] FdbRangeOptions options, int iteration, bool snapshot, CancellationToken ct);
+		Task<FdbRangeChunk> GetRangeAsync(KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions options, int iteration, bool snapshot, CancellationToken ct);
 
 		/// <summary>Returns a list of public network addresses as strings, one for each of the storage servers responsible for storing <paramref name="key"/> and its associated value</summary>
 		/// <param name="key">Name of the key whose location is to be queried.</param>
 		/// <param name="ct">Token used to cancel the operation from the outside</param>
 		/// <returns>Task that will return an array of strings, or an exception</returns>
-		[ItemNotNull]
 		Task<string[]> GetAddressesForKeyAsync(ReadOnlySpan<byte> key, CancellationToken ct);
 
 		/// <summary>Modify the database snapshot represented by transaction to change the given key to have the given value. If the given key was not previously present in the database it is inserted.
@@ -154,7 +151,7 @@ namespace FoundationDB.Client.Core
 		/// <param name="ct">CancellationToken used to abort the watch if the caller doesn't want to wait anymore. Note that you can manually cancel the watch by calling Cancel() on the returned FdbWatch instance</param>
 		/// <returns>FdbWatch that can be awaited and will complete when the key has changed in the database, or cancellation occurs. You can call Cancel() at any time if you are not interested in watching the key anymore. You MUST always call Dispose() if the watch completes or is cancelled, to ensure that resources are released properly.</returns>
 		/// <remarks>You can directly await an FdbWatch, or obtain a <c>Task&lt;Slice&gt;</c> by reading the <see cref="FdbWatch.Task"/> property.</remarks>
-		[Pure, NotNull]
+		[Pure]
 		FdbWatch Watch(Slice key, CancellationToken ct);
 
 		/// <summary>Attempts to commit the sets and clears previously applied to the database snapshot represented by this transaction to the actual database. 

--- a/FoundationDB.Client/DependencyInjection/FdbDatabaseProviderExtensions.cs
+++ b/FoundationDB.Client/DependencyInjection/FdbDatabaseProviderExtensions.cs
@@ -39,8 +39,8 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Convert this database instance into a <see cref="IFdbDatabaseScopeProvider">provider</see></summary>
-		[Pure, NotNull]
-		public static IFdbDatabaseScopeProvider AsDatabaseProvider([NotNull] this IFdbDatabase db)
+		[Pure]
+		public static IFdbDatabaseScopeProvider AsDatabaseProvider(this IFdbDatabase db)
 		{
 			return Fdb.CreateRootScope(db);
 		}
@@ -49,10 +49,10 @@ namespace FoundationDB.Client
 		/// <param name="db">Parent provider</param>
 		/// <param name="init">Handler that must run successfully once before allowing transactions on this scope</param>
 		/// <param name="lifetime">Optional cancellation token that can be used to externally abort the new scope</param>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IFdbDatabaseScopeProvider<TState> CreateRootScope<TState>(
-			[NotNull] this IFdbDatabase db,
-			[NotNull] Func<IFdbDatabase, CancellationToken, Task<(IFdbDatabase Db, TState state)>> init,
+			this IFdbDatabase db,
+			Func<IFdbDatabase, CancellationToken, Task<(IFdbDatabase Db, TState state)>> init,
 			CancellationToken lifetime = default
 		)
 		{
@@ -63,10 +63,10 @@ namespace FoundationDB.Client
 		/// <param name="provider">Parent provider</param>
 		/// <param name="init">Handler that must run successfully once before allowing transactions on this scope</param>
 		/// <param name="lifetime">Optional cancellation token that can be used to externally abort the new scope</param>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IFdbDatabaseScopeProvider CreateScope(
-			[NotNull] this IFdbDatabaseScopeProvider provider,
-			[NotNull] Func<IFdbDatabase, CancellationToken, Task> init,
+			this IFdbDatabaseScopeProvider provider,
+			Func<IFdbDatabase, CancellationToken, Task> init,
 			CancellationToken lifetime = default
 		)
 		{
@@ -77,10 +77,10 @@ namespace FoundationDB.Client
 		/// <param name="db">Parent database</param>
 		/// <param name="init">Handler that must run successfully once before allowing transactions on this scope</param>
 		/// <param name="lifetime">Optional cancellation token that can be used to externally abort the new scope</param>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IFdbDatabaseScopeProvider CreateRootScope(
-			[NotNull] this IFdbDatabase db,
-			[NotNull] Func<IFdbDatabase, CancellationToken, Task> init,
+			this IFdbDatabase db,
+			Func<IFdbDatabase, CancellationToken, Task> init,
 			CancellationToken lifetime = default
 		)
 		{
@@ -88,7 +88,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Wait for the scope to become ready.</summary>
-		public static ValueTask EnsureIsReady([NotNull] this IFdbDatabaseScopeProvider provider, CancellationToken ct)
+		public static ValueTask EnsureIsReady(this IFdbDatabaseScopeProvider provider, CancellationToken ct)
 		{
 			if (provider.IsAvailable)
 			{
@@ -111,8 +111,8 @@ namespace FoundationDB.Client
 		/// You must wait for the Task to complete successfully before updating the global state of the application.
 		/// </remarks>
 		public static async Task<TResult> ReadAsync<TResult>(
-			[NotNull] this IFdbDatabaseScopeProvider provider,
-			[NotNull, InstantHandle] Func<IFdbReadOnlyTransaction, Task<TResult>> handler,
+			this IFdbDatabaseScopeProvider provider,
+			[InstantHandle] Func<IFdbReadOnlyTransaction, Task<TResult>> handler,
 			CancellationToken ct)
 		{
 			var db = await provider.GetDatabase(ct).ConfigureAwait(false);
@@ -128,8 +128,8 @@ namespace FoundationDB.Client
 		/// You must wait for the Task to complete successfully before updating the global state of the application.
 		/// </remarks>
 		public static async Task<TResult> ReadAsync<TState, TResult>(
-			[NotNull] this IFdbDatabaseScopeProvider<TState> provider,
-			[NotNull, InstantHandle] Func<IFdbReadOnlyTransaction, TState, Task<TResult>> handler,
+			this IFdbDatabaseScopeProvider<TState> provider,
+			[InstantHandle] Func<IFdbReadOnlyTransaction, TState, Task<TResult>> handler,
 			CancellationToken ct)
 		{
 			(var db, var state) = await provider.GetDatabaseAndState(ct).ConfigureAwait(false);
@@ -147,8 +147,8 @@ namespace FoundationDB.Client
 		/// You must wait for the Task to complete successfully before updating the global state of the application.
 		/// </remarks>
 		public static async Task<TResult> ReadWriteAsync<TResult>(
-			[NotNull] this IFdbDatabaseScopeProvider provider,
-			[NotNull, InstantHandle] Func<IFdbTransaction, Task<TResult>> handler,
+			this IFdbDatabaseScopeProvider provider,
+			[InstantHandle] Func<IFdbTransaction, Task<TResult>> handler,
 			CancellationToken ct)
 		{
 			var db = await provider.GetDatabase(ct).ConfigureAwait(false);
@@ -166,8 +166,8 @@ namespace FoundationDB.Client
 		/// You must wait for the Task to complete successfully before updating the global state of the application.
 		/// </remarks>
 		public static async Task<TResult> ReadWriteAsync<TState, TResult>(
-			[NotNull] this IFdbDatabaseScopeProvider<TState> provider,
-			[NotNull, InstantHandle] Func<IFdbTransaction, TState, Task<TResult>> handler,
+			this IFdbDatabaseScopeProvider<TState> provider,
+			[InstantHandle] Func<IFdbTransaction, TState, Task<TResult>> handler,
 			CancellationToken ct)
 		{
 			(var db, var state) = await provider.GetDatabaseAndState(ct).ConfigureAwait(false);
@@ -185,8 +185,8 @@ namespace FoundationDB.Client
 		/// You must wait for the Task to complete successfully before updating the global state of the application.
 		/// </remarks>
 		public static async Task WriteAsync(
-			[NotNull] this IFdbDatabaseScopeProvider provider,
-			[NotNull, InstantHandle] Func<IFdbTransaction, Task> handler,
+			this IFdbDatabaseScopeProvider provider,
+			[InstantHandle] Func<IFdbTransaction, Task> handler,
 			CancellationToken ct)
 		{
 			var db = await provider.GetDatabase(ct).ConfigureAwait(false);
@@ -204,8 +204,8 @@ namespace FoundationDB.Client
 		/// You must wait for the Task to complete successfully before updating the global state of the application.
 		/// </remarks>
 		public static async Task WriteAsync<TState>(
-			[NotNull] this IFdbDatabaseScopeProvider<TState> provider,
-			[NotNull, InstantHandle] Func<IFdbTransaction, TState, Task> handler,
+			this IFdbDatabaseScopeProvider<TState> provider,
+			[InstantHandle] Func<IFdbTransaction, TState, Task> handler,
 			CancellationToken ct)
 		{
 			(var db, var state) = await provider.GetDatabaseAndState(ct).ConfigureAwait(false);
@@ -222,8 +222,8 @@ namespace FoundationDB.Client
 		/// You must wait for the Task to complete successfully before updating the global state of the application.
 		/// </remarks>
 		public static async Task WriteAsync(
-			[NotNull] this IFdbDatabaseScopeProvider provider,
-			[NotNull, InstantHandle] Action<IFdbTransaction> handler,
+			this IFdbDatabaseScopeProvider provider,
+			[InstantHandle] Action<IFdbTransaction> handler,
 			CancellationToken ct)
 		{
 			var db = await provider.GetDatabase(ct).ConfigureAwait(false);
@@ -240,8 +240,8 @@ namespace FoundationDB.Client
 		/// You must wait for the Task to complete successfully before updating the global state of the application.
 		/// </remarks>
 		public static async Task WriteAsync<TState>(
-			[NotNull] this IFdbDatabaseScopeProvider<TState> provider,
-			[NotNull, InstantHandle] Action<IFdbTransaction, TState> handler,
+			this IFdbDatabaseScopeProvider<TState> provider,
+			[InstantHandle] Action<IFdbTransaction, TState> handler,
 			CancellationToken ct)
 		{
 			(var db, var state) = await provider.GetDatabaseAndState(ct).ConfigureAwait(false);

--- a/FoundationDB.Client/DependencyInjection/IFdbDatabaseScopeProvider.cs
+++ b/FoundationDB.Client/DependencyInjection/IFdbDatabaseScopeProvider.cs
@@ -31,25 +31,21 @@ namespace FoundationDB.Client
 	using System;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using JetBrains.Annotations;
 
 	public interface IFdbDatabaseScopeProvider : IDisposable
 	{
 
 		/// <summary>Returns the parent scope (or null if this is the top-level scope)</summary>
-		[CanBeNull]
-		IFdbDatabaseScopeProvider Parent { get; }
+		IFdbDatabaseScopeProvider? Parent { get; }
 
 		/// <summary>Return an instance of the database, once it is ready</summary>
 		/// <remarks>During the startup of the application, the task returned will wait until the database becomes ready. After that, the task will immediately return the database singleton.</remarks>
-		[ItemNotNull]
 		ValueTask<IFdbDatabase> GetDatabase(CancellationToken ct);
 
 		/// <summary>Create a scope that will use the database provided by this instance, and which also needs to perform some initialization steps before being ready (ex: using the DirectoryLayer to open subspaces, ...)</summary>
 		/// <param name="start">Handler that will be called AFTER the database becomes ready, but BEFORE any consumer of this scope can run.</param>
 		/// <param name="lifetime">Optional cancellation token that can be used to externally abort the new scope</param>
-		[Pure, NotNull]
-		IFdbDatabaseScopeProvider<TState> CreateScope<TState>([NotNull] Func<IFdbDatabase, CancellationToken, Task<(IFdbDatabase Db, TState State)>> start, CancellationToken lifetime = default);
+		IFdbDatabaseScopeProvider<TState> CreateScope<TState>(Func<IFdbDatabase, CancellationToken, Task<(IFdbDatabase Db, TState State)>> start, CancellationToken lifetime = default);
 
 		/// <summary>If <c>true</c>, the database instance is ready. If <c>false</c>, the provider is either not started, or the connection is still pending.</summary>
 		bool IsAvailable { get; }

--- a/FoundationDB.Client/DependencyInjection/Implementation/FdbDatabaseSingletonProvider.cs
+++ b/FoundationDB.Client/DependencyInjection/Implementation/FdbDatabaseSingletonProvider.cs
@@ -29,19 +29,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace FoundationDB.DependencyInjection
 {
 	using System;
+	using System.Diagnostics.CodeAnalysis;
 	using System.Runtime.CompilerServices;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Default implementation of a scope provider that uses a pre-initialized database instance</summary>
 	/// <typeparam name="TState">Type of the state that will be passed to consumers of this type</typeparam>
 	internal sealed class FdbDatabaseSingletonProvider<TState> : IFdbDatabaseScopeProvider<TState>
 	{
 
-		public FdbDatabaseSingletonProvider([NotNull] IFdbDatabase db, [CanBeNull] TState state, [NotNull] CancellationTokenSource lifetime)
+		public FdbDatabaseSingletonProvider(IFdbDatabase db, [AllowNull] TState state, CancellationTokenSource lifetime)
 		{
 			Contract.Requires(db != null && lifetime != null);
 			this.Lifetime = lifetime;
@@ -51,21 +51,19 @@ namespace FoundationDB.DependencyInjection
 
 		private sealed class Scope
 		{
-			[NotNull]
 			public readonly IFdbDatabase Db;
 
-			[CanBeNull]
+			[AllowNull]
 			public readonly TState State;
 
-			public Scope([NotNull] IFdbDatabase db, [CanBeNull] TState state)
+			public Scope(IFdbDatabase db, [AllowNull] TState state)
 			{
 				this.Db = db;
 				this.State = state;
 			}
 		}
 
-		[CanBeNull]
-		private Scope InternalState;
+		private Scope? InternalState;
 
 		private CancellationTokenSource Lifetime { get; }
 
@@ -79,7 +77,7 @@ namespace FoundationDB.DependencyInjection
 			}
 		}
 
-		public IFdbDatabaseScopeProvider Parent => null;
+		public IFdbDatabaseScopeProvider? Parent => null;
 
 		public bool IsAvailable => Volatile.Read(ref m_disposed) == 0;
 

--- a/FoundationDB.Client/DependencyInjection/Implementation/FdbDatabaseTombstoneProvider.cs
+++ b/FoundationDB.Client/DependencyInjection/Implementation/FdbDatabaseTombstoneProvider.cs
@@ -29,16 +29,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace FoundationDB.DependencyInjection
 {
 	using System;
+	using System.Diagnostics.CodeAnalysis;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	internal sealed class FdbDatabaseTombstoneProvider<TState> : IFdbDatabaseScopeProvider<TState>
 	{
 
-		public FdbDatabaseTombstoneProvider([CanBeNull] IFdbDatabaseScopeProvider parent, [NotNull] Exception error, CancellationToken lifetime)
+		public FdbDatabaseTombstoneProvider(IFdbDatabaseScopeProvider? parent, Exception error, CancellationToken lifetime)
 		{
 			Contract.Requires(error != null);
 			this.Parent = parent;
@@ -46,11 +46,12 @@ namespace FoundationDB.DependencyInjection
 			this.Lifetime = parent != null ? CancellationTokenSource.CreateLinkedTokenSource(parent.Cancellation, lifetime) : CancellationTokenSource.CreateLinkedTokenSource(lifetime);
 		}
 
-		public IFdbDatabaseScopeProvider Parent { get; }
+		public IFdbDatabaseScopeProvider? Parent { get; }
 
 		public Exception Error { get; private set; }
 
-		public TState GetState() => default;
+		[return:MaybeNull]
+		public TState GetState() => default!;
 
 		private CancellationTokenSource Lifetime { get; }
 
@@ -70,7 +71,7 @@ namespace FoundationDB.DependencyInjection
 				finally
 				{
 					this.Lifetime.Dispose();
-					this.Error = null;
+					this.Error = new ObjectDisposedException(this.GetType().Name);
 				}
 			}
 		}

--- a/FoundationDB.Client/Fdb.Bulk.cs
+++ b/FoundationDB.Client/Fdb.Bulk.cs
@@ -71,7 +71,7 @@ namespace FoundationDB.Client
 
 				/// <summary>Used to report progress during the operation</summary>
 				/// <remarks>Since progress notification is async, this instance could be called even after the bulk operation has completed!</remarks>
-				public IProgress<long> Progress { get; set; }
+				public IProgress<long>? Progress { get; set; }
 			}
 
 			const int DEFAULT_WRITE_BATCH_COUNT = 2 * 1024;
@@ -90,7 +90,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Total number of values inserted in the database</returns>
 			/// <remarks>In case of a non-retry-able error, some of the keys may remain in the database. Other transactions running at the same time may observe only a fraction of the keys until the operation completes.</remarks>
-			public static Task<long> WriteAsync([NotNull] IFdbDatabase db, [NotNull] IEnumerable<KeyValuePair<Slice, Slice>> data, CancellationToken ct)
+			public static Task<long> WriteAsync(IFdbDatabase db, IEnumerable<KeyValuePair<Slice, Slice>> data, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(data, nameof(data));
@@ -112,7 +112,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Total number of values inserted in the database</returns>
 			/// <remarks>In case of a non retry-able error, some of the keys may remain in the database. Other transactions running at the same time may observe only a fraction of the keys until the operation completes.</remarks>
-			public static Task<long> WriteAsync([NotNull] IFdbDatabase db, [NotNull] IEnumerable<KeyValuePair<Slice, Slice>> data, WriteOptions options, CancellationToken ct)
+			public static Task<long> WriteAsync(IFdbDatabase db, IEnumerable<KeyValuePair<Slice, Slice>> data, WriteOptions options, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(data, nameof(data));
@@ -133,7 +133,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Total number of values inserted in the database</returns>
 			/// <remarks>In case of a non retry-able error, some of the keys may remain in the database. Other transactions running at the same time may observe only a fraction of the keys until the operation completes.</remarks>
-			public static Task<long> WriteAsync([NotNull] IFdbDatabase db, [NotNull] IEnumerable<(Slice Key, Slice Value)> data, CancellationToken ct)
+			public static Task<long> WriteAsync(IFdbDatabase db, IEnumerable<(Slice Key, Slice Value)> data, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(data, nameof(data));
@@ -155,7 +155,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Total number of values inserted in the database</returns>
 			/// <remarks>In case of a non retry-able error, some of the keys may remain in the database. Other transactions running at the same time may observe only a fraction of the keys until the operation completes.</remarks>
-			public static Task<long> WriteAsync([NotNull] IFdbDatabase db, [NotNull] IEnumerable<(Slice Key, Slice Value)> data, WriteOptions options, CancellationToken ct)
+			public static Task<long> WriteAsync(IFdbDatabase db, IEnumerable<(Slice Key, Slice Value)> data, WriteOptions options, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(data, nameof(data));
@@ -170,7 +170,7 @@ namespace FoundationDB.Client
 				);
 			}
 
-			internal static async Task<long> RunWriteOperationAsync([NotNull] IFdbDatabase db, [NotNull] IEnumerable<(Slice Key, Slice Value)> data, WriteOptions options, CancellationToken ct)
+			internal static async Task<long> RunWriteOperationAsync(IFdbDatabase db, IEnumerable<(Slice Key, Slice Value)> data, WriteOptions options, CancellationToken ct)
 			{
 				Contract.Requires(db != null && data != null && options != null);
 
@@ -245,13 +245,13 @@ namespace FoundationDB.Client
 
 			// Bulk inserting consists of inserting a lot of documents that must be serialized to slices, into the database, as fast as possible.
 			// => we expect the serialization of the data to be somewhat fast (ie: JSON serialization, Tuple encoding, ....)
-			// => the latency will come mostly from comitting the transaction to the database (i.e: network delay, disk delay)
+			// => the latency will come mostly from committing the transaction to the database (i.e: network delay, disk delay)
 			// => with multiple concurrent transaction, the commit latency could be used to serialize the next batch of data
 
 			#region Single...
 
 			// Items in the source are processed one by one, which may limit the throughput per transaction (by adding the latency of all the items)
-			// This is intended for Layers who can only process items one by one, and when there is no easy way to parralelize the work.
+			// This is intended for Layers who can only process items one by one, and when there is no easy way to parallelize the work.
 
 			/// <summary>Inserts a potentially large sequence of items into the database, by using as many transactions as necessary, and automatically retrying if needed.</summary>
 			/// <typeparam name="T">Type of the items in the <paramref name="source"/> sequence</typeparam>
@@ -261,7 +261,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of items that have been inserted</returns>
 			/// <remarks>In case of a non-retryable error, some of the items may remain in the database. Other transactions running at the same time may observe only a fraction of the items until the operation completes.</remarks>
-			public static Task<long> InsertAsync<T>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<T> source, [NotNull, InstantHandle] Action<T, IFdbTransaction> handler, CancellationToken ct)
+			public static Task<long> InsertAsync<T>(IFdbDatabase db, IEnumerable<T> source, [InstantHandle] Action<T, IFdbTransaction> handler, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(source, nameof(source));
@@ -287,7 +287,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of items that have been inserted</returns>
 			/// <remarks>In case of a non-retryable error, some of the items may remain in the database. Other transactions running at the same time may observe only a fraction of the items until the operation completes.</remarks>
-			public static Task<long> InsertAsync<T>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<T> source, [NotNull, InstantHandle] Action<T, IFdbTransaction> handler, WriteOptions options, CancellationToken ct)
+			public static Task<long> InsertAsync<T>(IFdbDatabase db, IEnumerable<T> source, [InstantHandle] Action<T, IFdbTransaction> handler, WriteOptions options, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(source, nameof(source));
@@ -312,7 +312,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of items that have been inserted</returns>
 			/// <remarks>In case of a non-retryable error, some of the items may remain in the database. Other transactions running at the same time may observe only a fraction of the items until the operation completes.</remarks>
-			public static Task<long> InsertAsync<T>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<T> source, [NotNull, InstantHandle] Func<T, IFdbTransaction, Task> handler, CancellationToken ct)
+			public static Task<long> InsertAsync<T>(IFdbDatabase db, IEnumerable<T> source, [InstantHandle] Func<T, IFdbTransaction, Task> handler, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(source, nameof(source));
@@ -338,7 +338,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of items that have been inserted</returns>
 			/// <remarks>In case of a non-retryable error, some of the items may remain in the database. Other transactions running at the same time may observe only a fraction of the items until the operation completes.</remarks>
-			public static Task<long> InsertAsync<T>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<T> source, [NotNull, InstantHandle] Func<T, IFdbTransaction, Task> handler, WriteOptions options, CancellationToken ct)
+			public static Task<long> InsertAsync<T>(IFdbDatabase db, IEnumerable<T> source, [InstantHandle] Func<T, IFdbTransaction, Task> handler, WriteOptions options, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(source, nameof(source));
@@ -357,10 +357,10 @@ namespace FoundationDB.Client
 
 			/// <summary>Runs a long duration bulk insertion, where items are processed one by one</summary>
 			internal static async Task<long> RunInsertOperationAsync<TSource>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				[NotNull] Delegate body,
-				[NotNull] WriteOptions options,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				Delegate body,
+				WriteOptions options,
 				CancellationToken ct
 			)
 			{
@@ -397,7 +397,7 @@ namespace FoundationDB.Client
 						Trace.WriteLine("> commit called with " + batch.Count.ToString("N0") + " items and " + trans.Size.ToString("N0") + " bytes");
 #endif
 
-						FdbException error = null;
+						FdbException? error = null;
 
 						// if transaction Size is bigger than Fdb.MaxTransactionSize (10MB) then commit will fail, but we will retry with a smaller batch anyway
 
@@ -458,7 +458,7 @@ namespace FoundationDB.Client
 						}
 
 						// commit the batch if ..
-						if (trans.Size >= sizeThreshold      // transaction is startting to get big...
+						if (trans.Size >= sizeThreshold      // transaction is starting to get big...
 						 || batch.Count >= batchCount        // too many items would need to be retried...
 						 || timer.Elapsed.TotalSeconds >= 4  // it's getting late...
 						)
@@ -481,7 +481,7 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Retry commiting a segment of a chunk, splitting it in sub-segments as needed</summary>
-			private static async Task RetryChunk<TSource>([NotNull] IFdbTransaction trans, [NotNull] List<TSource> chunk, int offset, int count, Func<TSource, IFdbTransaction, Task> bodyAsync, Action<TSource, IFdbTransaction> bodyBlocking)
+			private static async Task RetryChunk<TSource>(IFdbTransaction trans, List<TSource> chunk, int offset, int count, Func<TSource, IFdbTransaction, Task> bodyAsync, Action<TSource, IFdbTransaction> bodyBlocking)
 			{
 				Contract.Requires(trans != null && chunk != null && offset >= 0 && count >= 0 && (bodyAsync != null || bodyBlocking != null));
 
@@ -577,7 +577,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of items that have been inserted</returns>
 			/// <remarks>In case of a non-retryable error, some of the items may remain in the database. Other transactions running at the same time may observe only a fraction of the items until the operation completes.</remarks>
-			public static Task<long> InsertBatchedAsync<T>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<T> source, [NotNull, InstantHandle] Action<T[], IFdbTransaction> handler, CancellationToken ct)
+			public static Task<long> InsertBatchedAsync<T>(IFdbDatabase db, IEnumerable<T> source, [InstantHandle] Action<T[], IFdbTransaction> handler, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(source, nameof(source));
@@ -603,7 +603,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of items that have been inserted</returns>
 			/// <remarks>In case of a non retry-able error, some of the items may remain in the database. Other transactions running at the same time may observe only a fraction of the items until the operation completes.</remarks>
-			public static Task<long> InsertBatchedAsync<T>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<T> source, [NotNull, InstantHandle] Action<T[], IFdbTransaction> handler, WriteOptions options, CancellationToken ct)
+			public static Task<long> InsertBatchedAsync<T>(IFdbDatabase db, IEnumerable<T> source, [InstantHandle] Action<T[], IFdbTransaction> handler, WriteOptions options, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(source, nameof(source));
@@ -628,7 +628,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of items that have been inserted</returns>
 			/// <remarks>In case of a non retry-able error, some of the items may remain in the database. Other transactions running at the same time may observe only a fraction of the items until the operation completes.</remarks>
-			public static Task<long> InsertBatchedAsync<T>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<T> source, [NotNull, InstantHandle] Func<T[], IFdbTransaction, Task> handler, CancellationToken ct)
+			public static Task<long> InsertBatchedAsync<T>(IFdbDatabase db, IEnumerable<T> source, [InstantHandle] Func<T[], IFdbTransaction, Task> handler, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(source, nameof(source));
@@ -654,7 +654,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of items that have been inserted</returns>
 			/// <remarks>In case of a non retry-able error, some of the items may remain in the database. Other transactions running at the same time may observe only a fraction of the items until the operation completes.</remarks>
-			public static Task<long> InsertBatchedAsync<T>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<T> source, [NotNull, InstantHandle] Func<T[], IFdbTransaction, Task> handler, WriteOptions options, CancellationToken ct)
+			public static Task<long> InsertBatchedAsync<T>(IFdbDatabase db, IEnumerable<T> source, [InstantHandle] Func<T[], IFdbTransaction, Task> handler, WriteOptions options, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(source, nameof(source));
@@ -673,10 +673,10 @@ namespace FoundationDB.Client
 
 			/// <summary>Runs a long duration bulk insertion, where items are processed in batch</summary>
 			internal static async Task<long> RunBatchedInsertOperationAsync<TSource>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				[NotNull] Delegate body,
-				[NotNull] WriteOptions options,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				Delegate body,
+				WriteOptions options,
 				CancellationToken ct
 			)
 			{
@@ -713,7 +713,7 @@ namespace FoundationDB.Client
 						Trace.WriteLine("> commit called with " + batch.Count.ToString("N0") + " items and " + trans.Size.ToString("N0") + " bytes");
 #endif
 
-						FdbException error = null;
+						FdbException? error = null;
 
 						// if transaction Size is bigger than Fdb.MaxTransactionSize (10MB) then commit will fail, but we will retry with a smaller batch anyway
 
@@ -825,7 +825,7 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Retry commiting a segment of a chunk, splitting it in sub-segments as needed</summary>
-			private static async Task RetryChunk<TSource>([NotNull] IFdbTransaction trans, [NotNull] List<TSource> chunk, int offset, int count, Func<TSource[], IFdbTransaction, Task> bodyAsync, Action<TSource[], IFdbTransaction> bodyBlocking)
+			private static async Task RetryChunk<TSource>(IFdbTransaction trans, List<TSource> chunk, int offset, int count, Func<TSource[], IFdbTransaction, Task> bodyAsync, Action<TSource[], IFdbTransaction> bodyBlocking)
 			{
 				Contract.Requires(trans != null && chunk != null && offset >= 0 && count >= 0 && (bodyAsync != null || bodyBlocking != null));
 
@@ -921,7 +921,6 @@ namespace FoundationDB.Client
 			public sealed class BatchOperationContext
 			{
 				/// <summary>Transaction corresponding to the current generation</summary>
-				[NotNull] 
 				public IFdbReadOnlyTransaction Transaction { get; internal set; }
 
 				/// <summary>Offset of the current batch from the start of the source sequence</summary>
@@ -978,11 +977,11 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Task that completes when all the elements of <paramref name="source"/> have been processed, a non-retryable error occurs, or <paramref name="ct"/> is triggered</returns>
 			public static Task ForEachAsync<TSource, TLocal>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				[NotNull, InstantHandle] Func<TLocal> localInit,
-				[NotNull, InstantHandle] Func<TSource[], BatchOperationContext, TLocal, Task<TLocal>> body,
-				[NotNull, InstantHandle] Action<TLocal> localFinally,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				[InstantHandle] Func<TLocal> localInit,
+				[InstantHandle] Func<TSource[], BatchOperationContext, TLocal, Task<TLocal>> body,
+				[InstantHandle] Action<TLocal> localFinally,
 				CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
@@ -1005,11 +1004,11 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Task that completes when all the elements of <paramref name="source"/> have been processed, a non retry-able error occurs, or <paramref name="ct"/> is triggered</returns>
 			public static Task ForEachAsync<TSource, TLocal>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				[NotNull, InstantHandle] Func<TLocal> localInit,
-				[NotNull, InstantHandle] Func<TSource[], BatchOperationContext, TLocal, TLocal> body,
-				[NotNull, InstantHandle] Action<TLocal> localFinally,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				[InstantHandle] Func<TLocal> localInit,
+				[InstantHandle] Func<TSource[], BatchOperationContext, TLocal, TLocal> body,
+				[InstantHandle] Action<TLocal> localFinally,
 				CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
@@ -1034,9 +1033,9 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Task that completes when all the elements of <paramref name="source"/> have been processed, a non retry-able error occurs, or <paramref name="ct"/> is triggered</returns>
 			public static Task ForEachAsync<TSource>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				[NotNull, InstantHandle] Func<TSource[], BatchOperationContext, Task> body,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				[InstantHandle] Func<TSource[], BatchOperationContext, Task> body,
 				CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
@@ -1055,9 +1054,9 @@ namespace FoundationDB.Client
 			/// <returns>Task that completes when all the elements of <paramref name="source"/> have been processed, a non retry-able error occurs, or <paramref name="ct"/> is triggered</returns>
 			[Obsolete("EXPERIMENTAL: do not use yet!")]
 			public static Task ForEachAsync<TSource>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				[NotNull, InstantHandle] Action<TSource[], BatchOperationContext> body,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				[InstantHandle] Action<TSource[], BatchOperationContext> body,
 				CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
@@ -1086,10 +1085,10 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Task that completes when all the elements of <paramref name="source"/> have been processed, a non retry-able error occurs, or <paramref name="ct"/> is triggered</returns>
 			public static Task<TAggregate> AggregateAsync<TSource, TAggregate>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				[NotNull, InstantHandle] Func<TAggregate> localInit,
-				[NotNull, InstantHandle] Func<TSource[], BatchOperationContext, TAggregate, Task<TAggregate>> body,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				[InstantHandle] Func<TAggregate> localInit,
+				[InstantHandle] Func<TSource[], BatchOperationContext, TAggregate, Task<TAggregate>> body,
 				CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
@@ -1113,11 +1112,11 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Task that completes when all the elements of <paramref name="source"/> have been processed, a non-retryable error occurs, or <paramref name="ct"/> is triggered</returns>
 			public static Task<TResult> AggregateAsync<TSource, TAggregate, TResult>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				[NotNull, InstantHandle] Func<TAggregate> init,
-				[NotNull, InstantHandle] Func<TSource[], BatchOperationContext, TAggregate, Task<TAggregate>> body,
-				[NotNull, InstantHandle] Func<TAggregate, TResult> transform,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				[InstantHandle] Func<TAggregate> init,
+				[InstantHandle] Func<TSource[], BatchOperationContext, TAggregate, Task<TAggregate>> body,
+				[InstantHandle] Func<TAggregate, TResult> transform,
 				CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
@@ -1133,11 +1132,11 @@ namespace FoundationDB.Client
 
 			/// <summary>Runs a long duration bulk read</summary>
 			internal static async Task<TResult> RunBatchedReadOperationAsync<TSource, TLocal, TResult>(
-				[NotNull] IFdbDatabase db,
-				[NotNull] IEnumerable<TSource> source,
-				Func<TLocal> localInit,
+				IFdbDatabase db,
+				IEnumerable<TSource> source,
+				Func<TLocal>? localInit,
 				Delegate body,
-				Delegate localFinally,
+				Delegate? localFinally,
 				int initialBatchSize,
 				CancellationToken ct
 			)
@@ -1170,9 +1169,9 @@ namespace FoundationDB.Client
 				var batch = new List<TSource>(batchSize);
 
 				bool localInitialized = false;
-				TLocal localValue = default;
-				TSource[] items = null;
-				TResult result = default;
+				TLocal localValue = default!;
+				TSource[]? items = null;
+				TResult result = default!;
 
 				using (var iterator = source.GetEnumerator())
 				{
@@ -1216,7 +1215,7 @@ namespace FoundationDB.Client
 									}
 									batch.CopyTo(offsetInCurrentBatch, items, 0, items.Length);
 
-									FdbException error = null;
+									FdbException? error = null;
 									try
 									{
 										var sw = Stopwatch.StartNew();
@@ -1355,7 +1354,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of keys exported</returns>
 			/// <remarks>This method cannot guarantee that all data will be read from the same snapshot of the database, which means that writes committed while the export is running may be seen partially. Only the items inside a single batch are guaranteed to be from the same snapshot of the database.</remarks>
-			public static Task<long> ExportAsync([NotNull] IFdbDatabase db, Slice beginInclusive, Slice endExclusive, [NotNull, InstantHandle] Func<KeyValuePair<Slice, Slice>[], long, CancellationToken, Task> handler, CancellationToken ct)
+			public static Task<long> ExportAsync(IFdbDatabase db, Slice beginInclusive, Slice endExclusive, [InstantHandle] Func<KeyValuePair<Slice, Slice>[], long, CancellationToken, Task> handler, CancellationToken ct)
 			{
 				return ExportAsync(db, KeySelector.FirstGreaterOrEqual(beginInclusive), KeySelector.FirstGreaterOrEqual(endExclusive), handler, ct);
 			}
@@ -1367,7 +1366,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of keys exported</returns>
 			/// <remarks>This method cannot guarantee that all data will be read from the same snapshot of the database, which means that writes committed while the export is running may be seen partially. Only the items inside a single batch are guaranteed to be from the same snapshot of the database.</remarks>
-			public static Task<long> ExportAsync([NotNull] IFdbDatabase db, KeyRange range, [NotNull, InstantHandle] Func<KeyValuePair<Slice, Slice>[], long, CancellationToken, Task> handler, CancellationToken ct)
+			public static Task<long> ExportAsync(IFdbDatabase db, KeyRange range, [InstantHandle] Func<KeyValuePair<Slice, Slice>[], long, CancellationToken, Task> handler, CancellationToken ct)
 			{
 				return ExportAsync(db, KeySelector.FirstGreaterOrEqual(range.Begin), KeySelector.FirstGreaterOrEqual(range.End), handler, ct);
 			}
@@ -1380,7 +1379,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of keys exported</returns>
 			/// <remarks>This method cannot guarantee that all data will be read from the same snapshot of the database, which means that writes committed while the export is running may be seen partially. Only the items inside a single batch are guaranteed to be from the same snapshot of the database.</remarks>
-			public static async Task<long> ExportAsync([NotNull] IFdbDatabase db, KeySelector begin, KeySelector end, [NotNull, InstantHandle] Func<KeyValuePair<Slice, Slice>[], long, CancellationToken, Task> handler, CancellationToken ct)
+			public static async Task<long> ExportAsync(IFdbDatabase db, KeySelector begin, KeySelector end, [InstantHandle] Func<KeyValuePair<Slice, Slice>[], long, CancellationToken, Task> handler, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNull(handler, nameof(handler));
@@ -1474,7 +1473,7 @@ namespace FoundationDB.Client
 			/// <param name="options">Range read options</param>
 			/// <param name="onReset">Action (optional) that can reconfigure a transaction whenever it gets reset inside the retry loop.</param>
 			/// <returns>Task that will return the next batch</returns>
-			private static async Task<FdbRangeChunk> FetchNextBatchAsync(IFdbReadOnlyTransaction tr, KeySelector begin, KeySelector end, [NotNull] FdbRangeOptions options, Func<IFdbReadOnlyTransaction, Task> onReset = null)
+			private static async Task<FdbRangeChunk> FetchNextBatchAsync(IFdbReadOnlyTransaction tr, KeySelector begin, KeySelector end, FdbRangeOptions options, Func<IFdbReadOnlyTransaction, Task>? onReset = null)
 			{
 				Contract.Requires(tr != null && options != null);
 
@@ -1508,7 +1507,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of keys exported</returns>
 			/// <remarks>This method cannot guarantee that all data will be read from the same snapshot of the database, which means that writes committed while the export is running may be seen partially. Only the items inside a single batch are guaranteed to be from the same snapshot of the database.</remarks>
-			public static async Task<long> ExportAsync<TSubspace>([NotNull] IFdbDatabase db, ISubspaceLocation<TSubspace> path, [NotNull, InstantHandle] Func<KeyValuePair<Slice, Slice>[], TSubspace, long, CancellationToken, Task> handler, CancellationToken ct)
+			public static async Task<long> ExportAsync<TSubspace>(IFdbDatabase db, ISubspaceLocation<TSubspace> path, [InstantHandle] Func<KeyValuePair<Slice, Slice>[], TSubspace, long, CancellationToken, Task> handler, CancellationToken ct)
 				where TSubspace : IKeySubspace
 			{
 				Contract.NotNull(db, nameof(db));
@@ -1535,7 +1534,7 @@ namespace FoundationDB.Client
 				//	W:           [*B1]-----[*B2]-----[*B3]-----[ *B4 + flush to disk ...... |*B5]-----[*B6]------....
 
 				Slice previous = default;
-				TSubspace location = default;
+				TSubspace location = default!;
 				KeySelector begin = default;
 				KeySelector end = default;
 

--- a/FoundationDB.Client/Fdb.Options.cs
+++ b/FoundationDB.Client/Fdb.Options.cs
@@ -46,7 +46,7 @@ namespace FoundationDB.Client
 
 			/// <summary>Custom path from where to load the native C API library. If null, let the CLR find the dll. If String.Empty let Win32's LoadLibrary find the correct dll, else use the specified path to load the library</summary>
 			//REVIEW: change this into a get-only, and force people to call SetNativeLibPath(..)?
-			public static string NativeLibPath = String.Empty;
+			public static string? NativeLibPath = string.Empty;
 
 			/// <summary>Disable pre-loading of the native C API library. The CLR will handle the binding of the library.</summary>
 			/// <remarks>This *must* be called before the start of the network thread, otherwise it won't have any effects.</remarks>
@@ -59,7 +59,7 @@ namespace FoundationDB.Client
 			/// <remarks>This *must* be called before the start of the network thread, otherwise it won't have any effects.</remarks>
 			public static void EnableNativeLibraryPreloading()
 			{
-				Fdb.Options.NativeLibPath = String.Empty;
+				Fdb.Options.NativeLibPath = string.Empty;
 			}
 
 			/// <summary>Pre-load the native C API library from a specific path (relative of absolute) where the fdb_c.dll library is located</summary>
@@ -71,7 +71,7 @@ namespace FoundationDB.Client
 			/// This *must* be called before the start of the network thread, otherwise it won't have any effects.
 			/// You can specify the path to a library with a custom file name by making sure that <paramref name="path"/> ends with ".dll". If not, then "fdb_c.dll" will be appended to the path.
 			/// </remarks>
-			public static void SetNativeLibPath([NotNull] string path)
+			public static void SetNativeLibPath(string path)
 			{
 				Contract.NotNull(path, nameof(path));
 
@@ -84,7 +84,7 @@ namespace FoundationDB.Client
 			#region Trace Path...
 
 			/// <summary>Default path to the network thread tracing file</summary>
-			public static string TracePath;
+			public static string? TracePath;
 
 			/// <summary>Sets the custom path where the logs will be stored</summary>
 			/// <remarks>This *must* be called before the start of the network thread, otherwise it won't have any effects.</remarks>
@@ -99,19 +99,19 @@ namespace FoundationDB.Client
 
 			/// <summary>File path or linker-resolved name of the custom TLS plugin to load.</summary>
 			[Obsolete("This option is deprecated since v6.0")]
-			public static string TLSPlugin { get; private set; }
+			public static string? TLSPlugin { get; private set; }
 
 			/// <summary>Content of the TLS root and client certificates used for TLS connections (none by default)</summary>
 			public static Slice TLSCertificateBytes { get; private set; }
 
 			/// <summary>Path to the TLS root and client certificates used for TLS connections (none by default)</summary>
-			public static string TLSCertificatePath { get; private set; }
+			public static string? TLSCertificatePath { get; private set; }
 
 			/// <summary>Path to the Private Key used for TLS connections (none by default)</summary>
 			public static Slice TLSPrivateKeyBytes { get; private set; }
 
 			/// <summary>Path to the Private Key used for TLS connections (none by default)</summary>
-			public static string TLSPrivateKeyPath { get; private set; }
+			public static string? TLSPrivateKeyPath { get; private set; }
 
 			/// <summary>Pattern used to verify certificates of TLS peers (none by default)</summary>
 			public static Slice TLSVerificationPattern { get; private set; }
@@ -167,7 +167,7 @@ namespace FoundationDB.Client
 			/// <param name="privateKeyBytes">Content of the private key</param>
 			/// <param name="verificationPattern">Verification with which to verify certificates of TLS peers</param>
 			/// <param name="plugin">Optional file path or linker-resolved name of the custom TLS plugin to load</param>
-			public static void UseTLS(Slice certificateBytes, Slice privateKeyBytes, Slice verificationPattern = default, string plugin = null)
+			public static void UseTLS(Slice certificateBytes, Slice privateKeyBytes, Slice verificationPattern = default, string? plugin = null)
 			{
 				Fdb.Options.TLSPlugin = plugin;
 				Fdb.Options.TLSCertificateBytes = certificateBytes;
@@ -182,7 +182,7 @@ namespace FoundationDB.Client
 			/// <param name="privateKeyPath">Path to the private key</param>
 			/// <param name="verificationPattern">Verification with which to verify certificates of TLS peers</param>
 			/// <param name="plugin">Optional file path or linker-resolved name of the custom TLS plugin to load</param>
-			public static void UseTLS(string certificatePath, string privateKeyPath, Slice verificationPattern = default, string plugin = null)
+			public static void UseTLS(string certificatePath, string privateKeyPath, Slice verificationPattern = default, string? plugin = null)
 			{
 				Fdb.Options.TLSPlugin = plugin;
 				Fdb.Options.TLSCertificatePath = certificatePath;

--- a/FoundationDB.Client/Fdb.System.cs
+++ b/FoundationDB.Client/Fdb.System.cs
@@ -96,8 +96,7 @@ namespace FoundationDB.Client
 
 			private static readonly Slice StatusJsonKey = Slice.FromByteString("\xFF\xFF/status/json");
 
-			[ItemCanBeNull]
-			public static async Task<FdbSystemStatus> GetStatusAsync([NotNull] IFdbReadOnlyTransaction trans)
+			public static async Task<FdbSystemStatus?> GetStatusAsync(IFdbReadOnlyTransaction trans)
 			{
 				Contract.NotNull(trans, nameof(trans));
 
@@ -105,7 +104,7 @@ namespace FoundationDB.Client
 
 				if (data.IsNullOrEmpty) return null;
 
-				string jsonText = data.ToUnicode();
+				string jsonText = data.ToUnicode()!;
 
 				var doc = TinyJsonParser.ParseObject(jsonText);
 				if (doc == null) return null;
@@ -119,8 +118,7 @@ namespace FoundationDB.Client
 				return new FdbSystemStatus(doc, rv, jsonText);
 			}
 
-			[ItemCanBeNull]
-			public static Task<FdbSystemStatus> GetStatusAsync([NotNull] IFdbDatabase db, CancellationToken ct)
+			public static Task<FdbSystemStatus?> GetStatusAsync(IFdbDatabase db, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 
@@ -141,8 +139,7 @@ namespace FoundationDB.Client
 			/// <param name="db">Database to use for the operation</param>
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <remarks>Since the list of coordinators may change at anytime, the results may already be obsolete once this method completes!</remarks>
-			[ItemNotNull]
-			public static async Task<FdbClusterFile> GetCoordinatorsAsync([NotNull] IFdbDatabase db, CancellationToken ct)
+			public static async Task<FdbClusterFile> GetCoordinatorsAsync(IFdbDatabase db, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 
@@ -157,7 +154,7 @@ namespace FoundationDB.Client
 
 				if (coordinators.IsNull) throw new InvalidOperationException("Failed to read the list of coordinators from the cluster's system keyspace.");
 
-				return FdbClusterFile.Parse(coordinators.ToStringAscii());
+				return FdbClusterFile.Parse(coordinators.ToStringAscii()!);
 			}
 
 			/// <summary>Return the value of a configuration parameter (located under '\xFF/conf/')</summary>
@@ -165,7 +162,7 @@ namespace FoundationDB.Client
 			/// <param name="name">Name of the configuration key (ex: "storage_engine")</param>
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Value of '\xFF/conf/storage_engine'</returns>
-			public static Task<Slice> GetConfigParameterAsync([NotNull] IFdbDatabase db, [NotNull] string name, CancellationToken ct)
+			public static Task<Slice> GetConfigParameterAsync(IFdbDatabase db, string name, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 				Contract.NotNullOrEmpty(name, nameof(name), "Configuration parameter name cannot be null or empty.");
@@ -183,7 +180,7 @@ namespace FoundationDB.Client
 			/// <summary>Return the corresponding key for a config attribute</summary>
 			/// <param name="name">"foo"</param>
 			/// <returns>"\xFF/conf/foo"</returns>
-			public static Slice ConfigKey([NotNull] string name)
+			public static Slice ConfigKey(string name)
 			{
 				if (string.IsNullOrEmpty(name)) throw new ArgumentException("Attribute name cannot be null or empty", nameof(name));
 				return ConfigPrefix + Slice.FromByteString(name);
@@ -192,7 +189,7 @@ namespace FoundationDB.Client
 			/// <summary>Return the corresponding key for a global attribute</summary>
 			/// <param name="name">"foo"</param>
 			/// <returns>"\xFF/globals/foo"</returns>
-			public static Slice GlobalsKey([NotNull] string name)
+			public static Slice GlobalsKey(string name)
 			{
 				if (string.IsNullOrEmpty(name)) throw new ArgumentException("Attribute name cannot be null or empty", nameof(name));
 				return GlobalsPrefix + Slice.FromByteString(name);
@@ -202,7 +199,7 @@ namespace FoundationDB.Client
 			/// <param name="id">"ABC123"</param>
 			/// <param name="name">"foo"</param>
 			/// <returns>"\xFF/workers/ABC123/foo"</returns>
-			public static Slice WorkersKey([NotNull] string id, [NotNull] string name)
+			public static Slice WorkersKey(string id, string name)
 			{
 				if (string.IsNullOrEmpty(id)) throw new ArgumentException("Id cannot be null or empty", nameof(id));
 				if (string.IsNullOrEmpty(name)) throw new ArgumentException("Attribute name cannot be null or empty", nameof(name));
@@ -214,8 +211,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Returns either "memory" or "ssd"</returns>
 			/// <remarks>Will return a string starting with "unknown" if the storage engine mode is not recognized</remarks>
-			[ItemNotNull]
-			public static async Task<string> GetStorageEngineModeAsync([NotNull] IFdbDatabase db, CancellationToken ct)
+			public static async Task<string> GetStorageEngineModeAsync(IFdbDatabase db, CancellationToken ct)
 			{
 				// The '\xFF/conf/storage_engine' keys has value "0" for ssd-1 engine, "1" for memory engine and "2" for ssd-2 engine
 
@@ -242,8 +238,7 @@ namespace FoundationDB.Client
 			/// <param name="endExclusive">End key (exclusive) of the range to inspect</param>
 			/// <returns>List of keys that mark the start of a new chunk</returns>
 			/// <remarks>This method is not transactional. It will return an answer no older than the Transaction object it is passed, but the returned boundaries are an estimate and may not represent the exact boundary locations at any database version.</remarks>
-			[ItemNotNull]
-			public static async Task<List<Slice>> GetBoundaryKeysAsync([NotNull] IFdbReadOnlyTransaction trans, Slice beginInclusive, Slice endExclusive)
+			public static async Task<List<Slice>> GetBoundaryKeysAsync(IFdbReadOnlyTransaction trans, Slice beginInclusive, Slice endExclusive)
 			{
 				Contract.NotNull(trans, nameof(trans));
 				Contract.Requires(trans.Context?.Database != null);
@@ -268,8 +263,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>List of keys that mark the start of a new chunk</returns>
 			/// <remarks>This method is not transactional. It will return an answer no older than the Database object it is passed, but the returned boundaries are an estimate and may not represent the exact boundary locations at any database version.</remarks>
-			[ItemNotNull]
-			public static Task<List<Slice>> GetBoundaryKeysAsync([NotNull] IFdbDatabase db, Slice beginInclusive, Slice endExclusive, CancellationToken ct)
+			public static Task<List<Slice>> GetBoundaryKeysAsync(IFdbDatabase db, Slice beginInclusive, Slice endExclusive, CancellationToken ct)
 			{
 				Contract.NotNull(db, nameof(db));
 
@@ -284,8 +278,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>List of one or more chunks that constitutes the range, where each chunk represents a contiguous range stored on a single server. If the list contains a single range, that means that the range is small enough to fit inside a single chunk.</returns>
 			/// <remarks>This method is not transactional. It will return an answer no older than the Database object it is passed, but the returned ranges are an estimate and may not represent the exact boundary locations at any database version.</remarks>
-			[ItemNotNull]
-			public static Task<List<KeyRange>> GetChunksAsync([NotNull] IFdbDatabase db, KeyRange range, CancellationToken ct)
+			public static Task<List<KeyRange>> GetChunksAsync(IFdbDatabase db, KeyRange range, CancellationToken ct)
 			{
 				//REVIEW: maybe rename this to SplitIntoChunksAsync or SplitIntoShardsAsync or GetFragmentsAsync ?
 				return GetChunksAsync(db, range.Begin, range.End, ct);
@@ -298,8 +291,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>List of one or more chunks that constitutes the range, where each chunk represents a contiguous range stored on a single server. If the list contains a single range, that means that the range is small enough to fit inside a single chunk.</returns>
 			/// <remarks>This method is not transactional. It will return an answer no older than the Database object it is passed, but the returned ranges are an estimate and may not represent the exact boundary locations at any database version.</remarks>
-			[ItemNotNull]
-			public static async Task<List<KeyRange>> GetChunksAsync([NotNull] IFdbDatabase db, Slice beginInclusive, Slice endExclusive, CancellationToken ct)
+			public static async Task<List<KeyRange>> GetChunksAsync(IFdbDatabase db, Slice beginInclusive, Slice endExclusive, CancellationToken ct)
 			{
 				//REVIEW: maybe rename this to SplitIntoChunksAsync or SplitIntoShardsAsync or GetFragmentsAsync ?
 
@@ -331,8 +323,7 @@ namespace FoundationDB.Client
 				return chunks;
 			}
 
-			[ItemNotNull]
-			private static async Task<List<Slice>> GetBoundaryKeysInternalAsync([NotNull] IFdbReadOnlyTransaction trans, Slice begin, Slice end)
+			private static async Task<List<Slice>> GetBoundaryKeysInternalAsync(IFdbReadOnlyTransaction trans, Slice begin, Slice end)
 			{
 				Contract.Requires(trans != null && end >= begin);
 
@@ -347,7 +338,7 @@ namespace FoundationDB.Client
 				var options = new FdbRangeOptions { Mode = FdbStreamingMode.WantAll };
 				while (begin < end)
 				{
-					FdbException error = null;
+					FdbException? error = null;
 					Slice lastBegin = begin;
 					try
 					{
@@ -406,7 +397,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of keys k such that range.Begin &lt;= k &gt; range.End</returns>
 			/// <remarks>If the range contains a large of number keys, the operation may need more than one transaction to complete, meaning that the number will not be transactionally accurate.</remarks>
-			public static Task<long> EstimateCountAsync([NotNull] IFdbDatabase db, KeyRange range, CancellationToken ct)
+			public static Task<long> EstimateCountAsync(IFdbDatabase db, KeyRange range, CancellationToken ct)
 			{
 				return EstimateCountAsync(db, range.Begin, range.End, null, ct);
 				//REVIEW: BUGBUG: REFACTORING: deal with null value for End!
@@ -419,7 +410,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of keys k such that range.Begin &lt;= k &gt; range.End</returns>
 			/// <remarks>If the range contains a large of number keys, the operation may need more than one transaction to complete, meaning that the number will not be transactionally accurate.</remarks>
-			public static Task<long> EstimateCountAsync([NotNull] IFdbDatabase db, KeyRange range, IProgress<(long Count, Slice Current)> onProgress, CancellationToken ct)
+			public static Task<long> EstimateCountAsync(IFdbDatabase db, KeyRange range, IProgress<(long Count, Slice Current)> onProgress, CancellationToken ct)
 			{
 				return EstimateCountAsync(db, range.Begin, range.End, onProgress, ct);
 				//REVIEW: BUGBUG: REFACTORING: deal with null value for End!
@@ -433,7 +424,7 @@ namespace FoundationDB.Client
 			/// <param name="ct">Token used to cancel the operation</param>
 			/// <returns>Number of keys k such that <paramref name="beginInclusive"/> &lt;= k &gt; <paramref name="endExclusive"/></returns>
 			/// <remarks>If the range contains a large of number keys, the operation may need more than one transaction to complete, meaning that the number will not be transactionally accurate.</remarks>
-			public static async Task<long> EstimateCountAsync([NotNull] IFdbDatabase db, Slice beginInclusive, Slice endExclusive, IProgress<(long Count, Slice Current)> onProgress, CancellationToken ct)
+			public static async Task<long> EstimateCountAsync(IFdbDatabase db, Slice beginInclusive, Slice endExclusive, IProgress<(long Count, Slice Current)>? onProgress, CancellationToken ct)
 			{
 				const int INIT_WINDOW_SIZE = 1 << 8; // start at 256 //1024
 				const int MAX_WINDOW_SIZE = 1 << 13; // never use more than 4096
@@ -492,7 +483,7 @@ namespace FoundationDB.Client
 
 						var selector = KeySelector.FirstGreaterOrEqual(cursor) + windowSize;
 						Slice next = Slice.Nil;
-						FdbException error = null;
+						FdbException? error = null;
 						try
 						{
 							next = await tr.Snapshot.GetKeyAsync(selector).ConfigureAwait(false);

--- a/FoundationDB.Client/FdbClusterFile.cs
+++ b/FoundationDB.Client/FdbClusterFile.cs
@@ -43,19 +43,15 @@ namespace FoundationDB.Client
 	public sealed class FdbClusterFile
 	{
 		/// <summary>The raw value of the file</summary>
-		[NotNull]
 		internal string RawValue { get; }
 
 		/// <summary>Cluster Identifier</summary>
-		[NotNull]
 		public string Id { get; }
 
 		/// <summary>Logical description of the database</summary>
-		[NotNull]
 		public string Description { get; }
 
 		/// <summary>List of coordination servers</summary>
-		[NotNull, ItemNotNull]
 		public FdbEndPoint[] Coordinators { get; }
 
 		private FdbClusterFile(string rawValue, string description, string identifier, FdbEndPoint[] coordinators)
@@ -71,7 +67,7 @@ namespace FoundationDB.Client
 		/// <param name="description"></param>
 		/// <param name="identifier"></param>
 		/// <param name="coordinators"></param>
-		public FdbClusterFile([NotNull] string description, [NotNull] string identifier, [NotNull, ItemNotNull] IEnumerable<FdbEndPoint> coordinators)
+		public FdbClusterFile(string description, string identifier, IEnumerable<FdbEndPoint> coordinators)
 		{
 			Contract.NotNull(description, nameof(description));
 			Contract.NotNull(identifier, nameof(identifier));
@@ -93,7 +89,6 @@ namespace FoundationDB.Client
 		/// <summary>Parse the content of a .cluster file</summary>
 		/// <param name="rawValue">First line of a .cluster file</param>
 		/// <returns>Parsed cluster file instance</returns>
-		[NotNull]
 		public static FdbClusterFile Parse(string rawValue)
 		{
 			if (string.IsNullOrEmpty(rawValue)) throw new FormatException("Cluster file descriptor cannot be empty.");

--- a/FoundationDB.Client/FdbConnectionOptions.cs
+++ b/FoundationDB.Client/FdbConnectionOptions.cs
@@ -44,8 +44,7 @@ namespace FoundationDB.Client
 		public const string DefaultDbName = "DB";
 
 		/// <summary>Full path to a specific 'fdb.cluster' file</summary>
-		[CanBeNull]
-		public string ClusterFile { get; set; }
+		public string? ClusterFile { get; set; }
 
 		/// <summary>Default database name</summary>
 		/// <remarks>Only "DB" is supported for now</remarks>
@@ -70,12 +69,10 @@ namespace FoundationDB.Client
 		public FdbDirectoryPath Root { get; set; }
 
 		/// <summary>If set, specify the datacenter ID that was passed to fdbserver processes running in the same datacenter as this client, for better location-aware load balancing.</summary>
-		[CanBeNull]
-		public string DataCenterId { get; set; }
+		public string? DataCenterId { get; set; }
 
 		/// <summary>If set, specify the machine ID that was passed to fdbserver processes running on the same machine as this client, for better location-aware load balancing.</summary>
-		[CanBeNull]
-		public string MachineId { get; set; }
+		public string? MachineId { get; set; }
 
 
 		public override string ToString()
@@ -93,7 +90,7 @@ namespace FoundationDB.Client
 			return sb.ToString();
 		}
 
-		private static void AddKeyValue(StringBuilder sb, string key, string value)
+		private static void AddKeyValue(StringBuilder sb, string key, string? value)
 		{
 			if (value == null) return;
 			if (value.IndexOf(' ') >= 0 || value.IndexOf(';') >= 0)

--- a/FoundationDB.Client/FdbDatabaseExtensions.cs
+++ b/FoundationDB.Client/FdbDatabaseExtensions.cs
@@ -56,8 +56,8 @@ namespace FoundationDB.Client
 		/// }
 		/// </code>
 		/// </example>
-		[Pure, ItemNotNull]
-		public static async ValueTask<IFdbReadOnlyTransaction> BeginReadOnlyTransactionAsync([NotNull] this IFdbDatabase db, CancellationToken ct)
+		[Pure]
+		public static async ValueTask<IFdbReadOnlyTransaction> BeginReadOnlyTransactionAsync(this IFdbDatabase db, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return await db.BeginTransactionAsync(FdbTransactionMode.ReadOnly, ct, default(FdbOperationContext));
@@ -75,8 +75,8 @@ namespace FoundationDB.Client
 		///		tr.Clear(Slice.FromString("OldValue"));
 		///		await tr.CommitAsync();
 		/// }</example>
-		[Pure, ItemNotNull]
-		public static ValueTask<IFdbTransaction> BeginTransactionAsync([NotNull] this IFdbDatabase db, CancellationToken ct)
+		[Pure]
+		public static ValueTask<IFdbTransaction> BeginTransactionAsync(this IFdbDatabase db, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.BeginTransactionAsync(FdbTransactionMode.Default, ct, default(FdbOperationContext));
@@ -89,7 +89,7 @@ namespace FoundationDB.Client
 		/// <summary>Set the size of the client location cache. Raising this value can boost performance in very large databases where clients access data in a near-random pattern. Defaults to 100000.</summary>
 		/// <param name="db">Database instance</param>
 		/// <param name="size">Max location cache entries</param>
-		public static void SetLocationCacheSize([NotNull] this IFdbDatabase db, int size)
+		public static void SetLocationCacheSize(this IFdbDatabase db, int size)
 		{
 			Contract.NotNull(db, nameof(db));
 			if (size < 0) throw new FdbException(FdbError.InvalidOptionValue, "Location cache size must be a positive integer");
@@ -102,7 +102,7 @@ namespace FoundationDB.Client
 		/// <summary>Set the maximum number of watches allowed to be outstanding on a database connection. Increasing this number could result in increased resource usage. Reducing this number will not cancel any outstanding watches. Defaults to 10000 and cannot be larger than 1000000.</summary>
 		/// <param name="db">Database instance</param>
 		/// <param name="count">Max outstanding watches</param>
-		public static void SetMaxWatches([NotNull] this IFdbDatabase db, int count)
+		public static void SetMaxWatches(this IFdbDatabase db, int count)
 		{
 			Contract.NotNull(db, nameof(db));
 			if (count < 0) throw new FdbException(FdbError.InvalidOptionValue, "Maximum outstanding watches count must be a positive integer");
@@ -115,7 +115,7 @@ namespace FoundationDB.Client
 		/// <summary>Specify the machine ID that was passed to fdbserver processes running on the same machine as this client, for better location-aware load balancing.</summary>
 		/// <param name="db">Database instance</param>
 		/// <param name="hexId">Hexadecimal ID</param>
-		public static void SetMachineId([NotNull] this IFdbDatabase db, string hexId)
+		public static void SetMachineId(this IFdbDatabase db, string hexId)
 		{
 			Contract.NotNull(db, nameof(db));
 			//REVIEW: we can't really change this to a Property, because we don't have a way to get the current value for the getter, and set only properties are weird...
@@ -126,7 +126,7 @@ namespace FoundationDB.Client
 		/// <summary>Specify the datacenter ID that was passed to fdbserver processes running in the same datacenter as this client, for better location-aware load balancing.</summary>
 		/// <param name="db">Database instance</param>
 		/// <param name="hexId">Hexadecimal ID</param>
-		public static void SetDataCenterId([NotNull] this IFdbDatabase db, string hexId)
+		public static void SetDataCenterId(this IFdbDatabase db, string hexId)
 		{
 			Contract.NotNull(db, nameof(db));
 			//REVIEW: we can't really change this to a Property, because we don't have a way to get the current value for the getter, and set only properties are weird...
@@ -147,7 +147,7 @@ namespace FoundationDB.Client
 		/// If you need to read several keys at once, use a version of <see cref="GetValuesAsync(FoundationDB.Client.IFdbReadOnlyRetryable,System.Collections.Generic.IEnumerable{System.Slice},System.Threading.CancellationToken)"/>.
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbReadOnlyRetryable.ReadAsync{TResult}(System.Func{FoundationDB.Client.IFdbReadOnlyTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task<Slice> GetAsync([NotNull] this IFdbReadOnlyRetryable db, Slice key, CancellationToken ct)
+		public static Task<Slice> GetAsync(this IFdbReadOnlyRetryable db, Slice key, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.ReadAsync((tr) => tr.GetAsync(key), ct);
@@ -158,8 +158,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbReadOnlyRetryable.ReadAsync{TResult}(System.Func{FoundationDB.Client.IFdbReadOnlyTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		[ItemNotNull]
-		public static Task<Slice[]> GetValuesAsync([NotNull] this IFdbReadOnlyRetryable db, [NotNull] Slice[] keys, CancellationToken ct)
+		public static Task<Slice[]> GetValuesAsync(this IFdbReadOnlyRetryable db, Slice[] keys, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.ReadAsync((tr) => tr.GetValuesAsync(keys), ct);
@@ -170,8 +169,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbReadOnlyRetryable.ReadAsync{TResult}(System.Func{FoundationDB.Client.IFdbReadOnlyTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		[ItemNotNull]
-		public static Task<Slice[]> GetValuesAsync([NotNull] this IFdbReadOnlyRetryable db, [NotNull] IEnumerable<Slice> keys, CancellationToken ct)
+		public static Task<Slice[]> GetValuesAsync(this IFdbReadOnlyRetryable db, IEnumerable<Slice> keys, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.ReadAsync((tr) => tr.GetValuesAsync(keys), ct);
@@ -182,7 +180,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbReadOnlyRetryable.ReadAsync{TResult}(System.Func{FoundationDB.Client.IFdbReadOnlyTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task<Slice> GetKeyAsync([NotNull] this IFdbReadOnlyRetryable db, KeySelector keySelector, CancellationToken ct)
+		public static Task<Slice> GetKeyAsync(this IFdbReadOnlyRetryable db, KeySelector keySelector, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.ReadAsync((tr) => tr.GetKeyAsync(keySelector), ct);
@@ -193,8 +191,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbReadOnlyRetryable.ReadAsync{TResult}(System.Func{FoundationDB.Client.IFdbReadOnlyTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		[ItemNotNull]
-		public static Task<Slice[]> GetKeysAsync([NotNull] this IFdbReadOnlyRetryable db, [NotNull] KeySelector[] keySelectors, CancellationToken ct)
+		public static Task<Slice[]> GetKeysAsync(this IFdbReadOnlyRetryable db, KeySelector[] keySelectors, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			Contract.NotNull(keySelectors, nameof(keySelectors));
@@ -206,8 +203,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbReadOnlyRetryable.ReadAsync{TResult}(System.Func{FoundationDB.Client.IFdbReadOnlyTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		[ItemNotNull]
-		public static Task<Slice[]> GetKeysAsync([NotNull] this IFdbReadOnlyRetryable db, [NotNull] IEnumerable<KeySelector> keySelectors, CancellationToken ct)
+		public static Task<Slice[]> GetKeysAsync(this IFdbReadOnlyRetryable db, IEnumerable<KeySelector> keySelectors, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			Contract.NotNull(keySelectors, nameof(keySelectors));
@@ -219,7 +215,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbReadOnlyRetryable.ReadAsync{TResult}(System.Func{FoundationDB.Client.IFdbReadOnlyTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task<FdbRangeChunk> GetRangeAsync([NotNull] this IFdbReadOnlyRetryable db, KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions options, int iteration, CancellationToken ct)
+		public static Task<FdbRangeChunk> GetRangeAsync(this IFdbReadOnlyRetryable db, KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions options, int iteration, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.ReadAsync((tr) => tr.GetRangeAsync(beginInclusive, endExclusive, options, iteration), ct);
@@ -230,7 +226,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task SetAsync([NotNull] this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
+		public static Task SetAsync(this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Set(key, value), ct);
@@ -241,7 +237,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task SetValuesAsync([NotNull] this IFdbRetryable db, IEnumerable<KeyValuePair<Slice, Slice>> items, CancellationToken ct)
+		public static Task SetValuesAsync(this IFdbRetryable db, IEnumerable<KeyValuePair<Slice, Slice>> items, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) =>
@@ -258,7 +254,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task SetValuesAsync([NotNull] this IFdbRetryable db, IEnumerable<(Slice Key, Slice Value)> items, CancellationToken ct)
+		public static Task SetValuesAsync(this IFdbRetryable db, IEnumerable<(Slice Key, Slice Value)> items, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) =>
@@ -275,7 +271,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task ClearAsync([NotNull] this IFdbRetryable db, Slice key, CancellationToken ct)
+		public static Task ClearAsync(this IFdbRetryable db, Slice key, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Clear(key), ct);
@@ -286,7 +282,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task ClearRangeAsync([NotNull] this IFdbRetryable db, Slice beginKeyInclusive, Slice endKeyExclusive, CancellationToken ct)
+		public static Task ClearRangeAsync(this IFdbRetryable db, Slice beginKeyInclusive, Slice endKeyExclusive, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.ClearRange(beginKeyInclusive, endKeyExclusive), ct);
@@ -297,7 +293,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task ClearRangeAsync([NotNull] this IFdbRetryable db, KeyRange range, CancellationToken ct)
+		public static Task ClearRangeAsync(this IFdbRetryable db, KeyRange range, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.ClearRange(range), ct);
@@ -308,7 +304,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task AtomicAdd([NotNull] this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
+		public static Task AtomicAdd(this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Atomic(key, value, FdbMutationType.Add), ct);
@@ -319,7 +315,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task AtomicCompareAndClear([NotNull] this IFdbRetryable db, Slice key, Slice comparand, CancellationToken ct)
+		public static Task AtomicCompareAndClear(this IFdbRetryable db, Slice key, Slice comparand, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Atomic(key, comparand, FdbMutationType.CompareAndClear), ct);
@@ -330,7 +326,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task AtomicBitAnd([NotNull] this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
+		public static Task AtomicBitAnd(this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Atomic(key, value, FdbMutationType.BitAnd), ct);
@@ -341,7 +337,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task AtomicBitOr([NotNull] this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
+		public static Task AtomicBitOr(this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Atomic(key, value, FdbMutationType.BitOr), ct);
@@ -352,7 +348,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task AtomicBitXor([NotNull] this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
+		public static Task AtomicBitXor(this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Atomic(key, value, FdbMutationType.BitXor), ct);
@@ -363,7 +359,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task AtomicMax([NotNull] this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
+		public static Task AtomicMax(this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Atomic(key, value, FdbMutationType.Max), ct);
@@ -374,7 +370,7 @@ namespace FoundationDB.Client
 		/// Use this method only if you intend to perform a single operation inside your execution context (ex: HTTP request).
 		/// If you need to combine multiple read or write operations, consider using on of the multiple <see cref="IFdbRetryable.WriteAsync(System.Action{FoundationDB.Client.IFdbTransaction},System.Threading.CancellationToken)"/> or <see cref="IFdbRetryable.ReadWriteAsync{TResult}(System.Func{FoundationDB.Client.IFdbTransaction,System.Threading.Tasks.Task{TResult}},System.Threading.CancellationToken)"/> overrides.
 		/// </remarks>
-		public static Task AtomicMin([NotNull] this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
+		public static Task AtomicMin(this IFdbRetryable db, Slice key, Slice value, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			return db.WriteAsync((tr) => tr.Atomic(key, value, FdbMutationType.Min), ct);

--- a/FoundationDB.Client/FdbMergeQueryExtensions.cs
+++ b/FoundationDB.Client/FdbMergeQueryExtensions.cs
@@ -41,8 +41,8 @@ namespace FoundationDB.Client
 
 		#region MergeSort (x OR y)
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<KeyValuePair<Slice, Slice>> MergeSort<TKey>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeySelectorPair> ranges, [NotNull] Func<KeyValuePair<Slice, Slice>, TKey> keySelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<KeyValuePair<Slice, Slice>> MergeSort<TKey>(this IFdbReadOnlyTransaction trans, IEnumerable<KeySelectorPair> ranges, Func<KeyValuePair<Slice, Slice>, TKey> keySelector, IComparer<TKey>? keyComparer = null)
 		{
 			//TODO: Range options ?
 			Contract.NotNull(trans, nameof(trans));
@@ -59,8 +59,8 @@ namespace FoundationDB.Client
 			);
 		}
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> MergeSort<TKey, TResult>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeySelectorPair> ranges, [NotNull] Func<KeyValuePair<Slice, Slice>, TKey> keySelector, [NotNull] Func<KeyValuePair<Slice, Slice>, TResult> resultSelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> MergeSort<TKey, TResult>(this IFdbReadOnlyTransaction trans, IEnumerable<KeySelectorPair> ranges, Func<KeyValuePair<Slice, Slice>, TKey> keySelector, Func<KeyValuePair<Slice, Slice>, TResult> resultSelector, IComparer<TKey>? keyComparer = null)
 		{
 			//TODO: Range options ?
 			Contract.NotNull(trans, nameof(trans));
@@ -78,8 +78,8 @@ namespace FoundationDB.Client
 			);
 		}
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Union<TKey, TResult>([NotNull] IEnumerable<IAsyncEnumerable<TResult>> sources, [NotNull] Func<TResult, TKey> keySelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Union<TKey, TResult>(IEnumerable<IAsyncEnumerable<TResult>> sources, Func<TResult, TKey> keySelector, IComparer<TKey>? keyComparer = null)
 		{
 			Contract.NotNull(sources, nameof(sources));
 			Contract.NotNull(keySelector, nameof(keySelector));
@@ -92,8 +92,8 @@ namespace FoundationDB.Client
 			);
 		}
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Union<TResult>([NotNull] IEnumerable<IAsyncEnumerable<TResult>> sources, IComparer<TResult> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Union<TResult>(IEnumerable<IAsyncEnumerable<TResult>> sources, IComparer<TResult>? keyComparer = null)
 		{
 			Contract.NotNull(sources, nameof(sources));
 			return new MergeSortAsyncIterator<TResult, TResult, TResult>(
@@ -109,8 +109,8 @@ namespace FoundationDB.Client
 
 		#region Intersect (x AND y)
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<KeyValuePair<Slice, Slice>> Intersect<TKey>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeySelectorPair> ranges, [NotNull] Func<KeyValuePair<Slice, Slice>, TKey> keySelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<KeyValuePair<Slice, Slice>> Intersect<TKey>(this IFdbReadOnlyTransaction trans, IEnumerable<KeySelectorPair> ranges, Func<KeyValuePair<Slice, Slice>, TKey> keySelector, IComparer<TKey>? keyComparer = null)
 		{
 			//TODO: Range options ?
 			Contract.NotNull(trans, nameof(trans));
@@ -127,8 +127,8 @@ namespace FoundationDB.Client
 			);
 		}
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Intersect<TKey, TResult>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeySelectorPair> ranges, [NotNull] Func<KeyValuePair<Slice, Slice>, TKey> keySelector, [NotNull] Func<KeyValuePair<Slice, Slice>, TResult> resultSelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Intersect<TKey, TResult>(this IFdbReadOnlyTransaction trans, IEnumerable<KeySelectorPair> ranges, Func<KeyValuePair<Slice, Slice>, TKey> keySelector, Func<KeyValuePair<Slice, Slice>, TResult> resultSelector, IComparer<TKey>? keyComparer = null)
 		{
 			//TODO: Range options ?
 
@@ -142,8 +142,8 @@ namespace FoundationDB.Client
 			);
 		}
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Intersect<TKey, TResult>([NotNull] this IAsyncEnumerable<TResult> first, [NotNull] IAsyncEnumerable<TResult> second, [NotNull] Func<TResult, TKey> keySelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Intersect<TKey, TResult>(this IAsyncEnumerable<TResult> first, IAsyncEnumerable<TResult> second, Func<TResult, TKey> keySelector, IComparer<TKey>? keyComparer = null)
 		{
 			Contract.NotNull(first, nameof(first));
 			Contract.NotNull(second, nameof(second));
@@ -156,8 +156,8 @@ namespace FoundationDB.Client
 			);
 		}
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Intersect<TResult>([NotNull] this IAsyncEnumerable<TResult> first, [NotNull] IAsyncEnumerable<TResult> second, IComparer<TResult> comparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Intersect<TResult>(this IAsyncEnumerable<TResult> first, IAsyncEnumerable<TResult> second, IComparer<TResult>? comparer = null)
 		{
 			Contract.NotNull(first, nameof(first));
 			Contract.NotNull(second, nameof(second));
@@ -170,8 +170,8 @@ namespace FoundationDB.Client
 			);
 		}
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Intersect<TKey, TResult>([NotNull] IEnumerable<IAsyncEnumerable<TResult>> sources, [NotNull] Func<TResult, TKey> keySelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Intersect<TKey, TResult>(IEnumerable<IAsyncEnumerable<TResult>> sources, Func<TResult, TKey> keySelector, IComparer<TKey>? keyComparer = null)
 		{
 			Contract.NotNull(sources, nameof(sources));
 			Contract.NotNull(keySelector, nameof(keySelector));
@@ -184,8 +184,8 @@ namespace FoundationDB.Client
 			);
 		}
 
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Intersect<TResult>([NotNull] IEnumerable<IAsyncEnumerable<TResult>> sources, IComparer<TResult> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Intersect<TResult>(IEnumerable<IAsyncEnumerable<TResult>> sources, IComparer<TResult>? keyComparer = null)
 		{
 			Contract.NotNull(sources, nameof(sources));
 			return new IntersectAsyncIterator<TResult, TResult, TResult>(
@@ -208,8 +208,8 @@ namespace FoundationDB.Client
 		/// <param name="keySelector">Lambda called to extract the keys from the ranges</param>
 		/// <param name="keyComparer">Instance used to compare the keys returned by <paramref name="keySelector"/></param>
 		/// <returns>Async query that returns only the results that are in the first range, and not in any other range.</returns>
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<KeyValuePair<Slice, Slice>> Except<TKey>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeySelectorPair> ranges, [NotNull] Func<KeyValuePair<Slice, Slice>, TKey> keySelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<KeyValuePair<Slice, Slice>> Except<TKey>(this IFdbReadOnlyTransaction trans, IEnumerable<KeySelectorPair> ranges, Func<KeyValuePair<Slice, Slice>, TKey> keySelector, IComparer<TKey>? keyComparer = null)
 		{
 			//TODO: Range options ?
 			Contract.NotNull(trans, nameof(trans));
@@ -233,8 +233,8 @@ namespace FoundationDB.Client
 		/// <param name="keySelector">Lambda called to extract the keys from the ranges</param>
 		/// <param name="keyComparer">Instance used to compare the keys returned by <paramref name="keySelector"/></param>
 		/// <returns>Async query that returns only the results that are in the first range, and not in any other range.</returns>
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<KeyValuePair<Slice, Slice>> Except<TKey>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeyRange> ranges, [NotNull] Func<KeyValuePair<Slice, Slice>, TKey> keySelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<KeyValuePair<Slice, Slice>> Except<TKey>(this IFdbReadOnlyTransaction trans, IEnumerable<KeyRange> ranges, Func<KeyValuePair<Slice, Slice>, TKey> keySelector, IComparer<TKey>? keyComparer = null)
 		{
 			Contract.NotNull(ranges, nameof(ranges));
 			return Except<TKey>(trans, ranges.Select(r => KeySelectorPair.Create(r)), keySelector, keyComparer);
@@ -249,8 +249,8 @@ namespace FoundationDB.Client
 		/// <param name="resultSelector">Lambda called to extract the values returned by the query</param>
 		/// <param name="keyComparer">Instance used to compare the keys returned by <paramref name="keySelector"/></param>
 		/// <returns>Async query that returns only the results that are in the first range, and not in any other range.</returns>
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Except<TKey, TResult>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeySelectorPair> ranges, [NotNull] Func<KeyValuePair<Slice, Slice>, TKey> keySelector, [NotNull] Func<KeyValuePair<Slice, Slice>, TResult> resultSelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Except<TKey, TResult>(this IFdbReadOnlyTransaction trans, IEnumerable<KeySelectorPair> ranges, Func<KeyValuePair<Slice, Slice>, TKey> keySelector, Func<KeyValuePair<Slice, Slice>, TResult> resultSelector, IComparer<TKey>? keyComparer = null)
 		{
 			//TODO: Range options ?
 
@@ -273,8 +273,8 @@ namespace FoundationDB.Client
 		/// <param name="resultSelector">Lambda called to extract the values returned by the query</param>
 		/// <param name="keyComparer">Instance used to compare the keys returned by <paramref name="keySelector"/></param>
 		/// <returns>Async query that returns only the results that are in the first range, and not in any other range.</returns>
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Except<TKey, TResult>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeyRange> ranges, [NotNull] Func<KeyValuePair<Slice, Slice>, TKey> keySelector, [NotNull] Func<KeyValuePair<Slice, Slice>, TResult> resultSelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Except<TKey, TResult>(this IFdbReadOnlyTransaction trans, IEnumerable<KeyRange> ranges, Func<KeyValuePair<Slice, Slice>, TKey> keySelector, Func<KeyValuePair<Slice, Slice>, TResult> resultSelector, IComparer<TKey>? keyComparer = null)
 		{
 			Contract.NotNull(ranges, nameof(ranges));
 			return Except<TKey, TResult>(trans, ranges.Select(r => KeySelectorPair.Create(r)), keySelector, resultSelector, keyComparer);
@@ -288,8 +288,8 @@ namespace FoundationDB.Client
 		/// <param name="keySelector">Lambda used to extract keys from both queries.</param>
 		/// <param name="keyComparer">Instance used to compare keys</param>
 		/// <returns>Async query that returns only the elements that are in <paramref name="first"/>, and not in <paramref name="second"/></returns>
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Except<TKey, TResult>([NotNull] this IAsyncEnumerable<TResult> first, [NotNull] IAsyncEnumerable<TResult> second, [NotNull] Func<TResult, TKey> keySelector, IComparer<TKey> keyComparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Except<TKey, TResult>(this IAsyncEnumerable<TResult> first, IAsyncEnumerable<TResult> second, Func<TResult, TKey> keySelector, IComparer<TKey>? keyComparer = null)
 		{
 			Contract.NotNull(first, nameof(first));
 			Contract.NotNull(second, nameof(second));
@@ -309,8 +309,8 @@ namespace FoundationDB.Client
 		/// <param name="second">Second query that contains the elements that cannot be in the result</param>
 		/// <param name="comparer">Instance used to compare elements</param>
 		/// <returns>Async query that returns only the elements that are in <paramref name="first"/>, and not in <paramref name="second"/></returns>
-		[Pure, NotNull, LinqTunnel]
-		public static IAsyncEnumerable<TResult> Except<TResult>([NotNull] this IAsyncEnumerable<TResult> first, [NotNull] IAsyncEnumerable<TResult> second, IComparer<TResult> comparer = null)
+		[Pure, LinqTunnel]
+		public static IAsyncEnumerable<TResult> Except<TResult>(this IAsyncEnumerable<TResult> first, IAsyncEnumerable<TResult> second, IComparer<TResult>? comparer = null)
 		{
 			Contract.NotNull(first, nameof(first));
 			Contract.NotNull(second, nameof(second));

--- a/FoundationDB.Client/FdbRangeChunk.cs
+++ b/FoundationDB.Client/FdbRangeChunk.cs
@@ -42,7 +42,6 @@ namespace FoundationDB.Client
 	public sealed class FdbRangeChunk : IReadOnlyList<KeyValuePair<Slice, Slice>>
 	{
 		/// <summary>Contains the items that where </summary>
-		[NotNull]
 		public KeyValuePair<Slice, Slice>[] Items { get; }
 
 		/// <summary>Set to true if the original range read was reversed (meaning the items are in reverse lexicographic order</summary>
@@ -65,7 +64,7 @@ namespace FoundationDB.Client
 		/// <remarks>Note that if the range is reversed, then the last item will be LESS than the first!</remarks>
 		public Slice First { get; }
 
-		public FdbRangeChunk([NotNull] KeyValuePair<Slice, Slice>[] items, bool hasMore, int iteration, bool reversed, FdbReadMode readMode, Slice first, Slice last)
+		public FdbRangeChunk(KeyValuePair<Slice, Slice>[] items, bool hasMore, int iteration, bool reversed, FdbReadMode readMode, Slice first, Slice last)
 		{
 			Contract.NotNull(items, nameof(items));
 			this.Items = items;
@@ -363,8 +362,7 @@ namespace FoundationDB.Client
 		/// <param name="keyHandler">Lambda that can decode the keys of this chunk</param>
 		/// <param name="valueHandler">Lambda that can decode the values of this chunk</param>
 		/// <returns>Array of decoded key/value pairs, or an empty array if the chunk doesn't have any results</returns>
-		[NotNull]
-		public KeyValuePair<TKey, TValue>[] Decode<TKey, TValue>([NotNull] Func<Slice, TKey> keyHandler, [NotNull] Func<Slice, TValue> valueHandler)
+		public KeyValuePair<TKey, TValue>[] Decode<TKey, TValue>(Func<Slice, TKey> keyHandler, Func<Slice, TValue> valueHandler)
 		{
 			Contract.NotNull(keyHandler, nameof(keyHandler));
 			Contract.NotNull(valueHandler, nameof(valueHandler));
@@ -392,8 +390,7 @@ namespace FoundationDB.Client
 		/// <returns>Array of decoded key/value pairs, or an empty array if the chunk doesn't have any results</returns>
 		/// <exception cref="System.ArgumentException">If at least on key in the result is outside <paramref name="subspace"/>.</exception>
 		/// <exception cref="System.ArgumentNullException">If either <paramref name="subspace"/>, <paramref name="keyEncoder"/> or <paramref name="valueEncoder"/> is null.</exception>
-		[NotNull]
-		public KeyValuePair<TKey, TValue>[] Decode<TKey, TValue>([NotNull] KeySubspace subspace, [NotNull] IKeyEncoder<TKey> keyEncoder, [NotNull] IValueEncoder<TValue> valueEncoder)
+		public KeyValuePair<TKey, TValue>[] Decode<TKey, TValue>(KeySubspace subspace, IKeyEncoder<TKey> keyEncoder, IValueEncoder<TValue> valueEncoder)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(keyEncoder, nameof(keyEncoder));
@@ -420,8 +417,7 @@ namespace FoundationDB.Client
 		/// <param name="valueEncoder">Instance used to decode the values of this chunk</param>
 		/// <returns>Array of decoded key/value pairs, or an empty array if the chunk doesn't have any results</returns>
 		/// <exception cref="System.ArgumentNullException">If either <paramref name="keyEncoder"/> or <paramref name="valueEncoder"/> is null.</exception>
-		[NotNull]
-		public KeyValuePair<TKey, TValue>[] Decode<TKey, TValue>([NotNull] IKeyEncoder<TKey> keyEncoder, [NotNull] IValueEncoder<TValue> valueEncoder)
+		public KeyValuePair<TKey, TValue>[] Decode<TKey, TValue>(IKeyEncoder<TKey> keyEncoder, IValueEncoder<TValue> valueEncoder)
 		{
 			Contract.NotNull(keyEncoder, nameof(keyEncoder));
 			Contract.NotNull(valueEncoder, nameof(valueEncoder));
@@ -444,8 +440,7 @@ namespace FoundationDB.Client
 		/// <typeparam name="T">Type of the keys</typeparam>
 		/// <param name="handler">Instance used to decode the keys of this chunk</param>
 		/// <returns>Array of decoded keys, or an empty array if the chunk doesn't have any results</returns>
-		[NotNull]
-		public T[] DecodeKeys<T>([NotNull] Func<Slice, T> handler)
+		public T[] DecodeKeys<T>(Func<Slice, T> handler)
 		{
 			Contract.NotNull(handler, nameof(handler));
 
@@ -463,8 +458,7 @@ namespace FoundationDB.Client
 		/// <param name="subspace"></param>
 		/// <param name="keyEncoder">Instance used to decode the keys of this chunk</param>
 		/// <returns>Array of decoded keys, or an empty array if the chunk doesn't have any results</returns>
-		[NotNull]
-		public T[] DecodeKeys<T>([NotNull] KeySubspace subspace, [NotNull] IKeyEncoder<T> keyEncoder)
+		public T[] DecodeKeys<T>(KeySubspace subspace, IKeyEncoder<T> keyEncoder)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(keyEncoder, nameof(keyEncoder));
@@ -482,8 +476,7 @@ namespace FoundationDB.Client
 		/// <typeparam name="T">Type of the keys</typeparam>
 		/// <param name="keyEncoder">Instance used to decode the keys of this chunk</param>
 		/// <returns>Array of decoded keys, or an empty array if the chunk doesn't have any results</returns>
-		[NotNull]
-		public T[] DecodeKeys<T>([NotNull] IKeyEncoder<T> keyEncoder)
+		public T[] DecodeKeys<T>(IKeyEncoder<T> keyEncoder)
 		{
 			Contract.NotNull(keyEncoder, nameof(keyEncoder));
 
@@ -500,8 +493,7 @@ namespace FoundationDB.Client
 		/// <typeparam name="T">Type of the values</typeparam>
 		/// <param name="handler">Lambda that can decode the values of this chunk</param>
 		/// <returns>Array of decoded values, or an empty array if the chunk doesn't have any results</returns>
-		[NotNull]
-		public T[] DecodeValues<T>([NotNull] Func<Slice, T> handler)
+		public T[] DecodeValues<T>(Func<Slice, T> handler)
 		{
 			Contract.NotNull(handler, nameof(handler));
 
@@ -518,8 +510,7 @@ namespace FoundationDB.Client
 		/// <typeparam name="T">Type of the values</typeparam>
 		/// <param name="valueEncoder">Instance used to decode the values of this chunk</param>
 		/// <returns>Array of decoded values, or an empty array if the chunk doesn't have any results</returns>
-		[NotNull]
-		public T[] DecodeValues<T>([NotNull] IValueEncoder<T> valueEncoder)
+		public T[] DecodeValues<T>(IValueEncoder<T> valueEncoder)
 		{
 			Contract.NotNull(valueEncoder, nameof(valueEncoder));
 

--- a/FoundationDB.Client/FdbRangeOptions.cs
+++ b/FoundationDB.Client/FdbRangeOptions.cs
@@ -86,7 +86,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Copy an existing set of options</summary>
 		/// <param name="options"></param>
-		public FdbRangeOptions([NotNull] FdbRangeOptions options)
+		public FdbRangeOptions(FdbRangeOptions options)
 		{
 			Contract.Requires(options != null);
 			this.Limit = options.Limit;
@@ -106,7 +106,7 @@ namespace FoundationDB.Client
 		/// <param name="read">Default value for Read mode if not provided</param>
 		/// <param name="reverse">Default value for Reverse if not provided</param>
 		/// <returns>Options with all the values filled</returns>
-		public static FdbRangeOptions EnsureDefaults(FdbRangeOptions options, int? limit, int? targetBytes, FdbStreamingMode mode, FdbReadMode read, bool reverse)
+		public static FdbRangeOptions EnsureDefaults(FdbRangeOptions? options, int? limit, int? targetBytes, FdbStreamingMode mode, FdbReadMode read, bool reverse)
 		{
 			Contract.Requires((limit ?? 0) >= 0 && (targetBytes ?? 0) >= 0);
 
@@ -152,49 +152,48 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return the default range options</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static FdbRangeOptions FromDefault()
 		{
 			return new FdbRangeOptions();
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeOptions WithLimit(int limit)
 		{
 			return this.Limit == limit ? this : new FdbRangeOptions(this) { Limit = limit };
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeOptions WithTargetBytes(int targetBytes)
 		{
 			return this.TargetBytes == targetBytes ? this : new FdbRangeOptions(this) { TargetBytes = targetBytes };
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeOptions WithStreamingMode(FdbStreamingMode mode)
 		{
 			return this.Mode == mode ? this : new FdbRangeOptions(this) { Mode = mode };
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeOptions Reversed()
 		{
 			return this.Reverse.GetValueOrDefault() ? this : new FdbRangeOptions(this) { Reverse = true };
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeOptions OnlyKeys()
 		{
 			return this.Read == FdbReadMode.Keys ? this : new FdbRangeOptions(this) { Read = FdbReadMode.Keys };
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeOptions OnlyValues()
 		{
 			return this.Read == FdbReadMode.Values ? this : new FdbRangeOptions(this) { Read = FdbReadMode.Values };
 		}
 
 	}
-
 
 }

--- a/FoundationDB.Client/FdbRangeQuery.PagingIterator.cs
+++ b/FoundationDB.Client/FdbRangeQuery.PagingIterator.cs
@@ -39,7 +39,6 @@ namespace FoundationDB.Client
 	using Doxense.Linq;
 	using Doxense.Linq.Async.Iterators;
 	using Doxense.Threading.Tasks;
-	using JetBrains.Annotations;
 
 	public partial class FdbRangeQuery<T>
 	{
@@ -75,7 +74,7 @@ namespace FoundationDB.Client
 			private int Iteration { get; set; }
 
 			/// <summary>Current page (may contain all records or only a segment at a time)</summary>
-			private KeyValuePair<Slice, Slice>[] Chunk { get; set; }
+			private KeyValuePair<Slice, Slice>[]? Chunk { get; set; }
 
 			/// <summary>If true, we have more records pending</summary>
 			private bool HasMore { get; set; }
@@ -87,11 +86,11 @@ namespace FoundationDB.Client
 			private int RowCount { get; set; }
 
 			/// <summary>Current/Last batch read task</summary>
-			private Task<bool> PendingReadTask { get; set; }
+			private Task<bool>? PendingReadTask { get; set; }
 
 			#endregion
 
-			public PagingIterator([NotNull] FdbRangeQuery<T> query, IFdbReadOnlyTransaction transaction)
+			public PagingIterator(FdbRangeQuery<T> query, IFdbReadOnlyTransaction transaction)
 			{
 				Contract.Requires(query != null);
 

--- a/FoundationDB.Client/FdbRangeQuery.cs
+++ b/FoundationDB.Client/FdbRangeQuery.cs
@@ -44,7 +44,7 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Construct a query with a set of initial settings</summary>
-		internal FdbRangeQuery([NotNull] IFdbReadOnlyTransaction transaction, KeySelector begin, KeySelector end, [NotNull] Func<KeyValuePair<Slice, Slice>, T> transform, bool snapshot, [CanBeNull] FdbRangeOptions options)
+		internal FdbRangeQuery(IFdbReadOnlyTransaction transaction, KeySelector begin, KeySelector end, Func<KeyValuePair<Slice, Slice>, T> transform, bool snapshot, FdbRangeOptions? options)
 		{
 			Contract.Requires(transaction != null && transform != null);
 
@@ -58,7 +58,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Copy constructor</summary>
-		private FdbRangeQuery([NotNull] FdbRangeQuery<T> query, [NotNull] FdbRangeOptions options)
+		private FdbRangeQuery(FdbRangeQuery<T> query, FdbRangeOptions options)
 		{
 			Contract.Requires(query != null && options != null);
 
@@ -108,11 +108,9 @@ namespace FoundationDB.Client
 		public bool Reversed => this.Options.Reverse ?? false;
 
 		/// <summary>Parent transaction used to perform the GetRange operation</summary>
-		[NotNull]
 		internal IFdbReadOnlyTransaction Transaction { get; }
 
 		/// <summary>Transformation applied to the result</summary>
-		[NotNull]
 		internal Func<KeyValuePair<Slice, Slice>, T> Transform { get; }
 
 		#endregion
@@ -122,7 +120,7 @@ namespace FoundationDB.Client
 		/// <summary>Only return up to a specific number of results</summary>
 		/// <param name="count">Maximum number of results to return</param>
 		/// <returns>A new query object that will only return up to <paramref name="count"/> results when executed</returns>
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeQuery<T> Take([Positive] int count)
 		{
 			Contract.Positive(count, nameof(count));
@@ -141,7 +139,7 @@ namespace FoundationDB.Client
 		/// <summary>Bypasses a specified number of elements in a sequence and then returns the remaining elements.</summary>
 		/// <param name="count"></param>
 		/// <returns>A new query object that will skip the first <paramref name="count"/> results when executed</returns>
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeQuery<T> Skip([Positive] int count)
 		{
 			Contract.Positive(count, nameof(count));
@@ -188,7 +186,7 @@ namespace FoundationDB.Client
 		/// <returns>A new query object that will return the results in reverse order when executed</returns>
 		/// <remarks>Calling Reverse() on an already reversed query will cancel the effect, and the results will be returned in their natural order.
 		/// Note: Combining the effects of Take()/Skip() and Reverse() may have an impact on performance, especially if the ReadYourWriteDisabled transaction is options set.</remarks>
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeQuery<T> Reverse()
 		{
 			var begin = this.Begin;
@@ -220,7 +218,7 @@ namespace FoundationDB.Client
 		/// <summary>Use a specific target bytes size</summary>
 		/// <param name="bytes"></param>
 		/// <returns>A new query object that will use the specified target bytes size when executed</returns>
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeQuery<T> WithTargetBytes([Positive] int bytes)
 		{
 			Contract.Positive(bytes, nameof(bytes));
@@ -234,7 +232,7 @@ namespace FoundationDB.Client
 		/// <summary>Use a different Streaming Mode</summary>
 		/// <param name="mode">Streaming mode to use when reading the results from the database</param>
 		/// <returns>A new query object that will use the specified streaming mode when executed</returns>
-		[Pure, NotNull]
+		[Pure]
 		public FdbRangeQuery<T> WithMode(FdbStreamingMode mode)
 		{
 			if (!Enum.IsDefined(typeof(FdbStreamingMode), mode))
@@ -251,8 +249,8 @@ namespace FoundationDB.Client
 		/// <summary>Force the query to use a specific transaction</summary>
 		/// <param name="transaction">Transaction to use when executing this query</param>
 		/// <returns>A new query object that will use the specified transaction when executed</returns>
-		[Pure, NotNull]
-		public FdbRangeQuery<T> UseTransaction([NotNull] IFdbReadOnlyTransaction transaction)
+		[Pure]
+		public FdbRangeQuery<T> UseTransaction(IFdbReadOnlyTransaction transaction)
 		{
 			Contract.NotNull(transaction, nameof(transaction));
 
@@ -281,7 +279,6 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return a list of all the elements of the range results</summary>
-		[ItemNotNull]
 		public Task<List<T>> ToListAsync()
 		{
 			// ReSharper disable once InvokeAsExtensionMethod
@@ -289,7 +286,6 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return a list of all the elements of the range results</summary>
-		[ItemNotNull]
 		public Task<List<T>> ToListAsync(CancellationToken ct)
 		{
 			// ReSharper disable once InvokeAsExtensionMethod
@@ -297,7 +293,6 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return an array with all the elements of the range results</summary>
-		[ItemNotNull]
 		public Task<T[]> ToArrayAsync()
 		{
 			// ReSharper disable once InvokeAsExtensionMethod
@@ -305,7 +300,6 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return an array with all the elements of the range results</summary>
-		[ItemNotNull]
 		public Task<T[]> ToArrayAsync(CancellationToken ct)
 		{
 			// ReSharper disable once InvokeAsExtensionMethod
@@ -320,8 +314,8 @@ namespace FoundationDB.Client
 			return AsyncEnumerable.CountAsync(this, this.Transaction.Cancellation);
 		}
 
-		[Pure, NotNull]
-		internal FdbRangeQuery<TResult> Map<TResult>([NotNull] Func<KeyValuePair<Slice, Slice>, TResult> transform)
+		[Pure]
+		internal FdbRangeQuery<TResult> Map<TResult>(Func<KeyValuePair<Slice, Slice>, TResult> transform)
 		{
 			Contract.Requires(transform != null);
 			return new FdbRangeQuery<TResult>(
@@ -335,8 +329,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Projects each element of the range results into a new form.</summary>
-		[Pure, NotNull]
-		public FdbRangeQuery<TResult> Select<TResult>([NotNull] Func<T, TResult> lambda)
+		[Pure]
+		public FdbRangeQuery<TResult> Select<TResult>(Func<T, TResult> lambda)
 		{
 			Contract.Requires(lambda != null);
 			// note: avoid storing the query in the scope by storing the transform locally so that only 'f' and 'lambda' are kept alive
@@ -347,13 +341,12 @@ namespace FoundationDB.Client
 
 		/// <summary>Filters the range results based on a predicate.</summary>
 		/// <remarks>Caution: filtering occurs on the client side !</remarks>
-		[Pure, NotNull]
-		public IAsyncEnumerable<T> Where([NotNull] Func<T, bool> predicate)
+		[Pure]
+		public IAsyncEnumerable<T> Where(Func<T, bool> predicate)
 		{
 			return AsyncEnumerable.Where(this, predicate);
 		}
 
-		[ItemCanBeNull]
 		public Task<T> FirstOrDefaultAsync()
 		{
 			// we can optimize this by passing Limit=1
@@ -366,7 +359,6 @@ namespace FoundationDB.Client
 			return HeadAsync(single: false, orDefault: false);
 		}
 
-		[ItemCanBeNull]
 		public Task<T> LastOrDefaultAsync()
 		{
 			//BUGBUG: if there is a Take(N) on the query, Last() will mean "The Nth key" and not the "last key in the original range".
@@ -383,7 +375,6 @@ namespace FoundationDB.Client
 			return this.Reverse().HeadAsync(single: false, orDefault:false);
 		}
 
-		[ItemCanBeNull]
 		public Task<T> SingleOrDefaultAsync()
 		{
 			// we can optimize this by passing Limit=2
@@ -412,7 +403,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Execute an action on each key/value pair of the range results</summary>
-		public Task ForEachAsync([NotNull] Action<T> action)
+		public Task ForEachAsync(Action<T> action)
 		{
 			// ReSharper disable once InvokeAsExtensionMethod
 			return AsyncEnumerable.ForEachAsync(this, action, this.Transaction.Cancellation);
@@ -444,7 +435,7 @@ namespace FoundationDB.Client
 			if (results.IsEmpty)
 			{ // no result
 				if (!orDefault) throw new InvalidOperationException("The range was empty");
-				return default;
+				return default!;
 			}
 
 			if (single && results.Count > 1)
@@ -501,8 +492,8 @@ namespace FoundationDB.Client
 	public static class FdbRangeQueryExtensions
 	{
 
-		[Pure, NotNull]
-		public static FdbRangeQuery<TKey> Keys<TKey, TValue>([NotNull] this FdbRangeQuery<KeyValuePair<TKey, TValue>> query)
+		[Pure]
+		public static FdbRangeQuery<TKey> Keys<TKey, TValue>(this FdbRangeQuery<KeyValuePair<TKey, TValue>> query)
 		{
 			Contract.NotNull(query, nameof(query));
 
@@ -513,8 +504,8 @@ namespace FoundationDB.Client
 			return query.Map<TKey>((x) => f(x).Key);
 		}
 
-		[Pure, NotNull]
-		public static FdbRangeQuery<TResult> Keys<TKey, TValue, TResult>([NotNull] this FdbRangeQuery<KeyValuePair<TKey, TValue>> query, [NotNull] Func<TKey, TResult> transform)
+		[Pure]
+		public static FdbRangeQuery<TResult> Keys<TKey, TValue, TResult>(this FdbRangeQuery<KeyValuePair<TKey, TValue>> query, Func<TKey, TResult> transform)
 		{
 			Contract.NotNull(query, nameof(query));
 			Contract.NotNull(transform, nameof(transform));
@@ -526,8 +517,8 @@ namespace FoundationDB.Client
 			return query.Map<TResult>((x) => transform(f(x).Key));
 		}
 
-		[Pure, NotNull]
-		public static FdbRangeQuery<TValue> Values<TKey, TValue>([NotNull] this FdbRangeQuery<KeyValuePair<TKey, TValue>> query)
+		[Pure]
+		public static FdbRangeQuery<TValue> Values<TKey, TValue>(this FdbRangeQuery<KeyValuePair<TKey, TValue>> query)
 		{
 			Contract.NotNull(query, nameof(query));
 
@@ -538,8 +529,8 @@ namespace FoundationDB.Client
 			return query.Map<TValue>((x) => f(x).Value);
 		}
 
-		[Pure, NotNull]
-		public static FdbRangeQuery<TResult> Values<TKey, TValue, TResult>([NotNull] this FdbRangeQuery<KeyValuePair<TKey, TValue>> query, [NotNull] Func<TValue, TResult> transform)
+		[Pure]
+		public static FdbRangeQuery<TResult> Values<TKey, TValue, TResult>(this FdbRangeQuery<KeyValuePair<TKey, TValue>> query, Func<TValue, TResult> transform)
 		{
 			Contract.NotNull(query, nameof(query));
 			Contract.NotNull(transform, nameof(transform));

--- a/FoundationDB.Client/FdbTransaction.Snapshot.cs
+++ b/FoundationDB.Client/FdbTransaction.Snapshot.cs
@@ -33,14 +33,13 @@ namespace FoundationDB.Client
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 
 	/// <summary>Wraps an FDB_TRANSACTION handle</summary>
 	public partial class FdbTransaction
 	{
 
 		/// <summary>Snapshot version of this transaction (lazily allocated)</summary>
-		private Snapshotted m_snapshotted;
+		private Snapshotted? m_snapshotted;
 
 		/// <summary>Returns a version of this transaction that perform snapshotted operations</summary>
 		public IFdbReadOnlyTransaction Snapshot
@@ -59,7 +58,7 @@ namespace FoundationDB.Client
 
 			private readonly FdbTransaction m_parent;
 
-			public Snapshotted([NotNull] FdbTransaction parent)
+			public Snapshotted(FdbTransaction parent)
 			{
 				Contract.NotNull(parent, nameof(parent));
 				m_parent = parent;
@@ -152,7 +151,7 @@ namespace FoundationDB.Client
 				return m_parent.m_handler.GetKeysAsync(selectors, snapshot: true, ct: m_parent.m_cancellation);
 			}
 
-			public Task<FdbRangeChunk> GetRangeAsync(KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions options, int iteration)
+			public Task<FdbRangeChunk> GetRangeAsync(KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions? options, int iteration)
 			{
 				EnsureCanRead();
 

--- a/FoundationDB.Client/FdbTransaction.cs
+++ b/FoundationDB.Client/FdbTransaction.cs
@@ -34,6 +34,7 @@ namespace FoundationDB.Client
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
+	using System.Diagnostics.CodeAnalysis;
 	using System.Runtime.CompilerServices;
 	using System.Threading;
 	using System.Threading.Tasks;
@@ -130,11 +131,9 @@ namespace FoundationDB.Client
 		public FdbOperationContext Context => m_context;
 
 		/// <summary>Database instance that manages this transaction</summary>
-		[NotNull]
 		public FdbDatabase Database => m_database;
 
 		/// <summary>Returns the handler for this transaction</summary>
-		[NotNull]
 		internal IFdbTransactionHandler Handler => m_handler;
 
 		/// <summary>If true, the transaction is still pending (not committed or rolled back).</summary>
@@ -242,7 +241,7 @@ namespace FoundationDB.Client
 
 		#region Versions...
 
-		private Task<long> CachedReadVersion;
+		private Task<long>? CachedReadVersion;
 
 		/// <inheritdoc />
 		public Task<long> GetReadVersionAsync()
@@ -291,7 +290,7 @@ namespace FoundationDB.Client
 		}
 
 		// all access to this should be made under lock!
-		private Dictionary<Slice, (Task<VersionStamp?> Task, bool Snapshot)> MetadataVersionKeysCache;
+		private Dictionary<Slice, (Task<VersionStamp?> Task, bool Snapshot)>? MetadataVersionKeysCache;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private Dictionary<Slice, (Task<VersionStamp?> Task, bool Snapshot)> GetMetadataVersionKeysCache()
@@ -357,7 +356,6 @@ namespace FoundationDB.Client
 			}
 			return t.Task;
 		}
-
 
 		private async Task<VersionStamp?> ReadAndParseMetadataVersionSlow(Slice key)
 		{
@@ -442,7 +440,7 @@ namespace FoundationDB.Client
 			unsafe
 			{
 				// use a 128-bit guid as the source of entropy for our new token
-				Guid rnd = Guid.NewGuid();
+				var rnd = Guid.NewGuid();
 				ulong* p = (ulong*) &rnd;
 				x = p[0] ^ p[1];
 			}
@@ -555,8 +553,8 @@ namespace FoundationDB.Client
 
 		#region GetRange...
 
-		[Pure, NotNull, LinqTunnel]
-		internal FdbRangeQuery<TResult> GetRangeCore<TResult>(KeySelector begin, KeySelector end, FdbRangeOptions options, bool snapshot, [NotNull] Func<KeyValuePair<Slice, Slice>, TResult> selector)
+		[Pure, LinqTunnel]
+		internal FdbRangeQuery<TResult> GetRangeCore<TResult>(KeySelector begin, KeySelector end, FdbRangeOptions? options, bool snapshot, Func<KeyValuePair<Slice, Slice>, TResult> selector)
 		{
 			Contract.Requires(selector != null);
 
@@ -1116,7 +1114,7 @@ namespace FoundationDB.Client
 			}
 		}
 
-		[ContractAnnotation("=> halt")]
+		[DoesNotReturn]
 		internal static void ThrowOnInvalidState(FdbTransaction trans)
 		{
 			switch (trans.State)
@@ -1130,7 +1128,7 @@ namespace FoundationDB.Client
 			}
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		internal static Exception ThrowReadOnlyTransaction(FdbTransaction trans)
 		{
 			return new InvalidOperationException("Cannot write to a read-only transaction");

--- a/FoundationDB.Client/FdbTransactionExtensions.cs
+++ b/FoundationDB.Client/FdbTransactionExtensions.cs
@@ -50,7 +50,7 @@ namespace FoundationDB.Client
 		#region Fluent Options...
 
 		/// <summary>Allows this transaction to read system keys (those that start with the byte 0xFF)</summary>
-		public static TTransaction WithReadAccessToSystemKeys<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithReadAccessToSystemKeys<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.SetOption(Fdb.ApiVersion >= 300 ? FdbTransactionOption.ReadSystemKeys : FdbTransactionOption.AccessSystemKeys);
@@ -59,7 +59,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Allows this transaction to read and modify system keys (those that start with the byte 0xFF)</summary>
-		public static TTransaction WithWriteAccessToSystemKeys<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithWriteAccessToSystemKeys<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbTransaction
 		{
 			trans.SetOption(FdbTransactionOption.AccessSystemKeys);
@@ -68,7 +68,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Specifies that this transaction should be treated as highest priority and that lower priority transactions should block behind this one. Use is discouraged outside of low-level tools</summary>
-		public static TTransaction WithPrioritySystemImmediate<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithPrioritySystemImmediate<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.SetOption(FdbTransactionOption.PrioritySystemImmediate);
@@ -77,7 +77,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Specifies that this transaction should be treated as low priority and that default priority transactions should be processed first. Useful for doing batch work simultaneously with latency-sensitive work</summary>
-		public static TTransaction WithPriorityBatch<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithPriorityBatch<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.SetOption(FdbTransactionOption.PriorityBatch);
@@ -86,7 +86,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Reads performed by a transaction will not see any prior mutations that occurred in that transaction, instead seeing the value which was in the database at the transaction's read version. This option may provide a small performance benefit for the client, but also disables a number of client-side optimizations which are beneficial for transactions which tend to read and write the same keys within a single transaction. Also note that with this option invoked any outstanding reads will return errors when transaction commit is called (rather than the normal behavior of commit waiting for outstanding reads to complete).</summary>
-		public static TTransaction WithReadYourWritesDisable<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithReadYourWritesDisable<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbTransaction
 		{
 			trans.SetOption(FdbTransactionOption.ReadYourWritesDisable);
@@ -94,7 +94,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Snapshot reads performed by a transaction will see the results of writes done in the same transaction.</summary>
-		public static TTransaction WithSnapshotReadYourWritesEnable<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithSnapshotReadYourWritesEnable<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.SetOption(FdbTransactionOption.SnapshotReadYourWriteEnable);
@@ -102,7 +102,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Reads performed by a transaction will not see the results of writes done in the same transaction.</summary>
-		public static TTransaction WithSnapshotReadYourWritesDisable<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithSnapshotReadYourWritesDisable<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.SetOption(FdbTransactionOption.SnapshotReadYourWriteDisable);
@@ -110,7 +110,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Disables read-ahead caching for range reads. Under normal operation, a transaction will read extra rows from the database into cache if range reads are used to page through a series of data one row at a time (i.e. if a range read with a one row limit is followed by another one row range read starting immediately after the result of the first).</summary>
-		public static TTransaction WithReadAheadDisable<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithReadAheadDisable<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.SetOption(FdbTransactionOption.ReadAheadDisable);
@@ -118,7 +118,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>The next write performed on this transaction will not generate a write conflict range. As a result, other transactions which read the key(s) being modified by the next write will not conflict with this transaction. Care needs to be taken when using this option on a transaction that is shared between multiple threads. When setting this option, write conflict ranges will be disabled on the next write operation, regardless of what thread it is on.</summary>
-		public static TTransaction WithNextWriteNoWriteConflictRange<TTransaction>([NotNull] this TTransaction trans)
+		public static TTransaction WithNextWriteNoWriteConflictRange<TTransaction>(this TTransaction trans)
 			where TTransaction : IFdbTransaction
 		{
 			trans.SetOption(FdbTransactionOption.NextWriteNoWriteConflictRange);
@@ -133,7 +133,7 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="timeout">Timeout (with millisecond precision), or TimeSpan.Zero for infinite timeout</param>
-		public static TTransaction WithTimeout<TTransaction>([NotNull] this TTransaction trans, TimeSpan timeout)
+		public static TTransaction WithTimeout<TTransaction>(this TTransaction trans, TimeSpan timeout)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			return WithTimeout<TTransaction>(trans, timeout == TimeSpan.Zero ? 0 : (int)Math.Ceiling(timeout.TotalMilliseconds));
@@ -147,7 +147,7 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="milliseconds">Timeout in millisecond, or 0 for infinite timeout</param>
-		public static TTransaction WithTimeout<TTransaction>([NotNull] this TTransaction trans, int milliseconds)
+		public static TTransaction WithTimeout<TTransaction>(this TTransaction trans, int milliseconds)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.Timeout = milliseconds;
@@ -157,7 +157,7 @@ namespace FoundationDB.Client
 		/// <summary>Set a maximum number of retries after which additional calls to onError will throw the most recently seen error code.
 		/// Valid parameter values are [-1, int.MaxValue].
 		/// If set to -1, will disable the retry limit.</summary>
-		public static TTransaction WithRetryLimit<TTransaction>([NotNull] this TTransaction trans, int retries)
+		public static TTransaction WithRetryLimit<TTransaction>(this TTransaction trans, int retries)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.RetryLimit = retries;
@@ -168,7 +168,7 @@ namespace FoundationDB.Client
 		/// Defaults to 1000 ms. Valid parameter values are [0, int.MaxValue].
 		/// If the maximum retry delay is less than the current retry delay of the transaction, then the current retry delay will be clamped to the maximum retry delay.
 		/// </summary>
-		public static TTransaction WithMaxRetryDelay<TTransaction>([NotNull] this TTransaction trans, int milliseconds)
+		public static TTransaction WithMaxRetryDelay<TTransaction>(this TTransaction trans, int milliseconds)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			trans.MaxRetryDelay = milliseconds;
@@ -179,7 +179,7 @@ namespace FoundationDB.Client
 		/// Defaults to 1000 ms. Valid parameter values are [TimeSpan.Zero, TimeSpan.MaxValue].
 		/// If the maximum retry delay is less than the current retry delay of the transaction, then the current retry delay will be clamped to the maximum retry delay.
 		/// </summary>
-		public static TTransaction WithMaxRetryDelay<TTransaction>([NotNull] this TTransaction trans, TimeSpan delay)
+		public static TTransaction WithMaxRetryDelay<TTransaction>(this TTransaction trans, TimeSpan delay)
 			where TTransaction : IFdbReadOnlyTransaction
 		{
 			return WithMaxRetryDelay<TTransaction>(trans, delay == TimeSpan.Zero ? 0 : (int)Math.Ceiling(delay.TotalMilliseconds));
@@ -197,7 +197,7 @@ namespace FoundationDB.Client
 		/// <exception cref="System.OperationCanceledException">If the cancellation token is already triggered</exception>
 		/// <exception cref="System.ObjectDisposedException">If the transaction has already been completed</exception>
 		/// <exception cref="System.InvalidOperationException">If the operation method is called from the Network Thread</exception>
-		public static Task<Slice> GetAsync([NotNull] this IFdbReadOnlyTransaction trans, Slice key)
+		public static Task<Slice> GetAsync(this IFdbReadOnlyTransaction trans, Slice key)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			return trans.GetAsync(key.Span);
@@ -213,7 +213,7 @@ namespace FoundationDB.Client
 		/// <exception cref="System.OperationCanceledException">If the cancellation token is already triggered</exception>
 		/// <exception cref="System.ObjectDisposedException">If the transaction has already been completed</exception>
 		/// <exception cref="System.InvalidOperationException">If the operation method is called from the Network Thread</exception>
-		public static async Task<TValue> GetAsync<TValue>([NotNull] this IFdbReadOnlyTransaction trans, Slice key, [NotNull] IValueEncoder<TValue> encoder)
+		public static async Task<TValue> GetAsync<TValue>(this IFdbReadOnlyTransaction trans, Slice key, IValueEncoder<TValue> encoder)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(encoder, nameof(encoder));
@@ -242,7 +242,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key to be inserted into the database.</param>
 		/// <param name="value">Value to be inserted into the database.</param>
-		public static void Set([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		public static void Set(this IFdbTransaction trans, Slice key, Slice value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			if (value.IsNull) throw Fdb.Errors.ValueCannotBeNull();
@@ -256,7 +256,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key to be inserted into the database.</param>
 		/// <param name="value">Value to be inserted into the database.</param>
-		public static void Set([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, Slice value)
+		public static void Set(this IFdbTransaction trans, ReadOnlySpan<byte> key, Slice value)
 		{
 			if (value.IsNull) throw Fdb.Errors.ValueCannotBeNull();
 			trans.Set(key, value.Span);
@@ -269,7 +269,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key to be inserted into the database.</param>
 		/// <param name="value">Value to be inserted into the database.</param>
-		public static void Set([NotNull] this IFdbTransaction trans, Slice key, ReadOnlySpan<byte> value)
+		public static void Set(this IFdbTransaction trans, Slice key, ReadOnlySpan<byte> value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			trans.Set(key.Span, value);
@@ -281,7 +281,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Key to set</param>
 		/// <param name="value">Value of the key</param>
 		/// <param name="encoder">Encoder used to convert <paramref name="value"/> into a binary slice.</param>
-		public static void Set<TValue>([NotNull] this IFdbTransaction trans, Slice key, TValue value, [NotNull] IValueEncoder<TValue> encoder)
+		public static void Set<TValue>(this IFdbTransaction trans, Slice key, TValue value, IValueEncoder<TValue> encoder)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(encoder, nameof(encoder));
@@ -296,7 +296,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Key to set</param>
 		/// <param name="data">Stream that holds the content of the key, whose length should not exceed the allowed maximum value size.</param>
 		/// <remarks>This method works best with streams that do not block, like a <see cref="MemoryStream"/>. For streams that may block, consider using <see cref="SetAsync(IFdbTransaction, Slice, Stream)"/> instead.</remarks>
-		public static void Set([NotNull] this IFdbTransaction trans, Slice key, [NotNull] Stream data)
+		public static void Set(this IFdbTransaction trans, Slice key, Stream data)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(data, nameof(data));
@@ -314,7 +314,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Key to set</param>
 		/// <param name="data">Stream that holds the content of the key, whose length should not exceed the allowed maximum value size.</param>
 		/// <remarks>If reading from the stream takes more than 5 seconds, the transaction will not be able to commit. For streams that are stored in memory, like a MemoryStream, consider using <see cref="Set(IFdbTransaction, Slice, Stream)"/> instead.</remarks>
-		public static async Task SetAsync([NotNull] this IFdbTransaction trans, Slice key, [NotNull] Stream data)
+		public static async Task SetAsync(this IFdbTransaction trans, Slice key, Stream data)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(data, nameof(data));
@@ -340,7 +340,7 @@ namespace FoundationDB.Client
 		/// </remarks>
 		/// <exception cref="ArgumentNullException">If either <paramref name="trans"/> or <paramref name="keyValuePairs"/> is null.</exception>
 		/// <exception cref="FdbException">If this operation would exceed the maximum allowed size for a transaction.</exception>
-		public static void SetValues([NotNull] this IFdbTransaction trans, KeyValuePair<Slice, Slice>[] keyValuePairs)
+		public static void SetValues(this IFdbTransaction trans, KeyValuePair<Slice, Slice>[] keyValuePairs)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keyValuePairs, nameof(keyValuePairs));
@@ -360,7 +360,7 @@ namespace FoundationDB.Client
 		/// </remarks>
 		/// <exception cref="ArgumentNullException">If either <paramref name="trans"/> or <paramref name="keyValuePairs"/> is null.</exception>
 		/// <exception cref="FdbException">If this operation would exceed the maximum allowed size for a transaction.</exception>
-		public static void SetValues([NotNull] this IFdbTransaction trans, ReadOnlySpan<KeyValuePair<Slice, Slice>> keyValuePairs)
+		public static void SetValues(this IFdbTransaction trans, ReadOnlySpan<KeyValuePair<Slice, Slice>> keyValuePairs)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -381,7 +381,7 @@ namespace FoundationDB.Client
 		/// <exception cref="ArgumentNullException">If either <paramref name="trans"/>, <paramref name="keys"/> or <paramref name="values"/> is null.</exception>
 		/// <exception cref="ArgumentException">If the <paramref name="values"/> does not have the same length as <paramref name="keys"/>.</exception>
 		/// <exception cref="FdbException">If this operation would exceed the maximum allowed size for a transaction.</exception>
-		public static void SetValues([NotNull] this IFdbTransaction trans, [NotNull] Slice[] keys, [NotNull] Slice[] values)
+		public static void SetValues(this IFdbTransaction trans, Slice[] keys, Slice[] values)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keys, nameof(keys));
@@ -405,7 +405,7 @@ namespace FoundationDB.Client
 		/// <exception cref="ArgumentNullException">If either <paramref name="trans"/>, <paramref name="keys"/> or <paramref name="values"/> is null.</exception>
 		/// <exception cref="ArgumentException">If the <paramref name="values"/> does not have the same length as <paramref name="keys"/>.</exception>
 		/// <exception cref="FdbException">If this operation would exceed the maximum allowed size for a transaction.</exception>
-		public static void SetValues([NotNull] this IFdbTransaction trans, ReadOnlySpan<Slice> keys, ReadOnlySpan<Slice> values)
+		public static void SetValues(this IFdbTransaction trans, ReadOnlySpan<Slice> keys, ReadOnlySpan<Slice> values)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (values.Length != keys.Length) throw new ArgumentException("Both key and value arrays must have the same size.", nameof(values));
@@ -425,7 +425,7 @@ namespace FoundationDB.Client
 		/// </remarks>
 		/// <exception cref="ArgumentNullException">If either <paramref name="trans"/> or <paramref name="keyValuePairs"/> is null.</exception>
 		/// <exception cref="FdbException">If this operation would exceed the maximum allowed size for a transaction.</exception>
-		public static void SetValues([NotNull] this IFdbTransaction trans, [NotNull] IEnumerable<KeyValuePair<Slice, Slice>> keyValuePairs)
+		public static void SetValues(this IFdbTransaction trans, IEnumerable<KeyValuePair<Slice, Slice>> keyValuePairs)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keyValuePairs, nameof(keyValuePairs));
@@ -447,7 +447,7 @@ namespace FoundationDB.Client
 		/// <exception cref="ArgumentNullException">If either <paramref name="trans"/>, <paramref name="keys"/> or <paramref name="values"/> is null.</exception>
 		/// <exception cref="ArgumentException">If the <paramref name="values"/> does not have the same number of elements as <paramref name="keys"/>.</exception>
 		/// <exception cref="FdbException">If this operation would exceed the maximum allowed size for a transaction.</exception>
-		public static void SetValues([NotNull] this IFdbTransaction trans, [NotNull] IEnumerable<Slice> keys, [NotNull] IEnumerable<Slice> values)
+		public static void SetValues(this IFdbTransaction trans, IEnumerable<Slice> keys, IEnumerable<Slice> values)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keys, nameof(keys));
@@ -475,7 +475,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="param">Parameter with which the atomic operation will mutate the value associated with key_name.</param>
 		/// <param name="mutation">Type of mutation that should be performed on the key</param>
-		public static void Atomic([NotNull] this IFdbTransaction trans, Slice key, Slice param, FdbMutationType mutation)
+		public static void Atomic(this IFdbTransaction trans, Slice key, Slice param, FdbMutationType mutation)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			trans.Atomic(key.Span, param.Span, mutation);
@@ -485,7 +485,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Value to add to existing value of key.</param>
-		public static void AtomicAdd([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		public static void AtomicAdd(this IFdbTransaction trans, Slice key, Slice value)
 		{
 			trans.Atomic(key, value, FdbMutationType.Add);
 		}
@@ -494,7 +494,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Value to add to existing value of key.</param>
-		public static void AtomicAdd([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+		public static void AtomicAdd(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
 		{
 			trans.Atomic(key, value, FdbMutationType.Add);
 		}
@@ -507,7 +507,7 @@ namespace FoundationDB.Client
 		/// If the <paramref name="key"/> does not exist, or has a different value than <paramref name="comparand"/> then no changes will be performed.
 		/// This method requires API version 610 or greater.
 		/// </remarks>
-		public static void AtomicCompareAndClear([NotNull] this IFdbTransaction trans, Slice key, Slice comparand)
+		public static void AtomicCompareAndClear(this IFdbTransaction trans, Slice key, Slice comparand)
 		{
 			trans.Atomic(key, comparand, FdbMutationType.CompareAndClear);
 		}
@@ -520,7 +520,7 @@ namespace FoundationDB.Client
 		/// If the <paramref name="key"/> does not exist, or has a different value than <paramref name="comparand"/> then no changes will be performed.
 		/// This method requires API version 610 or greater.
 		/// </remarks>
-		public static void AtomicCompareAndClear([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> comparand)
+		public static void AtomicCompareAndClear(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> comparand)
 		{
 			trans.Atomic(key, comparand, FdbMutationType.CompareAndClear);
 		}
@@ -582,7 +582,7 @@ namespace FoundationDB.Client
 		/// <summary>Modify the database snapshot represented by this transaction to increment by one the 32-bit value stored by the given <paramref name="key"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
-		public static void AtomicIncrement32([NotNull] this IFdbTransaction trans, Slice key)
+		public static void AtomicIncrement32(this IFdbTransaction trans, Slice key)
 		{
 			trans.Atomic(key, PlusOne32, FdbMutationType.Add);
 		}
@@ -590,7 +590,7 @@ namespace FoundationDB.Client
 		/// <summary>Modify the database snapshot represented by this transaction to increment by one the 32-bit value stored by the given <paramref name="key"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
-		public static void AtomicIncrement32([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key)
+		public static void AtomicIncrement32(this IFdbTransaction trans, ReadOnlySpan<byte> key)
 		{
 			trans.Atomic(key, PlusOne32.Span, FdbMutationType.Add);
 		}
@@ -598,7 +598,7 @@ namespace FoundationDB.Client
 		/// <summary>Modify the database snapshot represented by this transaction to subtract 1 from the 32-bit value stored by the given <paramref name="key"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
-		public static void AtomicDecrement32([NotNull] this IFdbTransaction trans, Slice key)
+		public static void AtomicDecrement32(this IFdbTransaction trans, Slice key)
 		{
 			trans.Atomic(key, MinusOne32, FdbMutationType.Add);
 		}
@@ -606,7 +606,7 @@ namespace FoundationDB.Client
 		/// <summary>Modify the database snapshot represented by this transaction to subtract 1 from the 32-bit value stored by the given <paramref name="key"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
-		public static void AtomicDecrement32([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key)
+		public static void AtomicDecrement32(this IFdbTransaction trans, ReadOnlySpan<byte> key)
 		{
 			trans.Atomic(key, MinusOne32.Span, FdbMutationType.Add);
 		}
@@ -616,7 +616,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="clearIfZero">If <c>true</c>, automatically clear the key if it reaches zero. If <c>false</c>, the key can remain with a value of 0 in the database.</param>
 		/// <remarks>This method requires API version 610 or greater.</remarks>
-		public static void AtomicDecrement32([NotNull] this IFdbTransaction trans, Slice key, bool clearIfZero)
+		public static void AtomicDecrement32(this IFdbTransaction trans, Slice key, bool clearIfZero)
 		{
 			trans.Atomic(key, MinusOne32, FdbMutationType.Add);
 			if (clearIfZero)
@@ -630,7 +630,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="clearIfZero">If <c>true</c>, automatically clear the key if it reaches zero. If <c>false</c>, the key can remain with a value of 0 in the database.</param>
 		/// <remarks>This method requires API version 610 or greater.</remarks>
-		public static void AtomicDecrement32([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, bool clearIfZero)
+		public static void AtomicDecrement32(this IFdbTransaction trans, ReadOnlySpan<byte> key, bool clearIfZero)
 		{
 			trans.Atomic(key, MinusOne32.Span, FdbMutationType.Add);
 			if (clearIfZero)
@@ -642,7 +642,7 @@ namespace FoundationDB.Client
 		/// <summary>Modify the database snapshot represented by this transaction to add 1 to the 64-bit value stored by the given <paramref name="key"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
-		public static void AtomicIncrement64([NotNull] this IFdbTransaction trans, Slice key)
+		public static void AtomicIncrement64(this IFdbTransaction trans, Slice key)
 		{
 			trans.Atomic(key, PlusOne64, FdbMutationType.Add);
 		}
@@ -650,7 +650,7 @@ namespace FoundationDB.Client
 		/// <summary>Modify the database snapshot represented by this transaction to add 1 to the 64-bit value stored by the given <paramref name="key"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
-		public static void AtomicIncrement64([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key)
+		public static void AtomicIncrement64(this IFdbTransaction trans, ReadOnlySpan<byte> key)
 		{
 			trans.Atomic(key, PlusOne64.Span, FdbMutationType.Add);
 		}
@@ -658,7 +658,7 @@ namespace FoundationDB.Client
 		/// <summary>Modify the database snapshot represented by this transaction to subtract 1 from the 64-bit value stored by the given <paramref name="key"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
-		public static void AtomicDecrement64([NotNull] this IFdbTransaction trans, Slice key)
+		public static void AtomicDecrement64(this IFdbTransaction trans, Slice key)
 		{
 			trans.Atomic(key, MinusOne64, FdbMutationType.Add);
 		}
@@ -666,7 +666,7 @@ namespace FoundationDB.Client
 		/// <summary>Modify the database snapshot represented by this transaction to subtract 1 from the 64-bit value stored by the given <paramref name="key"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
-		public static void AtomicDecrement64([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key)
+		public static void AtomicDecrement64(this IFdbTransaction trans, ReadOnlySpan<byte> key)
 		{
 			trans.Atomic(key, MinusOne64.Span, FdbMutationType.Add);
 		}
@@ -676,7 +676,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="clearIfZero">If <c>true</c>, automatically clear the key if it reaches zero. If <c>false</c>, the key can remain with a value of 0 in the database.</param>
 		/// <remarks>This method requires API version 610 or greater.</remarks>
-		public static void AtomicDecrement64([NotNull] this IFdbTransaction trans, Slice key, bool clearIfZero)
+		public static void AtomicDecrement64(this IFdbTransaction trans, Slice key, bool clearIfZero)
 		{
 			trans.Atomic(key, MinusOne64, FdbMutationType.Add);
 			if (clearIfZero)
@@ -690,7 +690,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="clearIfZero">If <c>true</c>, automatically clear the key if it reaches zero. If <c>false</c>, the key can remain with a value of 0 in the database.</param>
 		/// <remarks>This method requires API version 610 or greater.</remarks>
-		public static void AtomicDecrement64([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, bool clearIfZero)
+		public static void AtomicDecrement64(this IFdbTransaction trans, ReadOnlySpan<byte> key, bool clearIfZero)
 		{
 			trans.Atomic(key, MinusOne64.Span, FdbMutationType.Add);
 			if (clearIfZero)
@@ -703,7 +703,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Integer add to existing value of key. It will encoded as 4 bytes in high-endian.</param>
-		public static void AtomicAdd32([NotNull] this IFdbTransaction trans, Slice key, int value)
+		public static void AtomicAdd32(this IFdbTransaction trans, Slice key, int value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			trans.AtomicAdd32(key.Span, value);
@@ -713,7 +713,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Integer add to existing value of key. It will encoded as 4 bytes in high-endian.</param>
-		public static void AtomicAdd32([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, int value)
+		public static void AtomicAdd32(this IFdbTransaction trans, ReadOnlySpan<byte> key, int value)
 		{
 			if (value == 1)
 			{
@@ -735,7 +735,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Integer add to existing value of key. It will encoded as 4 bytes in high-endian.</param>
-		public static void AtomicAdd32([NotNull] this IFdbTransaction trans, Slice key, uint value)
+		public static void AtomicAdd32(this IFdbTransaction trans, Slice key, uint value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			trans.AtomicAdd32(key.Span, value);
@@ -745,7 +745,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Integer add to existing value of key. It will encoded as 4 bytes in high-endian.</param>
-		public static void AtomicAdd32([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, uint value)
+		public static void AtomicAdd32(this IFdbTransaction trans, ReadOnlySpan<byte> key, uint value)
 		{
 			if (value == 1)
 			{
@@ -767,7 +767,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Integer add to existing value of key. It will encoded as 8 bytes in high-endian.</param>
-		public static void AtomicAdd64([NotNull] this IFdbTransaction trans, Slice key, long value)
+		public static void AtomicAdd64(this IFdbTransaction trans, Slice key, long value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			trans.AtomicAdd64(key.Span, value);
@@ -777,7 +777,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Integer add to existing value of key. It will encoded as 8 bytes in high-endian.</param>
-		public static void AtomicAdd64([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, long value)
+		public static void AtomicAdd64(this IFdbTransaction trans, ReadOnlySpan<byte> key, long value)
 		{
 			if (value == 1)
 			{
@@ -799,7 +799,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Integer add to existing value of key. It will encoded as 8 bytes in high-endian.</param>
-		public static void AtomicAdd64([NotNull] this IFdbTransaction trans, Slice key, ulong value)
+		public static void AtomicAdd64(this IFdbTransaction trans, Slice key, ulong value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			trans.AtomicAdd64(key.Span, value);
@@ -809,7 +809,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Integer add to existing value of key. It will encoded as 8 bytes in high-endian.</param>
-		public static void AtomicAdd64([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ulong value)
+		public static void AtomicAdd64(this IFdbTransaction trans, ReadOnlySpan<byte> key, ulong value)
 		{
 			if (value == 1)
 			{
@@ -831,7 +831,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="mask">Bit mask.</param>
-		public static void AtomicAnd([NotNull] this IFdbTransaction trans, Slice key, Slice mask)
+		public static void AtomicAnd(this IFdbTransaction trans, Slice key, Slice mask)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 
@@ -843,7 +843,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="mask">Bit mask.</param>
-		public static void AtomicOr([NotNull] this IFdbTransaction trans, Slice key, Slice mask)
+		public static void AtomicOr(this IFdbTransaction trans, Slice key, Slice mask)
 		{
 			//TODO: rename this to AtomicBitOr(...) ?
 			trans.Atomic(key, mask, FdbMutationType.BitOr);
@@ -853,7 +853,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="mask">Bit mask.</param>
-		public static void AtomicOr([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> mask)
+		public static void AtomicOr(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> mask)
 		{
 			//TODO: rename this to AtomicBitOr(...) ?
 			trans.Atomic(key, mask, FdbMutationType.BitOr);
@@ -863,7 +863,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="mask">Bit mask.</param>
-		public static void AtomicXor([NotNull] this IFdbTransaction trans, Slice key, Slice mask)
+		public static void AtomicXor(this IFdbTransaction trans, Slice key, Slice mask)
 		{
 			//TODO: rename this to AtomicBitXOr(...) ?
 			trans.Atomic(key, mask, FdbMutationType.BitXor);
@@ -873,7 +873,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="mask">Bit mask.</param>
-		public static void AtomicXor([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> mask)
+		public static void AtomicXor(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> mask)
 		{
 			//TODO: rename this to AtomicBitXOr(...) ?
 			trans.Atomic(key, mask, FdbMutationType.BitXor);
@@ -883,7 +883,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Value to append.</param>
-		public static void AtomicAppendIfFits([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		public static void AtomicAppendIfFits(this IFdbTransaction trans, Slice key, Slice value)
 		{
 			trans.Atomic(key, value, FdbMutationType.AppendIfFits);
 		}
@@ -892,7 +892,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Value to append.</param>
-		public static void AtomicAppendIfFits([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+		public static void AtomicAppendIfFits(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
 		{
 			trans.Atomic(key, value, FdbMutationType.AppendIfFits);
 		}
@@ -901,7 +901,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Bit mask.</param>
-		public static void AtomicMax([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		public static void AtomicMax(this IFdbTransaction trans, Slice key, Slice value)
 		{
 			trans.Atomic(key, value, FdbMutationType.Max);
 		}
@@ -910,7 +910,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Bit mask.</param>
-		public static void AtomicMax([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+		public static void AtomicMax(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
 		{
 			trans.Atomic(key, value, FdbMutationType.Max);
 		}
@@ -919,7 +919,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Bit mask.</param>
-		public static void AtomicMin([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		public static void AtomicMin(this IFdbTransaction trans, Slice key, Slice value)
 		{
 			trans.Atomic(key, value, FdbMutationType.Min);
 		}
@@ -928,7 +928,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Bit mask.</param>
-		public static void AtomicMin([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+		public static void AtomicMin(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
 		{
 			trans.Atomic(key, value, FdbMutationType.Min);
 		}
@@ -972,7 +972,7 @@ namespace FoundationDB.Client
 			return p;
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		private static Exception FailVersionStampNotSupported()
 		{
 			return new NotSupportedException($"VersionStamps are not supported at API version {Fdb.ApiVersion}. You need to select at least API Version 400 or above.");
@@ -982,7 +982,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated. This key must contain a single <see cref="VersionStamp"/>, whose position will be automatically detected.</param>
 		/// <param name="value">New value for this key.</param>
-		public static void SetVersionStampedKey([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		public static void SetVersionStampedKey(this IFdbTransaction trans, Slice key, Slice value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			if (value.IsNull) throw Fdb.Errors.ValueCannotBeNull();
@@ -994,7 +994,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated. This key must contain a single <see cref="VersionStamp"/>, whose position will be automatically detected.</param>
 		/// <param name="value">New value for this key.</param>
-		public static void SetVersionStampedKey([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+		public static void SetVersionStampedKey(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1032,7 +1032,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated. This key must contain a single <see cref="VersionStamp"/>, whose start is defined by <paramref name="stampOffset"/>.</param>
 		/// <param name="stampOffset">Offset in <paramref name="key"/> where the 80-bit VersionStamp is located.</param>
 		/// <param name="value">New value for this key.</param>
-		public static void SetVersionStampedKey([NotNull] this IFdbTransaction trans, Slice key, int stampOffset, Slice value)
+		public static void SetVersionStampedKey(this IFdbTransaction trans, Slice key, int stampOffset, Slice value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			if (value.IsNull) throw Fdb.Errors.ValueCannotBeNull();
@@ -1045,7 +1045,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated. This key must contain a single <see cref="VersionStamp"/>, whose start is defined by <paramref name="stampOffset"/>.</param>
 		/// <param name="stampOffset">Offset in <paramref name="key"/> where the 80-bit VersionStamp is located.</param>
 		/// <param name="value">New value for this key.</param>
-		public static void SetVersionStampedKey([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, int stampOffset, ReadOnlySpan<byte> value)
+		public static void SetVersionStampedKey(this IFdbTransaction trans, ReadOnlySpan<byte> key, int stampOffset, ReadOnlySpan<byte> value)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.Positive(stampOffset, nameof(stampOffset));
@@ -1080,7 +1080,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Value whose first 10 bytes will be overwritten by the database with the resolved VersionStamp at commit time. The rest of the value will be untouched.</param>
-		public static void SetVersionStampedValue([NotNull] this IFdbTransaction trans, Slice key, Slice value)
+		public static void SetVersionStampedValue(this IFdbTransaction trans, Slice key, Slice value)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			if (value.IsNull) throw Fdb.Errors.ValueCannotBeNull();
@@ -1092,7 +1092,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Value whose first 10 bytes will be overwritten by the database with the resolved VersionStamp at commit time. The rest of the value will be untouched.</param>
-		public static void SetVersionStampedValue([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+		public static void SetVersionStampedValue(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (value.Length < 10) throw new ArgumentException("The value must be at least 10 bytes long.", nameof(value));
@@ -1131,7 +1131,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Value of the key. The 10 bytes starting at <paramref name="stampOffset"/> will be overwritten by the database with the resolved VersionStamp at commit time. The rest of the value will be untouched.</param>
 		/// <param name="stampOffset">Offset in <paramref name="value"/> where the 80-bit VersionStamp is located. Prior to API version 520, it can only be located at offset 0.</param>
-		public static void SetVersionStampedValue([NotNull] this IFdbTransaction trans, Slice key, Slice value, int stampOffset)
+		public static void SetVersionStampedValue(this IFdbTransaction trans, Slice key, Slice value, int stampOffset)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			if (value.IsNull) throw Fdb.Errors.ValueCannotBeNull();
@@ -1144,7 +1144,7 @@ namespace FoundationDB.Client
 		/// <param name="key">Name of the key whose value is to be mutated.</param>
 		/// <param name="value">Value of the key. The 10 bytes starting at <paramref name="stampOffset"/> will be overwritten by the database with the resolved VersionStamp at commit time. The rest of the value will be untouched.</param>
 		/// <param name="stampOffset">Offset in <paramref name="value"/> where the 80-bit VersionStamp is located. Prior to API version 520, it can only be located at offset 0.</param>
-		public static void SetVersionStampedValue([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, int stampOffset)
+		public static void SetVersionStampedValue(this IFdbTransaction trans, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, int stampOffset)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.Positive(stampOffset, nameof(stampOffset));
@@ -1179,7 +1179,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
 		[Obsolete("Use the overload that takes an FdbRangeOptions argument, or use LINQ to configure the query!")]
-		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange([NotNull] this IFdbReadOnlyTransaction trans, KeySelector beginInclusive, KeySelector endExclusive, int limit, bool reverse = false)
+		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange(this IFdbReadOnlyTransaction trans, KeySelector beginInclusive, KeySelector endExclusive, int limit, bool reverse = false)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1187,20 +1187,20 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
-		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange([NotNull] this IFdbReadOnlyTransaction trans, KeyRange range, FdbRangeOptions? options = null)
+		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange(this IFdbReadOnlyTransaction trans, KeyRange range, FdbRangeOptions? options = null)
 		{
 			return GetRange(trans, KeySelectorPair.Create(range), options);
 		}
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
 		[Obsolete("Use the overload that takes an FdbRangeOptions argument, or use LINQ to configure the query!")]
-		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange([NotNull] this IFdbReadOnlyTransaction trans, KeyRange range, int limit, bool reverse = false)
+		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange(this IFdbReadOnlyTransaction trans, KeyRange range, int limit, bool reverse = false)
 		{
 			return GetRange(trans, range, new FdbRangeOptions(limit: limit, reverse: reverse));
 		}
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
-		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange([NotNull] this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, FdbRangeOptions? options = null)
+		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange(this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1216,13 +1216,13 @@ namespace FoundationDB.Client
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
 		[Obsolete("Use the overload that takes an FdbRangeOptions argument, or use LINQ to configure the query!")]
-		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange([NotNull] this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, int limit, bool reverse = false)
+		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange(this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, int limit, bool reverse = false)
 		{
 			return GetRange(trans, beginKeyInclusive, endKeyExclusive, new FdbRangeOptions(limit: limit, reverse: reverse));
 		}
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
-		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange([NotNull] this IFdbReadOnlyTransaction trans, KeySelectorPair range, FdbRangeOptions? options = null)
+		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange(this IFdbReadOnlyTransaction trans, KeySelectorPair range, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1234,13 +1234,13 @@ namespace FoundationDB.Client
 		#region GetRange<T>...
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
-		public static FdbRangeQuery<TResult> GetRange<TResult>([NotNull] this IFdbReadOnlyTransaction trans, KeyRange range, Func<KeyValuePair<Slice, Slice>, TResult> transform, FdbRangeOptions? options = null)
+		public static FdbRangeQuery<TResult> GetRange<TResult>(this IFdbReadOnlyTransaction trans, KeyRange range, Func<KeyValuePair<Slice, Slice>, TResult> transform, FdbRangeOptions? options = null)
 		{
 			return GetRange(trans, KeySelectorPair.Create(range), transform, options);
 		}
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
-		public static FdbRangeQuery<TResult> GetRange<TResult>([NotNull] this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, Func<KeyValuePair<Slice, Slice>, TResult> transform, FdbRangeOptions? options = null)
+		public static FdbRangeQuery<TResult> GetRange<TResult>(this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, Func<KeyValuePair<Slice, Slice>, TResult> transform, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1256,7 +1256,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a new range query that will read all key-value pairs in the database snapshot represented by the transaction</summary>
-		public static FdbRangeQuery<TResult> GetRange<TResult>([NotNull] this IFdbReadOnlyTransaction trans, KeySelectorPair range, Func<KeyValuePair<Slice, Slice>, TResult> transform, FdbRangeOptions? options = null)
+		public static FdbRangeQuery<TResult> GetRange<TResult>(this IFdbReadOnlyTransaction trans, KeySelectorPair range, Func<KeyValuePair<Slice, Slice>, TResult> transform, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1269,16 +1269,16 @@ namespace FoundationDB.Client
 
 		private static readonly Func<KeyValuePair<Slice, Slice>, Slice> KeyValuePairToKey = (kv) => kv.Key;
 
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> OnlyKeys([NotNull] this FdbRangeQuery<KeyValuePair<Slice, Slice>> query)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> OnlyKeys(this FdbRangeQuery<KeyValuePair<Slice, Slice>> query)
 		{
 			if (query.Read == FdbReadMode.Values) throw new InvalidOperationException("Cannot extract keys because the source query only read the values.");
 			return new FdbRangeQuery<Slice>(query.Transaction, query.Begin, query.End, KeyValuePairToKey, query.Snapshot, query.Options.OnlyKeys());
 		}
 
 		/// <summary>Create a new range query that will read the keys of all key-value pairs in the database snapshot represented by the transaction</summary>
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> GetRangeKeys([NotNull] this IFdbReadOnlyTransaction trans, KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions? options = null)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> GetRangeKeys(this IFdbReadOnlyTransaction trans, KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			return trans.GetRange(
@@ -1290,8 +1290,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a new range query that will read the keys of all key-value pairs in the database snapshot represented by the transaction</summary>
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> GetRangeKeys([NotNull] this IFdbReadOnlyTransaction trans, KeyRange range, FdbRangeOptions? options = null)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> GetRangeKeys(this IFdbReadOnlyTransaction trans, KeyRange range, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			var selectors = KeySelectorPair.Create(range);
@@ -1304,8 +1304,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a new range query that will read the keys of all key-value pairs in the database snapshot represented by the transaction</summary>
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> GetRangeKeys([NotNull] this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, FdbRangeOptions? options = null)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> GetRangeKeys(this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			return trans.GetRange(
@@ -1317,8 +1317,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a new range query that will read the keys of all key-value pairs in the database snapshot represented by the transaction</summary>
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> GetRangeKeys([NotNull] this IFdbReadOnlyTransaction trans, KeySelectorPair range, FdbRangeOptions? options = null)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> GetRangeKeys(this IFdbReadOnlyTransaction trans, KeySelectorPair range, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			return trans.GetRange(
@@ -1335,16 +1335,16 @@ namespace FoundationDB.Client
 
 		private static readonly Func<KeyValuePair<Slice, Slice>, Slice> KeyValuePairToValue = (kv) => kv.Value;
 
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> OnlyValues([NotNull] this FdbRangeQuery<KeyValuePair<Slice, Slice>> query)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> OnlyValues(this FdbRangeQuery<KeyValuePair<Slice, Slice>> query)
 		{
 			if (query.Read == FdbReadMode.Keys) throw new InvalidOperationException("Cannot extract values because the source query only read the keys.");
 			return new FdbRangeQuery<Slice>(query.Transaction, query.Begin, query.End, KeyValuePairToValue, query.Snapshot, query.Options.OnlyValues());
 		}
 
 		/// <summary>Create a new range query that will read the values of all key-value pairs in the database snapshot represented by the transaction</summary>
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> GetRangeValues([NotNull] this IFdbReadOnlyTransaction trans, KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions? options = null)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> GetRangeValues(this IFdbReadOnlyTransaction trans, KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			return trans.GetRange(
@@ -1356,8 +1356,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a new range query that will read the values of all key-value pairs in the database snapshot represented by the transaction</summary>
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> GetRangeValues([NotNull] this IFdbReadOnlyTransaction trans, KeyRange range, FdbRangeOptions? options = null)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> GetRangeValues(this IFdbReadOnlyTransaction trans, KeyRange range, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			var selectors = KeySelectorPair.Create(range);
@@ -1370,8 +1370,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a new range query that will read the values of all key-value pairs in the database snapshot represented by the transaction</summary>
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> GetRangeValues([NotNull] this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, FdbRangeOptions? options = null)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> GetRangeValues(this IFdbReadOnlyTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			return trans.GetRange(
@@ -1383,8 +1383,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a new range query that will read the values of all key-value pairs in the database snapshot represented by the transaction</summary>
-		[Pure, NotNull, LinqTunnel]
-		public static FdbRangeQuery<Slice> GetRangeValues([NotNull] this IFdbReadOnlyTransaction trans, KeySelectorPair range, FdbRangeOptions? options = null)
+		[Pure, LinqTunnel]
+		public static FdbRangeQuery<Slice> GetRangeValues(this IFdbReadOnlyTransaction trans, KeySelectorPair range, FdbRangeOptions? options = null)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			return trans.GetRange(
@@ -1409,7 +1409,7 @@ namespace FoundationDB.Client
 		/// <param name="options">Optional query options (Limit, TargetBytes, Mode, Reverse, ...)</param>
 		/// <param name="iteration">If streaming mode is FdbStreamingMode.Iterator, this parameter should start at 1 and be incremented by 1 for each successive call while reading this range. In all other cases it is ignored.</param>
 		/// <returns></returns>
-		public static Task<FdbRangeChunk> GetRangeAsync([NotNull] this IFdbReadOnlyTransaction trans, KeySelectorPair range, FdbRangeOptions? options = null, int iteration = 0)
+		public static Task<FdbRangeChunk> GetRangeAsync(this IFdbReadOnlyTransaction trans, KeySelectorPair range, FdbRangeOptions? options = null, int iteration = 0)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1426,7 +1426,7 @@ namespace FoundationDB.Client
 		/// <param name="options">Optional query options (Limit, TargetBytes, Mode, Reverse, ...)</param>
 		/// <param name="iteration">If streaming mode is FdbStreamingMode.Iterator, this parameter should start at 1 and be incremented by 1 for each successive call while reading this range. In all other cases it is ignored.</param>
 		/// <returns></returns>
-		public static Task<FdbRangeChunk> GetRangeAsync([NotNull] this IFdbReadOnlyTransaction trans, KeyRange range, FdbRangeOptions? options = null, int iteration = 0)
+		public static Task<FdbRangeChunk> GetRangeAsync(this IFdbReadOnlyTransaction trans, KeyRange range, FdbRangeOptions? options = null, int iteration = 0)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1445,7 +1445,7 @@ namespace FoundationDB.Client
 		/// <param name="options">Optional query options (Limit, TargetBytes, Mode, Reverse, ...)</param>
 		/// <param name="iteration">If streaming mode is FdbStreamingMode.Iterator, this parameter should start at 1 and be incremented by 1 for each successive call while reading this range. In all other cases it is ignored.</param>
 		/// <returns></returns>
-		public static Task<FdbRangeChunk> GetRangeAsync([NotNull] this IFdbReadOnlyTransaction trans, Slice beginInclusive, Slice endExclusive, FdbRangeOptions? options = null, int iteration = 0)
+		public static Task<FdbRangeChunk> GetRangeAsync(this IFdbReadOnlyTransaction trans, Slice beginInclusive, Slice endExclusive, FdbRangeOptions? options = null, int iteration = 0)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1461,8 +1461,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key whose location is to be queried.</param>
 		/// <returns>Task that will return an array of strings, or an exception</returns>
-		[ItemNotNull]
-		public static Task<string[]> GetAddressesForKeyAsync([NotNull] this IFdbReadOnlyTransaction trans, Slice key)
+		public static Task<string[]> GetAddressesForKeyAsync(this IFdbReadOnlyTransaction trans, Slice key)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
 			return trans.GetAddressesForKeyAsync(key.Span);
@@ -1477,7 +1476,7 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="key">Name of the key to be removed from the database.</param>
-		public static void Clear([NotNull] this IFdbTransaction trans, Slice key)
+		public static void Clear(this IFdbTransaction trans, Slice key)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull(nameof(key));
 
@@ -1494,7 +1493,7 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="range">Pair of keys defining the range to clear.</param>
-		public static void ClearRange([NotNull] this IFdbTransaction trans, KeyRange range)
+		public static void ClearRange(this IFdbTransaction trans, KeyRange range)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -1508,7 +1507,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="beginKeyInclusive">Name of the key specifying the beginning of the range to clear.</param>
 		/// <param name="endKeyExclusive">Name of the key specifying the end of the range to clear.</param>
-		public static void ClearRange([NotNull] this IFdbTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive)
+		public static void ClearRange(this IFdbTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive)
 		{
 			if (beginKeyInclusive.IsNull) throw Fdb.Errors.KeyCannotBeNull(nameof(beginKeyInclusive));
 			if (endKeyExclusive.IsNull) throw Fdb.Errors.KeyCannotBeNull(nameof(endKeyExclusive));
@@ -1527,7 +1526,7 @@ namespace FoundationDB.Client
 		/// <param name="beginKeyInclusive">Key specifying the beginning of the conflict range. The key is included</param>
 		/// <param name="endKeyExclusive">Key specifying the end of the conflict range. The key is excluded</param>
 		/// <param name="type">One of the <see cref="FdbConflictRangeType"/> values indicating what type of conflict range is being set.</param>
-		public static void AddConflictRange([NotNull] this IFdbTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, FdbConflictRangeType type)
+		public static void AddConflictRange(this IFdbTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive, FdbConflictRangeType type)
 		{
 			if (beginKeyInclusive.IsNull) throw Fdb.Errors.KeyCannotBeNull(nameof(beginKeyInclusive));
 			if (endKeyExclusive.IsNull) throw Fdb.Errors.KeyCannotBeNull(nameof(endKeyExclusive));
@@ -1541,7 +1540,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="range">Range of the keys specifying the conflict range. The end key is excluded</param>
 		/// <param name="type">One of the FDBConflictRangeType values indicating what type of conflict range is being set.</param>
-		public static void AddConflictRange([NotNull] this IFdbTransaction trans, KeyRange range, FdbConflictRangeType type)
+		public static void AddConflictRange(this IFdbTransaction trans, KeyRange range, FdbConflictRangeType type)
 		{
 			trans.AddConflictRange(range.Begin, range.End.HasValue ? range.End : FdbKey.MaxValue, type);
 		}
@@ -1549,7 +1548,7 @@ namespace FoundationDB.Client
 		/// <summary>
 		/// Adds a range of keys to the transaction’s read conflict ranges as if you had read the range. As a result, other transactions that write a key in this range could cause the transaction to fail with a conflict.
 		/// </summary>
-		public static void AddReadConflictRange([NotNull] this IFdbTransaction trans, KeyRange range)
+		public static void AddReadConflictRange(this IFdbTransaction trans, KeyRange range)
 		{
 			AddConflictRange(trans, range, FdbConflictRangeType.Read);
 		}
@@ -1557,7 +1556,7 @@ namespace FoundationDB.Client
 		/// <summary>
 		/// Adds a range of keys to the transaction’s read conflict ranges as if you had read the range. As a result, other transactions that write a key in this range could cause the transaction to fail with a conflict.
 		/// </summary>
-		public static void AddReadConflictRange([NotNull] this IFdbTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive)
+		public static void AddReadConflictRange(this IFdbTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive)
 		{
 			trans.AddConflictRange(beginKeyInclusive, endKeyExclusive, FdbConflictRangeType.Read);
 		}
@@ -1565,7 +1564,7 @@ namespace FoundationDB.Client
 		/// <summary>
 		/// Adds a range of keys to the transaction’s read conflict ranges as if you had read the range. As a result, other transactions that write a key in this range could cause the transaction to fail with a conflict.
 		/// </summary>
-		public static void AddReadConflictRange([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> beginKeyInclusive, ReadOnlySpan<byte> endKeyExclusive)
+		public static void AddReadConflictRange(this IFdbTransaction trans, ReadOnlySpan<byte> beginKeyInclusive, ReadOnlySpan<byte> endKeyExclusive)
 		{
 			trans.AddConflictRange(beginKeyInclusive, endKeyExclusive, FdbConflictRangeType.Read);
 		}
@@ -1573,7 +1572,7 @@ namespace FoundationDB.Client
 		/// <summary>
 		/// Adds a key to the transaction’s read conflict ranges as if you had read the key. As a result, other transactions that write to this key could cause the transaction to fail with a conflict.
 		/// </summary>
-		public static void AddReadConflictKey([NotNull] this IFdbTransaction trans, Slice key)
+		public static void AddReadConflictKey(this IFdbTransaction trans, Slice key)
 		{
 			AddConflictRange(trans, KeyRange.FromKey(key), FdbConflictRangeType.Read);
 		}
@@ -1581,7 +1580,7 @@ namespace FoundationDB.Client
 		/// <summary>
 		/// Adds a range of keys to the transaction’s write conflict ranges as if you had cleared the range. As a result, other transactions that concurrently read a key in this range could fail with a conflict.
 		/// </summary>
-		public static void AddWriteConflictRange([NotNull] this IFdbTransaction trans, KeyRange range)
+		public static void AddWriteConflictRange(this IFdbTransaction trans, KeyRange range)
 		{
 			AddConflictRange(trans, range, FdbConflictRangeType.Write);
 		}
@@ -1589,7 +1588,7 @@ namespace FoundationDB.Client
 		/// <summary>
 		/// Adds a range of keys to the transaction’s write conflict ranges as if you had cleared the range. As a result, other transactions that concurrently read a key in this range could fail with a conflict.
 		/// </summary>
-		public static void AddWriteConflictRange([NotNull] this IFdbTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive)
+		public static void AddWriteConflictRange(this IFdbTransaction trans, Slice beginKeyInclusive, Slice endKeyExclusive)
 		{
 			trans.AddConflictRange(beginKeyInclusive, endKeyExclusive, FdbConflictRangeType.Write);
 		}
@@ -1597,7 +1596,7 @@ namespace FoundationDB.Client
 		/// <summary>
 		/// Adds a range of keys to the transaction’s write conflict ranges as if you had cleared the range. As a result, other transactions that concurrently read a key in this range could fail with a conflict.
 		/// </summary>
-		public static void AddWriteConflictRange([NotNull] this IFdbTransaction trans, ReadOnlySpan<byte> beginKeyInclusive, ReadOnlySpan<byte> endKeyExclusive)
+		public static void AddWriteConflictRange(this IFdbTransaction trans, ReadOnlySpan<byte> beginKeyInclusive, ReadOnlySpan<byte> endKeyExclusive)
 		{
 			trans.AddConflictRange(beginKeyInclusive, endKeyExclusive, FdbConflictRangeType.Write);
 		}
@@ -1605,7 +1604,7 @@ namespace FoundationDB.Client
 		/// <summary>
 		/// Adds a key to the transaction’s write conflict ranges as if you had cleared the key. As a result, other transactions that concurrently read this key could fail with a conflict.
 		/// </summary>
-		public static void AddWriteConflictKey([NotNull] this IFdbTransaction trans, Slice key)
+		public static void AddWriteConflictKey(this IFdbTransaction trans, Slice key)
 		{
 			AddConflictRange(trans, KeyRange.FromKey(key), FdbConflictRangeType.Write);
 		}
@@ -1620,7 +1619,7 @@ namespace FoundationDB.Client
 		/// <param name="ct">CancellationToken used to abort the watch if the caller doesn't want to wait anymore. Note that you can manually cancel the watch by calling Cancel() on the returned FdbWatch instance</param>
 		/// <returns>FdbWatch that can be awaited and will complete when the key has changed in the database, or cancellation occurs. You can call Cancel() at any time if you are not interested in watching the key anymore. You MUST always call Dispose() if the watch completes or is cancelled, to ensure that resources are released properly.</returns>
 		/// <remarks>You can directly await an FdbWatch, or obtain a Task&lt;Slice&gt; by reading the <see cref="FdbWatch.Task"/> property.</remarks>
-		[Pure, NotNull]
+		[Pure]
 		public static FdbWatch Watch(this IFdbTransaction trans, Slice key, CancellationToken ct)
 		{
 			if (key.IsNull) throw Fdb.Errors.KeyCannotBeNull();
@@ -1637,8 +1636,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="keys">Sequence of keys to be looked up in the database</param>
 		/// <returns>Task that will return an array of values, or an exception. The position of each item in the array is the same as its corresponding key in <paramref name="keys"/>. If a key does not exist in the database, its value will be Slice.Nil.</returns>
-		[ItemNotNull]
-		public static Task<Slice[]> GetValuesAsync([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<Slice> keys)
+		public static Task<Slice[]> GetValuesAsync(this IFdbReadOnlyTransaction trans, IEnumerable<Slice> keys)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keys, nameof(keys));
@@ -1655,8 +1653,7 @@ namespace FoundationDB.Client
 		/// <param name="keys">Sequence of keys to be looked up in the database</param>
 		/// <param name="decoder">Decoder used to decoded the results into values of type <typeparamref name="TValue"/></param>
 		/// <returns>Task that will return an array of decoded values, or an exception. The position of each item in the array is the same as its corresponding key in <paramref name="keys"/>. If a key does not exist in the database, its value depends on the behavior of <paramref name="decoder"/>.</returns>
-		[ItemNotNull]
-		public static async Task<TValue[]> GetValuesAsync<TValue>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<Slice> keys, [NotNull] IValueEncoder<TValue> decoder)
+		public static async Task<TValue[]> GetValuesAsync<TValue>(this IFdbReadOnlyTransaction trans, IEnumerable<Slice> keys, IValueEncoder<TValue> decoder)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(decoder, nameof(decoder));
@@ -1670,8 +1667,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="selectors">Sequence of key selectors to resolve</param>
 		/// <returns>Task that will return an array of keys matching the selectors, or an exception</returns>
-		[ItemNotNull]
-		public static Task<Slice[]> GetKeysAsync([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<KeySelector> selectors)
+		public static Task<Slice[]> GetKeysAsync(this IFdbReadOnlyTransaction trans, IEnumerable<KeySelector> selectors)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(selectors, nameof(selectors));
@@ -1688,8 +1684,7 @@ namespace FoundationDB.Client
 		/// <param name="keys">Sequence of keys to be looked up in the database</param>
 		/// <returns>Task that will return an array of key/value pairs, or an exception. Each pair in the array will contain the key at the same index in <paramref name="keys"/>, and its corresponding value in the database or Slice.Nil if that key does not exist.</returns>
 		/// <remarks>This method is equivalent to calling <see cref="IFdbReadOnlyTransaction.GetValuesAsync"/>, except that it will return the keys in addition to the values.</remarks>
-		[ItemNotNull]
-		public static Task<KeyValuePair<Slice, Slice>[]> GetBatchAsync([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<Slice> keys)
+		public static Task<KeyValuePair<Slice, Slice>[]> GetBatchAsync(this IFdbReadOnlyTransaction trans, IEnumerable<Slice> keys)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keys, nameof(keys));
@@ -1706,8 +1701,7 @@ namespace FoundationDB.Client
 		/// <param name="keys">Array of keys to be looked up in the database</param>
 		/// <returns>Task that will return an array of key/value pairs, or an exception. Each pair in the array will contain the key at the same index in <paramref name="keys"/>, and its corresponding value in the database or Slice.Nil if that key does not exist.</returns>
 		/// <remarks>This method is equivalent to calling <see cref="IFdbReadOnlyTransaction.GetValuesAsync"/>, except that it will return the keys in addition to the values.</remarks>
-		[ItemNotNull]
-		public static async Task<KeyValuePair<Slice, Slice>[]> GetBatchAsync([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] Slice[] keys)
+		public static async Task<KeyValuePair<Slice, Slice>[]> GetBatchAsync(this IFdbReadOnlyTransaction trans, Slice[] keys)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keys, nameof(keys));
@@ -1730,8 +1724,7 @@ namespace FoundationDB.Client
 		/// <param name="keys">Array of keys to be looked up in the database</param>
 		/// <param name="decoder">Decoder used to decoded the results into values of type <typeparamref name="TValue"/></param>
 		/// <returns>Task that will return an array of pairs of key and decoded values, or an exception. The position of each item in the array is the same as its corresponding key in <paramref name="keys"/>. If a key does not exist in the database, its value depends on the behavior of <paramref name="decoder"/>.</returns>
-		[ItemNotNull]
-		public static Task<KeyValuePair<Slice, TValue>[]> GetBatchAsync<TValue>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<Slice> keys, [NotNull] IValueEncoder<TValue> decoder)
+		public static Task<KeyValuePair<Slice, TValue>[]> GetBatchAsync<TValue>(this IFdbReadOnlyTransaction trans, IEnumerable<Slice> keys, IValueEncoder<TValue> decoder)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keys, nameof(keys));
@@ -1748,8 +1741,7 @@ namespace FoundationDB.Client
 		/// <param name="keys">Sequence of keys to be looked up in the database</param>
 		/// <param name="decoder">Decoder used to decoded the results into values of type <typeparamref name="TValue"/></param>
 		/// <returns>Task that will return an array of pairs of key and decoded values, or an exception. The position of each item in the array is the same as its corresponding key in <paramref name="keys"/>. If a key does not exist in the database, its value depends on the behavior of <paramref name="decoder"/>.</returns>
-		[ItemNotNull]
-		public static async Task<KeyValuePair<Slice, TValue>[]> GetBatchAsync<TValue>([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] Slice[] keys, [NotNull] IValueEncoder<TValue> decoder)
+		public static async Task<KeyValuePair<Slice, TValue>[]> GetBatchAsync<TValue>(this IFdbReadOnlyTransaction trans, Slice[] keys, IValueEncoder<TValue> decoder)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(keys, nameof(keys));
@@ -1775,8 +1767,7 @@ namespace FoundationDB.Client
 		/// <param name="handler">Lambda function that returns an async enumerable. The function may be called multiple times if the transaction conflicts.</param>
 		/// <param name="ct">Token used to cancel the operation</param>
 		/// <returns>Task returning the list of all the elements of the async enumerable returned by the last successful call to <paramref name="handler"/>.</returns>
-		[ItemNotNull]
-		public static Task<List<T>> QueryAsync<T>([NotNull] this IFdbReadOnlyRetryable db, [NotNull, InstantHandle] Func<IFdbReadOnlyTransaction, IAsyncEnumerable<T>> handler, CancellationToken ct)
+		public static Task<List<T>> QueryAsync<T>(this IFdbReadOnlyRetryable db, [InstantHandle] Func<IFdbReadOnlyTransaction, IAsyncEnumerable<T>> handler, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			Contract.NotNull(handler, nameof(handler));
@@ -1797,8 +1788,7 @@ namespace FoundationDB.Client
 		/// <param name="handler">Lambda function that returns an async enumerable. The function may be called multiple times if the transaction conflicts.</param>
 		/// <param name="ct">Token used to cancel the operation</param>
 		/// <returns>Task returning the list of all the elements of the async enumerable returned by the last successful call to <paramref name="handler"/>.</returns>
-		[ItemNotNull]
-		public static Task<List<T>> QueryAsync<T>([NotNull] this IFdbReadOnlyRetryable db, [NotNull, InstantHandle] Func<IFdbReadOnlyTransaction, Task<IAsyncEnumerable<T>>> handler, CancellationToken ct)
+		public static Task<List<T>> QueryAsync<T>(this IFdbReadOnlyRetryable db, [InstantHandle] Func<IFdbReadOnlyTransaction, Task<IAsyncEnumerable<T>>> handler, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			Contract.NotNull(handler, nameof(handler));

--- a/FoundationDB.Client/FdbWatch.cs
+++ b/FoundationDB.Client/FdbWatch.cs
@@ -42,14 +42,13 @@ namespace FoundationDB.Client
 	public sealed class FdbWatch : IDisposable
 	{
 
-		internal FdbWatch([NotNull] FdbFuture<Slice> future, Slice key)
+		internal FdbWatch(FdbFuture<Slice> future, Slice key)
 		{
 			Contract.Requires(future != null);
 			this.Future = future;
 			this.Key = key;
 		}
 
-		[NotNull]
 		private readonly FdbFuture<Slice> Future;
 
 		/// <summary>Key that is being watched</summary>

--- a/FoundationDB.Client/Filters/FdbDatabaseFilter.cs
+++ b/FoundationDB.Client/Filters/FdbDatabaseFilter.cs
@@ -56,13 +56,13 @@ namespace FoundationDB.Filters
 		protected bool m_disposed;
 
 		/// <summary>Wrapper for the inner db's Root property</summary>
-		protected FdbDirectorySubspaceLocation m_root;
+		protected FdbDirectorySubspaceLocation? m_root;
 
 		#endregion
 
 		#region Constructors...
 
-		protected FdbDatabaseFilter([NotNull] IFdbDatabase database, bool forceReadOnly, bool ownsDatabase)
+		protected FdbDatabaseFilter(IFdbDatabase database, bool forceReadOnly, bool ownsDatabase)
 		{
 			Contract.NotNull(database, nameof(database));
 
@@ -76,10 +76,8 @@ namespace FoundationDB.Filters
 		#region Public Properties...
 
 		/// <summary>Database instance configured to read and write data from this partition</summary>
-		[NotNull]
 		protected IFdbDatabase Database => m_database;
 
-		[NotNull]
 		internal IFdbDatabase GetInnerDatabase()
 		{
 			return m_database;
@@ -90,7 +88,7 @@ namespace FoundationDB.Filters
 		public string Name => m_database.Name;
 
 		/// <inheritdoc/>
-		public string ClusterFile => m_database.ClusterFile;
+		public string? ClusterFile => m_database.ClusterFile;
 
 		/// <inheritdoc/>
 		public CancellationToken Cancellation => m_database.Cancellation;
@@ -322,7 +320,7 @@ namespace FoundationDB.Filters
 			m_database.SetOption(option);
 		}
 
-		public virtual void SetOption(FdbDatabaseOption option, string value)
+		public virtual void SetOption(FdbDatabaseOption option, string? value)
 		{
 			ThrowIfDisposed();
 			m_database.SetOption(option, value);
@@ -374,8 +372,8 @@ namespace FoundationDB.Filters
 			if (m_disposed) throw ThrowFilterAlreadyDisposed(this);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		private Exception ThrowFilterAlreadyDisposed([NotNull] FdbDatabaseFilter filter)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		private Exception ThrowFilterAlreadyDisposed(FdbDatabaseFilter filter)
 		{
 			return new ObjectDisposedException(filter.GetType().Name);
 		}

--- a/FoundationDB.Client/Filters/FdbFilterExtensions.cs
+++ b/FoundationDB.Client/Filters/FdbFilterExtensions.cs
@@ -39,8 +39,7 @@ namespace FoundationDB.Filters
 		/// <summary>Return a read-only view of this transaction, that will only allow read operations.</summary>
 		/// <param name="trans">Transaction to secure</param>
 		/// <returns>The same transaction instance if it is already read-only, or a thin read-only wrapper around the transaction if it is writable.</returns>
-		[NotNull]
-		public static IFdbReadOnlyTransaction AsReadOnly([NotNull] this IFdbTransaction trans)
+		public static IFdbReadOnlyTransaction AsReadOnly(this IFdbTransaction trans)
 		{
 			Contract.NotNull(trans, nameof(trans));
 

--- a/FoundationDB.Client/Filters/FdbTransactionFilter.cs
+++ b/FoundationDB.Client/Filters/FdbTransactionFilter.cs
@@ -53,7 +53,7 @@ namespace FoundationDB.Filters
 		/// <param name="trans">Underlying transaction that will be exposed as read-only</param>
 		/// <param name="forceReadOnly">If true, force the transaction to be read-only. If false, use the read-only mode of the underlying transaction</param>
 		/// <param name="ownsTransaction">If true, the underlying transaction will also be disposed when this instance is disposed</param>
-		protected FdbTransactionFilter([NotNull] IFdbTransaction trans, bool forceReadOnly, bool ownsTransaction)
+		protected FdbTransactionFilter(IFdbTransaction trans, bool forceReadOnly, bool ownsTransaction)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -70,7 +70,7 @@ namespace FoundationDB.Filters
 		}
 
 		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
-		private static Exception FilterAlreadyDisposed([NotNull] FdbTransactionFilter filter)
+		private static Exception FilterAlreadyDisposed(FdbTransactionFilter filter)
 		{
 			return new ObjectDisposedException(filter.GetType().Name);
 		}

--- a/FoundationDB.Client/Filters/Logging/FdbLoggingExtensions.cs
+++ b/FoundationDB.Client/Filters/Logging/FdbLoggingExtensions.cs
@@ -44,8 +44,7 @@ namespace FoundationDB.Filters.Logging
 		/// <param name="handler">Handler that will be called every-time a transaction commits successfully, or gets disposed. The log of all operations performed by the transaction can be accessed via the <see cref="FdbLoggedTransaction.Log"/> property.</param>
 		/// <param name="options">Optional logging options</param>
 		/// <returns>Database filter, that will monitor all transactions initiated from it. Disposing this wrapper will NOT dispose the inner <paramref name="database"/> database.</returns>
-		[NotNull]
-		public static FdbLoggedDatabase Logged([NotNull] this IFdbDatabase database, [NotNull] Action<FdbLoggedTransaction> handler, FdbLoggingOptions options = FdbLoggingOptions.Default)
+		public static FdbLoggedDatabase Logged(this IFdbDatabase database, Action<FdbLoggedTransaction> handler, FdbLoggingOptions options = FdbLoggingOptions.Default)
 		{
 			Contract.NotNull(database, nameof(database));
 			Contract.NotNull(handler, nameof(handler));
@@ -61,28 +60,25 @@ namespace FoundationDB.Filters.Logging
 		/// <param name="handler">Handler that will be called every-time a transaction commits successfully, or gets disposed. The log of all operations performed by the transaction can be accessed via the <see cref="FdbLoggedTransaction.Log"/> property.</param>
 		/// <param name="options">Optional logging options</param>
 		/// <returns>Provider that will that will monitor all transactions initiated from it.</returns>
-		[NotNull]
-		public static IFdbDatabaseScopeProvider Logged([NotNull] this IFdbDatabaseScopeProvider provider, [NotNull] Action<FdbLoggedTransaction> handler, FdbLoggingOptions options = FdbLoggingOptions.Default)
+		public static IFdbDatabaseScopeProvider Logged(this IFdbDatabaseScopeProvider provider, Action<FdbLoggedTransaction> handler, FdbLoggingOptions options = FdbLoggingOptions.Default)
 		{
 			Contract.NotNull(provider, nameof(provider));
 			Contract.NotNull(handler, nameof(handler));
 
-			return provider.CreateScope<object>((db, ct) => !ct.IsCancellationRequested ? Task.FromResult<(IFdbDatabase, object)>((Logged(db, handler), null)) : Task.FromCanceled<(IFdbDatabase, object)>(ct));
+			return provider.CreateScope<object?>((db, ct) => !ct.IsCancellationRequested ? Task.FromResult<(IFdbDatabase, object?)>((Logged(db, handler), null)) : Task.FromCanceled<(IFdbDatabase, object?)>(ct));
 		}
 
 		/// <summary>Strip the logging behaviour of this database. Use this for boilerplate or test code that would pollute the logs otherwise.</summary>
 		/// <param name="database">Database instance (that may or may not be logged)</param>
 		/// <returns>Either <paramref name="database"/> itself if it is not logged, or the inner database if it was.</returns>
-		[NotNull]
-		public static IFdbDatabase WithoutLogging([NotNull] this IFdbDatabase database)
+		public static IFdbDatabase WithoutLogging(this IFdbDatabase database)
 		{
 			Contract.NotNull(database, nameof(database));
 
 			return database is FdbLoggedDatabase logged ? logged.GetInnerDatabase() : database;
 		}
 
-		[CanBeNull]
-		internal static FdbLoggedTransaction GetLogger([NotNull] IFdbReadOnlyTransaction trans)
+		internal static FdbLoggedTransaction? GetLogger(IFdbReadOnlyTransaction trans)
 		{
 			//TODO: the logged transaction could also be wrapped in other filters.
 			// => we need a recursive "FindFilter<TFilter>" method that would unwrap the filter onion looking for a specific one...
@@ -93,7 +89,7 @@ namespace FoundationDB.Filters.Logging
 		/// <summary>Test if logging is enabled on this transaction</summary>
 		/// <remarks>If <c>false</c>, then there is no point in calling <see cref="Annotate(FoundationDB.Client.IFdbReadOnlyTransaction,string)"/> because logging is disabled.</remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsLogged([NotNull] this IFdbReadOnlyTransaction trans)
+		public static bool IsLogged(this IFdbReadOnlyTransaction trans)
 		{
 			return trans is FdbLoggedTransaction;
 		}
@@ -104,7 +100,7 @@ namespace FoundationDB.Filters.Logging
 		/// Calling this method on regular transaction is a no-op.
 		/// You can call <see cref="IsLogged"/> first, if you don't want to pay the cost of formatting <paramref name="message"/> when logging not enabled.
 		/// </remarks>
-		public static void Annotate([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] string message)
+		public static void Annotate(this IFdbReadOnlyTransaction trans, string message)
 		{
 			var logged = GetLogger(trans);
 			logged?.Log.AddOperation(new FdbTransactionLog.LogCommand(message), countAsOperation: false);
@@ -117,7 +113,7 @@ namespace FoundationDB.Filters.Logging
 		/// You can call <see cref="IsLogged"/> first, if you don't want to pay the cost of formatting the message when logging not enabled.
 		/// </remarks>
 		[StringFormatMethod("format")]
-		public static void Annotate([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] string format, object arg0)
+		public static void Annotate(this IFdbReadOnlyTransaction trans, string format, object? arg0)
 		{
 			var logged = GetLogger(trans);
 			logged?.Log.AddOperation(new FdbTransactionLog.LogCommand(string.Format(CultureInfo.InvariantCulture, format, arg0)), countAsOperation: false);
@@ -130,7 +126,7 @@ namespace FoundationDB.Filters.Logging
 		/// You can call <see cref="IsLogged"/> first, if you don't want to pay the cost of formatting the message when logging not enabled.
 		/// </remarks>
 		[StringFormatMethod("format")]
-		public static void Annotate([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] string format, object arg0, object arg1)
+		public static void Annotate(this IFdbReadOnlyTransaction trans, string format, object? arg0, object? arg1)
 		{
 			GetLogger(trans)?.Log.AddOperation(new FdbTransactionLog.LogCommand(string.Format(CultureInfo.InvariantCulture, format, arg0, arg1)), countAsOperation: false);
 		}
@@ -142,7 +138,7 @@ namespace FoundationDB.Filters.Logging
 		/// You can call <see cref="IsLogged"/> first, if you don't want to pay the cost of formatting the message when logging not enabled.
 		/// </remarks>
 		[StringFormatMethod("format")]
-		public static void Annotate([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] string format, object arg0, object arg1, object arg2)
+		public static void Annotate(this IFdbReadOnlyTransaction trans, string format, object? arg0, object? arg1, object? arg2)
 		{
 			GetLogger(trans)?.Log.AddOperation(new FdbTransactionLog.LogCommand(string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2)), countAsOperation: false);
 		}
@@ -154,7 +150,7 @@ namespace FoundationDB.Filters.Logging
 		/// You can call <see cref="IsLogged"/> first, if you don't want to pay the cost of formatting the message when logging not enabled.
 		/// </remarks>
 		[StringFormatMethod("format")]
-		public static void Annotate([NotNull] this IFdbReadOnlyTransaction trans, [NotNull] string format, params object[] args)
+		public static void Annotate(this IFdbReadOnlyTransaction trans, string format, params object?[] args)
 		{
 			GetLogger(trans)?.Log.AddOperation(new FdbTransactionLog.LogCommand(string.Format(CultureInfo.InvariantCulture, format, args)), countAsOperation: false);
 		}

--- a/FoundationDB.Client/Filters/Logging/FdbTransactionLog.Commands.cs
+++ b/FoundationDB.Client/Filters/Logging/FdbTransactionLog.Commands.cs
@@ -68,7 +68,7 @@ namespace FoundationDB.Filters.Logging
 			public TimeSpan? EndOffset { get; internal set; }
 
 			/// <summary>Exception thrown by this operation</summary>
-			public Exception Error { get; internal set; }
+			public Exception? Error { get; internal set; }
 
 			/// <summary>Total size (in bytes) of the arguments</summary>
 			/// <remarks>For selectors, only include the size of the keys</remarks>
@@ -83,7 +83,7 @@ namespace FoundationDB.Filters.Logging
 
 			/// <summary>StackTrace of the method that started this operation</summary>
 			/// <remarks>Only if the <see cref="FdbLoggingOptions.RecordOperationStackTrace"/> option is set</remarks>
-			public StackTrace CallSite { get; internal set; }
+			public StackTrace? CallSite { get; internal set; }
 
 			/// <summary>Total duration of the command, or TimeSpan.Zero if the command is not yet completed</summary>
 			public TimeSpan Duration
@@ -244,7 +244,7 @@ namespace FoundationDB.Filters.Logging
 
 			protected virtual string Dump(TResult value)
 			{
-				return value.ToString();
+				return value?.ToString() ?? "<default>";
 			}
 		}
 
@@ -277,7 +277,7 @@ namespace FoundationDB.Filters.Logging
 			public readonly Slice[] Prefixes;
 			public readonly string[] Paths;
 
-			public DirectoryKeyResolver([NotNull] Dictionary<Slice, string> knownSubspaces)
+			public DirectoryKeyResolver(Dictionary<Slice, string> knownSubspaces)
 			{
 				Contract.Requires(knownSubspaces != null);
 				var prefixes = new Slice[knownSubspaces.Count];
@@ -297,7 +297,6 @@ namespace FoundationDB.Filters.Logging
 
 			/// <summary>Create a key resolver using the content of a DirectoryLayer as the map</summary>
 			/// <returns>Resolver that replace each directory prefix by its name</returns>
-			[ItemNotNull]
 			public static async Task<DirectoryKeyResolver> BuildFromDirectoryLayer(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory)
 			{
 				var metadata = await directory.Resolve(tr);
@@ -324,7 +323,7 @@ namespace FoundationDB.Filters.Logging
 				return new DirectoryKeyResolver(map);
 			}
 
-			private bool TryLookup(Slice key, out Slice prefix, out string path)
+			private bool TryLookup(Slice key, out Slice prefix, out string? path)
 			{
 				prefix = default(Slice);
 				path = null;
@@ -357,7 +356,7 @@ namespace FoundationDB.Filters.Logging
 
 			public override string Resolve(Slice key)
 			{
-				if (!TryLookup(key, out Slice prefix, out string path))
+				if (!TryLookup(key, out Slice prefix, out string? path))
 				{
 					return base.Resolve(key);
 				}
@@ -397,7 +396,7 @@ namespace FoundationDB.Filters.Logging
 			public long? IntValue { get; }
 
 			/// <summary>String value (if not null)</summary>
-			public string StringValue { get; }
+			public string? StringValue { get; }
 
 			public override Operation Op => Operation.SetOption;
 
@@ -674,7 +673,7 @@ namespace FoundationDB.Filters.Logging
 
 			public override Operation Op => Operation.GetValues;
 
-			public GetValuesCommand([NotNull] Slice[] keys)
+			public GetValuesCommand(Slice[] keys)
 			{
 				Contract.Requires(keys != null);
 				this.Keys = keys;
@@ -730,7 +729,7 @@ namespace FoundationDB.Filters.Logging
 
 			public override Operation Op => Operation.GetKeys;
 
-			public GetKeysCommand([NotNull] KeySelector[] selectors)
+			public GetKeysCommand(KeySelector[] selectors)
 			{
 				Contract.Requires(selectors != null);
 				this.Selectors = selectors;
@@ -778,14 +777,14 @@ namespace FoundationDB.Filters.Logging
 			public KeySelector End { get; }
 
 			/// <summary>Options of the range read</summary>
-			public FdbRangeOptions Options { get; }
+			public FdbRangeOptions? Options { get; }
 
 			/// <summary>Iteration number</summary>
 			public int Iteration { get; }
 
 			public override Operation Op => Operation.GetRange;
 
-			public GetRangeCommand(KeySelector begin, KeySelector end, FdbRangeOptions options, int iteration)
+			public GetRangeCommand(KeySelector begin, KeySelector end, FdbRangeOptions? options, int iteration)
 			{
 				this.Begin = begin;
 				this.End = end;

--- a/FoundationDB.Client/Filters/Logging/FdbTransactionLog.cs
+++ b/FoundationDB.Client/Filters/Logging/FdbTransactionLog.cs
@@ -31,7 +31,6 @@ namespace FoundationDB.Filters.Logging
 	using System;
 	using System.Collections.Concurrent;
 	using System.Diagnostics;
-	using System.Globalization;
 	using System.Reflection;
 	using System.Runtime.CompilerServices;
 	using System.Text;
@@ -72,7 +71,7 @@ namespace FoundationDB.Filters.Logging
 
 		/// <summary>StackTrace of the method that created this transaction</summary>
 		/// <remarks>Only if the <see cref="FdbLoggingOptions.RecordCreationStackTrace"/> option is set</remarks>
-		public StackTrace CallSite { get; private set; }
+		public StackTrace? CallSite { get; private set; }
 
 		internal StackTrace CaptureStackTrace(int numStackFramesToSkip)
 		{
@@ -101,7 +100,6 @@ namespace FoundationDB.Filters.Logging
 		public int Operations => m_operations;
 
 		/// <summary>List of all commands processed by the transaction</summary>
-		[NotNull]
 		public ConcurrentQueue<Command> Commands { get; private set; }
 
 		/// <summary>Timestamp of the start of transaction</summary>
@@ -243,7 +241,7 @@ namespace FoundationDB.Filters.Logging
 		}
 
 		/// <summary>Mark the end of the execution of a command</summary>
-		public void EndOperation(Command cmd, Exception error = null)
+		public void EndOperation(Command cmd, Exception? error = null)
 		{
 			Contract.Requires(cmd != null);
 
@@ -257,7 +255,6 @@ namespace FoundationDB.Filters.Logging
 		}
 
 		/// <summary>Generate an ASCII report with all the commands that were executed by the transaction</summary>
-		[NotNull]
 		public string GetCommandsReport(bool detailed = false, KeyResolver? keyResolver = null)
 		{
 			keyResolver ??= KeyResolver.Default;
@@ -301,7 +298,6 @@ namespace FoundationDB.Filters.Logging
 		}
 
 		/// <summary>Generate a full ASCII report with the detailed timeline of all the commands that were executed by the transaction</summary>
-		[NotNull]
 		public string GetTimingsReport(bool showCommands = false, KeyResolver? keyResolver = null)
 		{
 			keyResolver ??= KeyResolver.Default;

--- a/FoundationDB.Client/IFdbDatabase.cs
+++ b/FoundationDB.Client/IFdbDatabase.cs
@@ -38,14 +38,12 @@ namespace FoundationDB.Client
 	public interface IFdbDatabase : IFdbRetryable, IDisposable
 	{
 		/// <summary>Name of the database</summary>
-		[NotNull]
 		[Obsolete("This property is not supported anymore and will always return \"DB\".")]
 		string Name { get; }
 
 		/// <summary>Path to the cluster file used to connect to the database</summary>
 		/// <remarks>If null, the default path for this platform will be used</remarks>
-		[CanBeNull]
-		string ClusterFile { get; }
+		string? ClusterFile { get; }
 
 		/// <summary>Returns a cancellation token that is linked with the lifetime of this database instance</summary>
 		/// <remarks>The token will be cancelled if the database instance is disposed</remarks>

--- a/FoundationDB.Client/IFdbReadOnlyTransaction.cs
+++ b/FoundationDB.Client/IFdbReadOnlyTransaction.cs
@@ -44,14 +44,12 @@ namespace FoundationDB.Client
 		int Id { get; }
 
 		/// <summary>Context of this transaction.</summary>
-		[NotNull]
 		FdbOperationContext Context { get; }
 
 		/// <summary>If <c>true</c>, the transaction is operating in Snapshot mode</summary>
 		bool IsSnapshot { get; }
 
 		/// <summary>Return a Snapshot version of this transaction, or the transaction itself it is already operating in Snapshot mode.</summary>
-		[NotNull]
 		IFdbReadOnlyTransaction Snapshot { get; }
 
 		/// <summary>Cancellation Token linked to the life time of the transaction</summary>
@@ -76,8 +74,7 @@ namespace FoundationDB.Client
 		/// <summary>Reads several values from the database snapshot represented by the current transaction</summary>
 		/// <param name="keys">Keys to be looked up in the database</param>
 		/// <returns>Task that will return an array of values, or an exception. Each item in the array will contain the value of the key at the same index in <paramref name="keys"/>, or Slice.Nil if that key does not exist.</returns>
-		[ItemNotNull]
-		Task<Slice[]> GetValuesAsync([NotNull] Slice[] keys);
+		Task<Slice[]> GetValuesAsync(Slice[] keys);
 		//REVIEW: => ReadOnlySpan<Slice>
 
 		/// <summary>Resolves a key selector against the keys in the database snapshot represented by the current transaction.</summary>
@@ -88,8 +85,7 @@ namespace FoundationDB.Client
 		/// <summary>Resolves several key selectors against the keys in the database snapshot represented by the current transaction.</summary>
 		/// <param name="selectors">Key selectors to resolve</param>
 		/// <returns>Task that will return an array of keys matching the selectors, or an exception</returns>
-		[ItemNotNull]
-		Task<Slice[]> GetKeysAsync([NotNull] KeySelector[] selectors);
+		Task<Slice[]> GetKeysAsync(KeySelector[] selectors);
 		//REVIEW: => ReadOnlySpan<KeySelector>
 
 		/// <summary>
@@ -111,7 +107,7 @@ namespace FoundationDB.Client
 		/// <param name="endExclusive">key selector defining the end of the range</param>
 		/// <param name="options">Optional query options (Limit, TargetBytes, Mode, Reverse, ...)</param>
 		/// <returns>Range query that, once executed, will return all the key-value pairs matching the providing selector pair</returns>
-		[Pure, NotNull, LinqTunnel]
+		[Pure, LinqTunnel]
 		FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRange(KeySelector beginInclusive, KeySelector endExclusive, FdbRangeOptions? options = null);
 
 		/// <summary>
@@ -122,13 +118,12 @@ namespace FoundationDB.Client
 		/// <param name="selector">Selector used to convert each key-value pair into an element of type <typeparamref name="TResult"/></param>
 		/// <param name="options">Optional query options (Limit, TargetBytes, Mode, Reverse, ...)</param>
 		/// <returns>Range query that, once executed, will return all the key-value pairs matching the providing selector pair</returns>
-		[Pure, NotNull, LinqTunnel]
-		FdbRangeQuery<TResult> GetRange<TResult>(KeySelector beginInclusive, KeySelector endExclusive, [NotNull] Func<KeyValuePair<Slice, Slice>, TResult> selector, FdbRangeOptions? options = null);
+		[Pure, LinqTunnel]
+		FdbRangeQuery<TResult> GetRange<TResult>(KeySelector beginInclusive, KeySelector endExclusive, Func<KeyValuePair<Slice, Slice>, TResult> selector, FdbRangeOptions? options = null);
 
 		/// <summary>Returns a list of public network addresses as strings, one for each of the storage servers responsible for storing <paramref name="key"/> and its associated value</summary>
 		/// <param name="key">Name of the key whose location is to be queried.</param>
 		/// <returns>Task that will return an array of strings, or an exception</returns>
-		[ItemNotNull]
 		Task<string[]> GetAddressesForKeyAsync(ReadOnlySpan<byte> key);
 
 		/// <summary>Returns this transaction snapshot read version.</summary>

--- a/FoundationDB.Client/IFdbTransaction.cs
+++ b/FoundationDB.Client/IFdbTransaction.cs
@@ -166,7 +166,7 @@ namespace FoundationDB.Client
 		/// <param name="ct">CancellationToken used to abort the watch if the caller doesn't want to wait anymore. Note that you can manually cancel the watch by calling Cancel() on the returned FdbWatch instance</param>
 		/// <returns>FdbWatch that can be awaited and will complete when the key has changed in the database, or cancellation occurs. You can call Cancel() at any time if you are not interested in watching the key anymore. You MUST always call Dispose() if the watch completes or is cancelled, to ensure that resources are released properly.</returns>
 		/// <remarks>You can directly await an FdbWatch, or obtain a Task&lt;Slice&gt; by reading the <see cref="FdbWatch.Task"/> property.</remarks>
-		[Pure, NotNull]
+		[Pure]
 		FdbWatch Watch(ReadOnlySpan<byte> key, CancellationToken ct);
 
 	}

--- a/FoundationDB.Client/Layers/Directories/Fdb.Directory.cs
+++ b/FoundationDB.Client/Layers/Directories/Fdb.Directory.cs
@@ -46,7 +46,7 @@ namespace FoundationDB.Client
 		{
 
 			/// <summary>Opens a named partition, and change the root subspace of the database to the corresponding prefix</summary>
-			internal static async Task SwitchToNamedPartitionAsync([NotNull] FdbDatabase db, [NotNull] FdbDirectorySubspaceLocation top, bool readOnly, CancellationToken ct)
+			internal static async Task SwitchToNamedPartitionAsync(FdbDatabase db, FdbDirectorySubspaceLocation top, bool readOnly, CancellationToken ct)
 			{
 				Contract.Requires(db != null && top != null);
 				ct.ThrowIfCancellationRequested();
@@ -65,8 +65,7 @@ namespace FoundationDB.Client
 			/// <param name="tr">Transaction used for the operation</param>
 			/// <param name="parent">Parent directory</param>
 			/// <returns>Dictionary of all the sub directories of the <paramref name="parent"/> directory.</returns>
-			[ItemNotNull]
-			public static async Task<Dictionary<string, FdbDirectorySubspace>> BrowseAsync([NotNull] IFdbReadOnlyTransaction tr, [NotNull] IFdbDirectory parent)
+			public static async Task<Dictionary<string, FdbDirectorySubspace>> BrowseAsync(IFdbReadOnlyTransaction tr, IFdbDirectory parent)
 			{
 				Contract.NotNull(tr, nameof(tr));
 				Contract.NotNull(parent, nameof(parent));

--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
@@ -78,16 +78,13 @@ namespace FoundationDB.Client
 		public static bool AnnotateTransactions { get; set; }
 
 		/// <summary>Subspace where the content of each folder will be stored</summary>
-		[NotNull]
 		public DynamicKeySubspaceLocation Content { get; }
 
 		/// <summary>Random generator used by the internal allocators</summary>
-		[NotNull]
 		internal Random AllocatorRng { get; }
 
 		/// <summary>Most current cache context</summary>
-		[CanBeNull]
-		internal CacheContext Cache;
+		internal CacheContext? Cache;
 
 		/// <summary>Name of root directory of this layer</summary>
 		/// <remarks>Returns String.Empty for the root Directory Layer, or the name of the partition</remarks>
@@ -160,7 +157,6 @@ namespace FoundationDB.Client
 
 		/// <summary>Create an instance of a Directory Layer located under a specific subspace and path</summary>
 		/// <param name="location">Location of the Directory Layer's content. The nodes will be stored under the &lt;FE&gt; subspace</param>
-		[NotNull]
 		public static FdbDirectoryLayer Create(ISubspaceLocation location)
 		{
 			Contract.NotNull(location, nameof(location));
@@ -178,13 +174,12 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to create or open</param>
 		/// <param name="layer">If layer is specified, it is checked against the layer of an existing directory or set as the layer of a new directory.</param>
-		[ItemNotNull]
 		public async Task<FdbDirectorySubspace> CreateOrOpenAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var metadata = await Resolve(trans);
-			return await metadata.CreateOrOpenInternalAsync(null, trans, VerifyPath(path), layer, Slice.Nil, allowCreate: true, allowOpen: true, throwOnError: true);
+			return (await metadata.CreateOrOpenInternalAsync(null, trans, VerifyPath(path), layer, Slice.Nil, allowCreate: true, allowOpen: true, throwOnError: true))!;
 		}
 
 		/// <summary>Opens the directory with the given <paramref name="path"/>.
@@ -193,13 +188,12 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to open.</param>
 		/// <param name="layer">Optional layer id of the directory. If it is different than the layer specified when creating the directory, an exception will be thrown.</param>
-		[ItemNotNull]
 		public async Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var metadata = await Resolve(trans);
-			return await metadata.CreateOrOpenInternalAsync(trans, null, VerifyPath(path), layer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: true);
+			return (await metadata.CreateOrOpenInternalAsync(trans, null, VerifyPath(path), layer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: true))!;
 		}
 
 		/// <summary>Creates a directory with the given <paramref name="path"/> (creating parent directories if necessary).
@@ -208,29 +202,27 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
-		[ItemNotNull]
 		public async Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var metadata = await Resolve(trans);
-			return await metadata.CreateOrOpenInternalAsync(null, trans, VerifyPath(path), layer, prefix: Slice.Nil, allowCreate: true, allowOpen: false, throwOnError: true);
+			return (await metadata.CreateOrOpenInternalAsync(null, trans, VerifyPath(path), layer, prefix: Slice.Nil, allowCreate: true, allowOpen: false, throwOnError: true))!;
 		}
 
 		/// <summary>Attempts to open the directory with the given <paramref name="path"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to open.</param>
 		/// <param name="layer">Optional layer id of the directory. If it is different than the layer specified when creating the directory, an exception will be thrown.</param>
-		[ItemCanBeNull]
-		public async Task<FdbDirectorySubspace> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var metadata = await Resolve(trans);
-			return await metadata.CreateOrOpenInternalAsync(trans, null, VerifyPath(path), layer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: false);
+			return (await metadata.CreateOrOpenInternalAsync(trans, null, VerifyPath(path), layer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: false))!;
 		}
 
-		public async ValueTask<FdbDirectorySubspace> TryOpenCachedAsync([NotNull] IFdbReadOnlyTransaction trans, [ItemNotNull] FdbDirectoryPath path, Slice layer = default)
+		public async ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -238,7 +230,7 @@ namespace FoundationDB.Client
 			return await metadata.OpenCachedInternalAsync(trans, path, layer, throwOnError: false);
 		}
 
-		public async ValueTask<FdbDirectorySubspace[]> TryOpenCachedAsync([NotNull] IFdbReadOnlyTransaction trans, IEnumerable<FdbDirectoryPath> paths)
+		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<FdbDirectoryPath> paths)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -246,7 +238,7 @@ namespace FoundationDB.Client
 			return await metadata.OpenCachedInternalAsync(trans, paths.Select(p => (p, Slice.Nil)).ToArray(), throwOnError: false);
 		}
 
-		public async ValueTask<FdbDirectorySubspace[]> TryOpenCachedAsync([NotNull] IFdbReadOnlyTransaction trans, IEnumerable<(FdbDirectoryPath Path, Slice Layer)> paths)
+		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<(FdbDirectoryPath Path, Slice Layer)> paths)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -258,8 +250,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
-		[ItemCanBeNull]
-		public async Task<FdbDirectorySubspace> TryCreateAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace?> TryCreateAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -272,13 +263,12 @@ namespace FoundationDB.Client
 		/// <param name="path">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
 		/// <param name="prefix">The directory will be created with the given physical prefix; otherwise a prefix is allocated automatically.</param>
-		[ItemNotNull]
 		public async Task<FdbDirectorySubspace> RegisterAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer, Slice prefix)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var metadata = await Resolve(trans);
-			return await metadata.CreateOrOpenInternalAsync(null, trans, VerifyPath(path), layer, prefix: prefix, allowCreate: true, allowOpen: false, throwOnError: true);
+			return (await metadata.CreateOrOpenInternalAsync(null, trans, VerifyPath(path), layer, prefix: prefix, allowCreate: true, allowOpen: false, throwOnError: true))!;
 		}
 
 		/// <summary>Attempts to register an existing prefix as a directory with the given <paramref name="path"/> (creating parent directories if necessary). This method is only indented for advanced use cases.</summary>
@@ -286,8 +276,7 @@ namespace FoundationDB.Client
 		/// <param name="path">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
 		/// <param name="prefix">The directory will be created with the given physical prefix; otherwise a prefix is allocated automatically.</param>
-		[ItemCanBeNull]
-		public async Task<FdbDirectorySubspace> TryRegisterAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath path, Slice layer, Slice prefix)
+		public async Task<FdbDirectorySubspace?> TryRegisterAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer, Slice prefix)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
@@ -306,7 +295,6 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="oldPath">Path of the directory to move</param>
 		/// <param name="newPath">New path of the directory</param>
-		[ItemNotNull]
 		public async Task<FdbDirectorySubspace> MoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath)
 		{
 			Contract.NotNull(trans, nameof(trans));
@@ -317,7 +305,7 @@ namespace FoundationDB.Client
 			var newLocation = VerifyPath(newPath, nameof(newPath));
 
 			var metadata = await Resolve(trans);
-			return await metadata.MoveInternalAsync(trans, oldLocation, newLocation, throwOnError: true);
+			return (await metadata.MoveInternalAsync(trans, oldLocation, newLocation, throwOnError: true))!;
 		}
 
 		/// <summary>Attempts to move the directory found at <paramref name="oldPath"/> to <paramref name="newPath"/>.
@@ -327,8 +315,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="oldPath">Path of the directory to move</param>
 		/// <param name="newPath">New path of the directory</param>
-		[ItemCanBeNull]
-		public async Task<FdbDirectorySubspace> TryMoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath)
+		public async Task<FdbDirectorySubspace?> TryMoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (oldPath.IsEmpty) throw new InvalidOperationException("The root directory cannot be moved.");
@@ -350,7 +337,7 @@ namespace FoundationDB.Client
 			throw new InvalidOperationException("The root directory cannot be moved.");
 		}
 
-		Task<FdbDirectorySubspace> IFdbDirectory.TryMoveToAsync(IFdbTransaction trans, FdbDirectoryPath newAbsolutePath)
+		Task<FdbDirectorySubspace?> IFdbDirectory.TryMoveToAsync(IFdbTransaction trans, FdbDirectoryPath newAbsolutePath)
 		{
 			throw new InvalidOperationException("The root directory cannot be moved.");
 		}
@@ -414,25 +401,23 @@ namespace FoundationDB.Client
 		/// <summary>Returns the list of subdirectories of directory at <paramref name="path"/></summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to list</param>
-		[ItemNotNull]
 		public async Task<List<string>> ListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var metadata = await Resolve(trans);
-			return await metadata.ListInternalAsync(trans, VerifyPath(path), throwIfMissing: true);
+			return (await metadata.ListInternalAsync(trans, VerifyPath(path), throwIfMissing: true))!;
 		}
 
 		/// <summary>Returns the list of subdirectories of directory at <paramref name="path"/>, if it exists.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to list</param>
-		[ItemCanBeNull]
-		public async Task<List<string>> TryListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path = default)
+		public async Task<List<string>?> TryListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
-			var metadata = await Resolve(trans);
-			return await metadata.ListInternalAsync(trans, VerifyPath(path), throwIfMissing: false);
+			var metadata = await Resolve(trans).ConfigureAwait(false);
+			return await metadata.ListInternalAsync(trans, VerifyPath(path), throwIfMissing: false).ConfigureAwait(false);
 		}
 
 		#endregion
@@ -441,8 +426,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to change</param>
 		/// <param name="newLayer">New layer id of the directory</param>
-		[ItemCanBeNull]
-		public async Task<FdbDirectorySubspace> ChangeLayerAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath path, Slice newLayer)
+		public async Task<FdbDirectorySubspace> ChangeLayerAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice newLayer)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			var location = VerifyPath(path);
@@ -453,7 +437,7 @@ namespace FoundationDB.Client
 			await metadata.ChangeLayerInternalAsync(trans, location, newLayer).ConfigureAwait(false);
 
 			// And re-open the directory subspace
-			return await metadata.CreateOrOpenInternalAsync(null, trans, location, newLayer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: true).ConfigureAwait(false);
+			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, newLayer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: true).ConfigureAwait(false))!;
 		}
 
 		public override string ToString()
@@ -551,13 +535,13 @@ namespace FoundationDB.Client
 				this.ReadVersion = readVersion;
 			}
 
-			private static void SetLayer([NotNull] IFdbTransaction trans, [NotNull] PartitionDescriptor partition, Slice prefix, Slice layer)
+			private static void SetLayer(IFdbTransaction trans, PartitionDescriptor partition, Slice prefix, Slice layer)
 			{
 				if (layer.IsNull) layer = Slice.Empty;
 				trans.Set(partition.Nodes.Encode(prefix, LayerAttribute), layer);
 			}
 
-			private void UpdatePartitionMetadataVersion([NotNull] IFdbTransaction trans, PartitionDescriptor partition, bool init = false)
+			private void UpdatePartitionMetadataVersion(IFdbTransaction trans, PartitionDescriptor partition, bool init = false)
 			{
 				// update the metadata version of this partition
 				if (init)
@@ -579,7 +563,7 @@ namespace FoundationDB.Client
 
 			/// <summary>Finds a node subspace, given its path, by walking the tree from the root.</summary>
 			/// <returns>Node if it was found, or null</returns>
-			private static async Task<Node> FindAsync([NotNull] IFdbReadOnlyTransaction tr, PartitionDescriptor partition, FdbDirectoryPath path)
+			private static async Task<Node> FindAsync(IFdbReadOnlyTransaction tr, PartitionDescriptor partition, FdbDirectoryPath path)
 			{
 				Contract.Requires(tr != null);
 
@@ -621,7 +605,7 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Open a subspace using the local cache</summary>
-			internal async ValueTask<FdbDirectorySubspace> OpenCachedInternalAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer, bool throwOnError)
+			internal async ValueTask<FdbDirectorySubspace?> OpenCachedInternalAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer, bool throwOnError)
 			{
 				Contract.Requires(trans != null);
 
@@ -639,13 +623,13 @@ namespace FoundationDB.Client
 				return await OpenCachedInternalSlow(ctx, trans, path, layer, throwOnError);
 			}
 
-			private async Task<FdbDirectorySubspace> OpenCachedInternalSlow(CacheContext context, IFdbReadOnlyTransaction readTrans, FdbDirectoryPath path, Slice layer, bool throwOnError)
+			private async Task<FdbDirectorySubspace?> OpenCachedInternalSlow(CacheContext context, IFdbReadOnlyTransaction readTrans, FdbDirectoryPath path, Slice layer, bool throwOnError)
 			{
 				var existingNode = await FindAsync(readTrans, this.Partition, path).ConfigureAwait(false);
 
 				// Path of the partition that contains the target directory (updated whenever we traverse partitions)
 
-				FdbDirectorySubspace subspace;
+				FdbDirectorySubspace? subspace;
 				if (existingNode.Exists)
 				{
 					if (layer.Count != 0 && layer != existingNode.Layer)
@@ -664,7 +648,7 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Open a subspace using the local cache</summary>
-			internal async ValueTask<FdbDirectorySubspace[]> OpenCachedInternalAsync(IFdbReadOnlyTransaction trans, ReadOnlyMemory<(FdbDirectoryPath Path, Slice Layer)> paths, bool throwOnError)
+			internal async ValueTask<FdbDirectorySubspace?[]> OpenCachedInternalAsync(IFdbReadOnlyTransaction trans, ReadOnlyMemory<(FdbDirectoryPath Path, Slice Layer)> paths, bool throwOnError)
 			{
 				Contract.Requires(trans != null);
 
@@ -673,8 +657,8 @@ namespace FoundationDB.Client
 
 				if (EnsureCanCache(trans))
 				{
-					var results = new FdbDirectorySubspace[paths.Length];
-					List<(Task<FdbDirectorySubspace> Task, int Index)> tasks = null;
+					var results = new FdbDirectorySubspace?[paths.Length];
+					List<(Task<FdbDirectorySubspace?> Task, int Index)>? tasks = null;
 					for (int i = 0; i < paths.Length; i++)
 					{
 						(var path, var layer) = paths.Span[i];
@@ -685,7 +669,7 @@ namespace FoundationDB.Client
 						}
 						else
 						{
-							tasks ??= new List<(Task<FdbDirectorySubspace>, int)>();
+							tasks ??= new List<(Task<FdbDirectorySubspace?>, int)>();
 							tasks.Add((OpenCachedInternalSlow(ctx, trans, path, layer, throwOnError), i));
 						}
 					}
@@ -701,7 +685,7 @@ namespace FoundationDB.Client
 				}
 				else
 				{
-					var tasks = new List<Task<FdbDirectorySubspace>>(paths.Length);
+					var tasks = new List<Task<FdbDirectorySubspace?>>(paths.Length);
 					for (int i = 0; i < paths.Length; i++)
 					{
 						(var path, var layer) = paths.Span[i];
@@ -712,8 +696,7 @@ namespace FoundationDB.Client
 				}
 			}
 
-			[ItemCanBeNull]
-			internal async Task<FdbDirectorySubspace> CreateOrOpenInternalAsync(IFdbReadOnlyTransaction readTrans, IFdbTransaction trans, FdbDirectoryPath path, Slice layer, Slice prefix, bool allowCreate, bool allowOpen, bool throwOnError)
+			internal async Task<FdbDirectorySubspace?> CreateOrOpenInternalAsync(IFdbReadOnlyTransaction? readTrans, IFdbTransaction? trans, FdbDirectoryPath path, Slice layer, Slice prefix, bool allowCreate, bool allowOpen, bool throwOnError)
 			{
 				Contract.Requires(readTrans != null || trans != null, "Need at least one transaction");
 				Contract.Requires(readTrans == null || trans == null || object.ReferenceEquals(readTrans, trans), "The write transaction should be the same as the read transaction.");
@@ -725,7 +708,8 @@ namespace FoundationDB.Client
 
 				// to open an existing directory, we only need the read transaction
 				// if none was specified, we can use the writable transaction
-				if (readTrans == null) readTrans = trans;
+				readTrans ??= trans;
+				if (readTrans == null) throw new ArgumentNullException("readTrans", "You must either specify either a read or write transaction!");
 
 				await CheckReadVersionAsync(readTrans);
 
@@ -823,10 +807,9 @@ namespace FoundationDB.Client
 				return ContentsOfNode(path, prefix, layer, existingNode.Partition, existingNode.ParentPartition ?? existingNode.Partition, null);
 			}
 
-			[ItemCanBeNull]
-			internal async Task<FdbDirectorySubspace> MoveInternalAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath, bool throwOnError)
+			internal async Task<FdbDirectorySubspace?> MoveInternalAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath, bool throwOnError)
 			{
-				Contract.Requires(trans != null);
+				Contract.NotNull(trans, nameof(trans));
 
 				if (oldPath.Count == 0)
 				{
@@ -893,9 +876,9 @@ namespace FoundationDB.Client
 				return ContentsOfNode(newPath, oldNode.Prefix, oldNode.Layer, newNode.Partition, newNode.ParentPartition, null);
 			}
 
-			internal async Task<bool> RemoveInternalAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath path, bool throwIfMissing)
+			internal async Task<bool> RemoveInternalAsync(IFdbTransaction trans, FdbDirectoryPath path, bool throwIfMissing)
 			{
-				Contract.Requires(trans != null);
+				Contract.NotNull(trans, nameof(trans));
 
 				// We don't allow removing the root directory, because it would probably end up wiping out all the database.
 				if (path.Count == 0) throw new InvalidOperationException("The root directory may not be removed.");
@@ -916,10 +899,9 @@ namespace FoundationDB.Client
 				return true;
 			}
 
-			[ItemCanBeNull]
-			internal async Task<List<string>> ListInternalAsync([NotNull] IFdbReadOnlyTransaction trans, FdbDirectoryPath path, bool throwIfMissing)
+			internal async Task<List<string>?> ListInternalAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, bool throwIfMissing)
 			{
-				Contract.Requires(trans != null);
+				Contract.NotNull(trans, nameof(trans));
 
 				await CheckReadVersionAsync(trans);
 
@@ -931,20 +913,15 @@ namespace FoundationDB.Client
 					return null;
 				}
 
-				//if (node.IsInPartition(includeEmptySubPath: true))
-				//{
-				//	return await GetPartitionForNode(in node, null).DirectoryLayer.ListInternalAsync(trans, node.PartitionSubPath, throwIfMissing).ConfigureAwait(false);
-				//}
-
 				return await SubdirNamesAndNodes(trans, node.Partition, node.Prefix)
 					.Select(kvp => kvp.Key)
 					.ToListAsync()
 					.ConfigureAwait(false);
 			}
 
-			internal async Task<bool> ExistsInternalAsync([NotNull] IFdbReadOnlyTransaction trans, FdbDirectoryPath path)
+			internal async Task<bool> ExistsInternalAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path)
 			{
-				Contract.Requires(trans != null);
+				Contract.NotNull(trans, nameof(trans));
 
 				await CheckReadVersionAsync(trans).ConfigureAwait(false);
 
@@ -955,9 +932,9 @@ namespace FoundationDB.Client
 				return true;
 			}
 
-			internal async Task ChangeLayerInternalAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath path, Slice newLayer)
+			internal async Task ChangeLayerInternalAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice newLayer)
 			{
-				Contract.Requires(trans != null);
+				Contract.NotNull(trans, nameof(trans));
 
 				await CheckWriteVersionAsync(trans).ConfigureAwait(false);
 
@@ -972,10 +949,8 @@ namespace FoundationDB.Client
 				UpdatePartitionMetadataVersion(trans, node.Partition);
 			}
 
-			private async Task<Slice> CheckReadVersionAsync([NotNull] IFdbReadOnlyTransaction trans)
+			private async Task<Slice> CheckReadVersionAsync(IFdbReadOnlyTransaction trans)
 			{
-				Contract.Requires(trans != null);
-
 				//TODO: we could defer the check using the cache context!
 
 				var value = await trans.GetAsync(this.Partition.VersionKey).ConfigureAwait(false);
@@ -987,10 +962,8 @@ namespace FoundationDB.Client
 				return value;
 			}
 
-			private async Task CheckWriteVersionAsync([NotNull] IFdbTransaction trans)
+			private async Task CheckWriteVersionAsync(IFdbTransaction trans)
 			{
-				Contract.Requires(trans != null);
-
 				var version = await CheckReadVersionAsync(trans);
 
 				if (version.IsNullOrEmpty)
@@ -999,10 +972,8 @@ namespace FoundationDB.Client
 				}
 			}
 
-			private void InitializePartition([NotNull] IFdbTransaction trans, PartitionDescriptor partition)
+			private void InitializePartition(IFdbTransaction trans, PartitionDescriptor partition)
 			{
-				Contract.Requires(trans != null);
-
 				// Set the version key
 				trans.Set(partition.VersionKey, MakeVersionValue());
 				UpdatePartitionMetadataVersion(trans, partition, init: true);
@@ -1017,11 +988,8 @@ namespace FoundationDB.Client
 				return writer.ToSlice();
 			}
 
-			[ItemCanBeNull]
-			private async Task<bool> NodeContainingKey([NotNull] IFdbReadOnlyTransaction tr, PartitionDescriptor partition, Slice key)
+			private async Task<bool> NodeContainingKey(IFdbReadOnlyTransaction tr, PartitionDescriptor partition, Slice key)
 			{
-				Contract.Requires(tr != null);
-
 				// Right now this is only used for _is_prefix_free(), but if we add
 				// parent pointers to directory nodes, it could also be used to find a
 				// path based on a key.
@@ -1051,17 +1019,8 @@ namespace FoundationDB.Client
 				return false;
 			}
 
-			/// <summary>Returns the subspace to a node metadata, given its prefix</summary>
-			[CanBeNull]
-			private IDynamicKeySubspace NodeWithPrefix(IDynamicKeySubspace nodes, Slice prefix)
-			{
-				if (prefix.IsNullOrEmpty) return null;
-				return nodes.Partition.ByKey(prefix);
-			}
-
 			/// <summary>Returns a new Directory Subspace given its node subspace, path and layer id</summary>
-			[NotNull]
-			private FdbDirectorySubspace ContentsOfNode(FdbDirectoryPath path, Slice prefix, Slice layer, PartitionDescriptor partition, PartitionDescriptor parentPartition, [CanBeNull] ISubspaceContext context)
+			private FdbDirectorySubspace ContentsOfNode(FdbDirectoryPath path, Slice prefix, Slice layer, PartitionDescriptor partition, PartitionDescriptor parentPartition, ISubspaceContext? context)
 			{
 				Contract.Requires(partition != null && parentPartition != null);
 
@@ -1078,8 +1037,7 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Returns the list of names and nodes of all children of the specified node</summary>
-			[NotNull]
-			private IAsyncEnumerable<KeyValuePair<string, Slice>> SubdirNamesAndNodes([NotNull] IFdbReadOnlyTransaction tr, [NotNull] PartitionDescriptor partition, Slice prefix)
+			private IAsyncEnumerable<KeyValuePair<string, Slice>> SubdirNamesAndNodes(IFdbReadOnlyTransaction tr, PartitionDescriptor partition, Slice prefix)
 			{
 				Contract.Requires(tr != null && partition != null);
 
@@ -1094,7 +1052,7 @@ namespace FoundationDB.Client
 
 			/// <summary>Remove an existing node from its parents</summary>
 			/// <returns>True if the parent node was found, otherwise false</returns>
-			private async Task<bool> RemoveFromParent([NotNull] IFdbTransaction tr, FdbDirectoryPath path)
+			private async Task<bool> RemoveFromParent(IFdbTransaction tr, FdbDirectoryPath path)
 			{
 				Contract.Requires(tr != null);
 
@@ -1110,7 +1068,7 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Recursively remove a node (including the content), all its children</summary>
-			private async Task RemoveRecursive([NotNull] IFdbTransaction tr, [NotNull] PartitionDescriptor partition, Slice prefix)
+			private async Task RemoveRecursive(IFdbTransaction tr, PartitionDescriptor partition, Slice prefix)
 			{
 				Contract.Requires(tr != null && partition != null);
 
@@ -1126,7 +1084,7 @@ namespace FoundationDB.Client
 				tr.ClearRange(partition.Nodes.EncodeRange(prefix));
 			}
 
-			private async Task<bool> IsPrefixFree([NotNull] IFdbReadOnlyTransaction tr, PartitionDescriptor partition, Slice prefix)
+			private async Task<bool> IsPrefixFree(IFdbReadOnlyTransaction tr, PartitionDescriptor partition, Slice prefix)
 			{
 				Contract.Requires(tr != null);
 
@@ -1151,7 +1109,7 @@ namespace FoundationDB.Client
 					.ConfigureAwait(false);
 			}
 
-			private static Slice GetSubDirKey([NotNull] PartitionDescriptor partition, Slice prefix, string segment)
+			private static Slice GetSubDirKey(PartitionDescriptor partition, Slice prefix, string segment)
 			{
 				Contract.Requires(partition != null);
 
@@ -1241,10 +1199,21 @@ namespace FoundationDB.Client
 
 			internal async ValueTask<CacheContext> GetContext(IFdbReadOnlyTransaction trans)
 			{
+				Contract.NotNull(trans, nameof(trans));
+
+				// We will first check the value of the global \xff/metadataVersion key.
+				// - If it hasn't changed, then we assume that the current context is still valid
+				// - If it has changed, then we will have to read our local metadata version (stored in the partition)
+				//  - If it hasn't changed, the current context is still valid, and can be updated to the last global metadata version
+				//  - If it has changed, then we (for now) throw away the entire cache and start a new one.
+
+				// Check the global metadata version key (should be fast, obtained along side the transaction read version)
 				var gmv = await trans.GetMetadataVersionKeyAsync().ConfigureAwait(false);
+				// We can observe "null" if the key has already been touched previously in the same transaction.
+				// Since it is a versionstamp, we have no way to know its value until we commit, and this transaction will not be able cache anything
+				// => we hope that the NEXT transaction will rebuild the cache for us.
 
 				var context = Volatile.Read(ref this.Context) ?? this.Layer.Cache;
-
 				if (context != null)
 				{
 					if (gmv != null && context.MetadataVersion == gmv.Value)
@@ -1308,7 +1277,7 @@ namespace FoundationDB.Client
 				}
 			}
 
-			internal CacheContext Context;
+			internal CacheContext? Context;
 
 			string ISubspaceContext.Name => this.Context?.DirectoryLayer.FullName ?? "<invalid>";
 
@@ -1323,7 +1292,7 @@ namespace FoundationDB.Client
 
 		}
 
-		internal static FdbDirectoryPath VerifyPath(FdbDirectoryPath path, string argName = null)
+		internal static FdbDirectoryPath VerifyPath(FdbDirectoryPath path, string? argName = null)
 		{
 			// The path should not contain any null strings
 			var segments = path.Segments.Span;
@@ -1383,7 +1352,7 @@ namespace FoundationDB.Client
 			public Slice LayerVersion { get; set; }
 			// content of [PARTITION, "version"] key
 
-			public Dictionary<FdbDirectoryPath, FdbDirectorySubspace> CachedSubspaces { get; } = new Dictionary<FdbDirectoryPath, FdbDirectorySubspace>();
+			public Dictionary<FdbDirectoryPath, FdbDirectorySubspace?> CachedSubspaces { get; } = new Dictionary<FdbDirectoryPath, FdbDirectorySubspace?>();
 
 			private ReaderWriterLockSlim Lock { get; } = new ReaderWriterLockSlim();
 
@@ -1409,12 +1378,12 @@ namespace FoundationDB.Client
 			/// <param name="path">Absolute path to the subspace</param>
 			/// <param name="subspace">If the method returns <c>true</c>, receives the cached subspace instance.</param>
 			/// <returns>True if the subspace was found in the cache.</returns>
-			public bool TryGetSubspace([NotNull] IFdbReadOnlyTransaction tr, Metadata metadata, FdbDirectoryPath path, [CanBeNull] out FdbDirectorySubspace subspace)
+			public bool TryGetSubspace(IFdbReadOnlyTransaction tr, Metadata metadata, FdbDirectoryPath path, out FdbDirectorySubspace? subspace)
 			{
 				Contract.Requires(tr != null);
 				subspace = null;
 
-				FdbDirectorySubspace candidate;
+				FdbDirectorySubspace? candidate;
 
 				this.Lock.EnterReadLock();
 				try
@@ -1437,7 +1406,7 @@ namespace FoundationDB.Client
 				return true;
 			}
 
-			public FdbDirectorySubspace AddSubspace(FdbDirectoryPath path, [CanBeNull] FdbDirectorySubspace subspace)
+			public FdbDirectorySubspace? AddSubspace(FdbDirectoryPath path, FdbDirectorySubspace? subspace)
 			{
 				Contract.Requires(subspace == null || subspace.Descriptor.Path == path);
 				//TODO: check !
@@ -1462,14 +1431,13 @@ namespace FoundationDB.Client
 
 		}
 
-		[DebuggerDisplay("Path={Path}, Prefix={Prefix}, Parent=({Parent})")]
+		[DebuggerDisplay("Path={Path}, Prefix={Content}, Parent=({Parent})")]
 		internal sealed class PartitionDescriptor
 		{
 
 			public FdbDirectoryPath Path { get; }
 
-			[CanBeNull]
-			public PartitionDescriptor Parent { get; }
+			public PartitionDescriptor? Parent { get; }
 
 			public IDynamicKeySubspace Content { get; }
 
@@ -1479,7 +1447,7 @@ namespace FoundationDB.Client
 
 			public Slice MetadataKey { get; }
 
-			public PartitionDescriptor(FdbDirectoryPath path, IDynamicKeySubspace content, PartitionDescriptor parent)
+			public PartitionDescriptor(FdbDirectoryPath path, IDynamicKeySubspace content, PartitionDescriptor? parent)
 			{
 				this.Path = path;
 				this.Parent = parent;
@@ -1504,7 +1472,7 @@ namespace FoundationDB.Client
 		[DebuggerDisplay("Path={Path}, Prefix={Prefix}, Layer={Layer}, Partition={Partition.Path}|{Partition.Content.GetPrefix()}")]
 		internal sealed class DirectoryDescriptor
 		{
-			public DirectoryDescriptor([NotNull] FdbDirectoryLayer directoryLayer, FdbDirectoryPath path, Slice prefix, Slice layer, PartitionDescriptor partition)
+			public DirectoryDescriptor(FdbDirectoryLayer directoryLayer, FdbDirectoryPath path, Slice prefix, Slice layer, PartitionDescriptor partition)
 			{
 				Contract.Requires(directoryLayer != null && partition != null && path.StartsWith(partition.Path));
 

--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryPartition.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryPartition.cs
@@ -31,7 +31,6 @@ namespace FoundationDB.Client
 	using System;
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Serialization.Encoders;
-	using JetBrains.Annotations;
 
 	public class FdbDirectoryPartition : FdbDirectorySubspace
 	{
@@ -39,7 +38,7 @@ namespace FoundationDB.Client
 		/// <summary>Returns a slice with the ASCII string "partition"</summary>
 		public static Slice LayerId => Slice.FromString("partition");
 
-		internal FdbDirectoryPartition(FdbDirectoryLayer.DirectoryDescriptor descriptor, FdbDirectoryLayer.PartitionDescriptor parent, [NotNull] IDynamicKeyEncoder keyEncoder, [CanBeNull] ISubspaceContext context)
+		internal FdbDirectoryPartition(FdbDirectoryLayer.DirectoryDescriptor descriptor, FdbDirectoryLayer.PartitionDescriptor parent, IDynamicKeyEncoder keyEncoder, ISubspaceContext? context)
 			: base(descriptor, keyEncoder, context)
 		{
 			Contract.NotNull(parent, nameof(parent));

--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryPath.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryPath.cs
@@ -87,12 +87,12 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Append a new segment to the curent path</summary>
-		public FdbDirectoryPath this[[NotNull] string segment] => Add(segment);
+		public FdbDirectoryPath this[string segment] => Add(segment);
 
 		/// <summary>Append one or more new segments to the curent path</summary>
 		public FdbDirectoryPath this[ReadOnlySpan<string> segments] => Add(segments);
 
-		private static ReadOnlyMemory<string> AppendSegment(ReadOnlySpan<string> head, [NotNull] string segment)
+		private static ReadOnlyMemory<string> AppendSegment(ReadOnlySpan<string> head, string segment)
 		{
 			Contract.NotNull(segment, nameof(segment));
 			int n = head.Length;
@@ -102,7 +102,7 @@ namespace FoundationDB.Client
 			return tmp;
 		}
 
-		private static ReadOnlyMemory<string> AppendSegments(ReadOnlySpan<string> head, [NotNull] string segment1, [NotNull] string segment2)
+		private static ReadOnlyMemory<string> AppendSegments(ReadOnlySpan<string> head, string segment1, string segment2)
 		{
 			Contract.NotNull(segment1, nameof(segment1));
 			Contract.NotNull(segment2, nameof(segment2));
@@ -132,11 +132,11 @@ namespace FoundationDB.Client
 
 		/// <summary>Append a new segment to the curent path</summary>
 		[Pure]
-		public FdbDirectoryPath Add([NotNull] string segment) => new FdbDirectoryPath(AppendSegment(this.Segments.Span, segment));
+		public FdbDirectoryPath Add(string segment) => new FdbDirectoryPath(AppendSegment(this.Segments.Span, segment));
 
 		/// <summary>Append a new segment to the curent path</summary>
 		[Pure]
-		public FdbDirectoryPath Add([NotNull] string segment1, string segment2) => new FdbDirectoryPath(AppendSegments(this.Segments.Span, segment1, segment2));
+		public FdbDirectoryPath Add(string segment1, string segment2) => new FdbDirectoryPath(AppendSegments(this.Segments.Span, segment1, segment2));
 
 		/// <summary>Append a new segment to the curent path</summary>
 		[Pure]
@@ -148,11 +148,11 @@ namespace FoundationDB.Client
 
 		/// <summary>Add new segments to the current path</summary>
 		[Pure]
-		public FdbDirectoryPath Add([NotNull] params string[] segments) => new FdbDirectoryPath(AppendSegments(this.Segments.Span, segments.AsSpan()));
+		public FdbDirectoryPath Add(params string[] segments) => new FdbDirectoryPath(AppendSegments(this.Segments.Span, segments.AsSpan()));
 
 		/// <summary>Add new segments to the current path</summary>
 		[Pure]
-		public FdbDirectoryPath Add([NotNull] IEnumerable<string> segments) => new FdbDirectoryPath(AppendSegments(this.Segments.Span, segments));
+		public FdbDirectoryPath Add(IEnumerable<string> segments) => new FdbDirectoryPath(AppendSegments(this.Segments.Span, segments));
 
 		/// <summary>Add a path to the current path</summary>
 		[Pure]
@@ -236,7 +236,7 @@ namespace FoundationDB.Client
 		}
 
 		[Pure]
-		public static FdbDirectoryPath Combine([NotNull] params string[] segments)
+		public static FdbDirectoryPath Combine(params string[] segments)
 		{
 			Contract.NotNull(segments, nameof(segments));
 			return new FdbDirectoryPath(segments);
@@ -257,14 +257,14 @@ namespace FoundationDB.Client
 		}
 
 		[Pure]
-		public static FdbDirectoryPath Combine([NotNull, ItemNotNull] IEnumerable<string> segments)
+		public static FdbDirectoryPath Combine(IEnumerable<string> segments)
 		{
 			Contract.NotNull(segments, nameof(segments));
 			return new FdbDirectoryPath(segments.ToArray());
 		}
 
 		[Pure]
-		public static FdbDirectoryPath Parse([CanBeNull] string path)
+		public static FdbDirectoryPath Parse(string? path)
 		{
 			if (string.IsNullOrEmpty(path)) return Empty;
 
@@ -315,18 +315,18 @@ namespace FoundationDB.Client
 		}
 
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static implicit operator FdbDirectoryPath([NotNull] string segment)
+		public static implicit operator FdbDirectoryPath(string segment)
 		{
 			return Combine(segment);
 		}
 
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static implicit operator FdbDirectoryPath([NotNull, ItemNotNull] string[] segments)
+		public static implicit operator FdbDirectoryPath(string[] segments)
 		{
 			return Combine(segments);
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		internal static string FormatPath(ReadOnlySpan<string> paths)
 		{
 			var sb = new StringBuilder();

--- a/FoundationDB.Client/Layers/Directories/FdbHighContentionAllocator.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbHighContentionAllocator.cs
@@ -28,13 +28,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace FoundationDB.Layers.Allocators
 {
-	using FoundationDB.Client;
-	using FoundationDB.Filters.Logging;
-	using JetBrains.Annotations;
 	using System;
 	using System.Diagnostics;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
+	using FoundationDB.Client;
+	using FoundationDB.Filters.Logging;
 
 	/// <summary>Custom allocator that generates unique integer values with low probability of conflicts</summary>
 	[DebuggerDisplay("Location={" + nameof(Location) + "}")]
@@ -54,7 +53,6 @@ namespace FoundationDB.Layers.Allocators
 		}
 
 		/// <summary>Location of the allocator</summary>
-		[NotNull]
 		public TypedKeySubspaceLocation<int, long> Location { get; }
 
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
@@ -67,10 +65,8 @@ namespace FoundationDB.Layers.Allocators
 		public sealed class State
 		{
 			/// <summary>Location of the allocator</summary>
-			[NotNull]
 			public ITypedKeySubspace<int, long> Subspace { get; }
 
-			[NotNull]
 			private Random Rng { get; }
 
 			public State(ITypedKeySubspace<int, long> subspace, Random rng)
@@ -84,14 +80,14 @@ namespace FoundationDB.Layers.Allocators
 			///    method on the same subspace
 			/// 2) is nearly as short as possible given the above
 			/// </summary>
-			public Task<long> AllocateAsync([NotNull] IFdbTransaction trans)
+			public Task<long> AllocateAsync(IFdbTransaction trans)
 			{
 				return FdbHighContentionAllocator.AllocateAsync(trans, this.Subspace, this.Rng);
 			}
 
 		}
 
-		public static async Task<long> AllocateAsync([NotNull] IFdbTransaction trans, ITypedKeySubspace<int, long> subspace, Random rng)
+		public static async Task<long> AllocateAsync(IFdbTransaction trans, ITypedKeySubspace<int, long> subspace, Random rng)
 		{
 			Contract.NotNull(trans, nameof(trans));
 

--- a/FoundationDB.Client/Layers/Directories/IFdbDirectory.cs
+++ b/FoundationDB.Client/Layers/Directories/IFdbDirectory.cs
@@ -41,11 +41,9 @@ namespace FoundationDB.Client
 	public interface IFdbDirectory
 	{
 		/// <summary>Name of this <code>Directory</code>.</summary>
-		[NotNull]
 		string Name { get; }
 
 		/// <summary>Formatted path of this <code>Directory</code></summary>
-		[NotNull]
 		string FullName { get; }
 
 		/// <summary>Gets the path represented by this <code>Directory</code>.</summary>
@@ -55,30 +53,25 @@ namespace FoundationDB.Client
 		Slice Layer { get; }
 
 		/// <summary>Get the <code>DirectoryLayer</code> that was used to create this <code>Directory</code>.</summary>
-		[NotNull]
 		FdbDirectoryLayer DirectoryLayer { get; }
 
 		/// <summary>Get the location of the sub-directory with the given path</summary>
-		[NotNull]
 		FdbDirectorySubspaceLocation this[string segment] { get; }
 
 		/// <summary>Get the location of the sub-directory with the given path</summary>
-		[NotNull]
 		FdbDirectorySubspaceLocation this[string segment, Slice layer] { get; }
 
 		/// <summary>Get the location of the sub-directory with the given path</summary>
-		[NotNull]
 		FdbDirectorySubspaceLocation this[FdbDirectoryPath relativePath] { get; }
 
 		/// <summary>Get the location of the sub-directory with the given path</summary>
-		[NotNull]
 		FdbDirectorySubspaceLocation this[FdbDirectoryPath relativePath, Slice layer] { get; }
 
 		/// <summary>Opens a sub-directory with the given path.
 		/// If the sub-directory does not exist, it is created (creating intermediate subdirectories if necessary).
 		/// If layer is specified, it is checked against the layer of an existing sub-directory or set as the layer of a new sub-directory.
 		/// </summary>
-		Task<FdbDirectorySubspace> CreateOrOpenAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
+		Task<FdbDirectorySubspace> CreateOrOpenAsync(IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
 
 		/// <summary>Opens a sub-directory with the given <paramref name="path"/>.
 		/// An exception is thrown if the sub-directory does not exist, or if a layer is specified and a different layer was specified when the sub-directory was created.
@@ -86,7 +79,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Relative path of the sub-directory to open</param>
 		/// <param name="layer">Expected layer id for the sub-directory (optional)</param>
-		Task<FdbDirectorySubspace> OpenAsync([NotNull] IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
+		Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
 
 		/// <summary>Opens a sub-directory with the given <paramref name="path"/>.
 		/// An exception is thrown if the sub-directory if a layer is specified and a different layer was specified when the sub-directory was created.
@@ -95,8 +88,7 @@ namespace FoundationDB.Client
 		/// <param name="path">Relative path of the sub-directory to open</param>
 		/// <param name="layer">Expected layer id for the sub-directory (optional)</param>
 		/// <returns>Returns the directory if it exists, or null if it was not found</returns>
-		[ItemCanBeNull]
-		Task<FdbDirectorySubspace> TryOpenAsync([NotNull] IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
+		Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
 
 		/// <summary>Opens a sub-directory with the given <paramref name="path"/>, using the partition's cache context.</summary>
 		/// <returns>Returns the directory if it exists, or null if it was not found</returns>
@@ -104,8 +96,7 @@ namespace FoundationDB.Client
 		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, FdbDirectoryPath, Slice)"/> on every new transaction to obtained either the previously cached instance, or a new instance.
 		/// Attempting to used a cached instance outside the transaction that produced it may throw exceptions!
 		/// </remarks>
-		[ItemCanBeNull]
-		ValueTask<FdbDirectorySubspace> TryOpenCachedAsync([NotNull] IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
+		ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
 
 		/// <summary>Opens multiple sub-directories with the given <paramref name="paths"/>, using the partition's cache context.</summary>
 		/// <returns>Returns the list directories, in the same order. If a directory does not exist, the corresponding slot will contain <c>null</c></returns>
@@ -113,7 +104,7 @@ namespace FoundationDB.Client
 		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, IEnumerable{FdbDirectoryPath})"/> on every new transaction to obtained either the previously cached instances, or a new instances.
 		/// Attempting to used a cached instances outside the transaction that produced them may throw exceptions!
 		/// </remarks>
-		ValueTask<FdbDirectorySubspace[]> TryOpenCachedAsync([NotNull] IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<FdbDirectoryPath> paths);
+		ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<FdbDirectoryPath> paths);
 		//REVIEW: only keep the version that accept layers, and use an extension method instead?
 
 		/// <summary>Opens multiple sub-directories with the given <paramref name="paths"/>, using the partition's cache context.</summary>
@@ -122,7 +113,7 @@ namespace FoundationDB.Client
 		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, IEnumerable{ValueTuple{FdbDirectoryPath, Slice}})"/> on every new transaction to obtained either the previously cached instances, or a new instances.
 		/// Attempting to used a cached instances outside the transaction that produced them may throw exceptions!
 		/// </remarks>
-		ValueTask<FdbDirectorySubspace[]> TryOpenCachedAsync([NotNull] IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<(FdbDirectoryPath Path, Slice Layer)> paths);
+		ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<(FdbDirectoryPath Path, Slice Layer)> paths);
 
 		/// <summary>Creates a sub-directory with the given <paramref name="subPath"/> (creating intermediate subdirectories if necessary).
 		/// An exception is thrown if the given sub-directory already exists.
@@ -130,7 +121,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Relative path of the sub-directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the sub-directory and will be checked by future calls to open.</param>
-		Task<FdbDirectorySubspace> CreateAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
+		Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
 
 		/// <summary>Creates a sub-directory with the given <paramref name="subPath"/> (creating intermediate subdirectories if necessary).
 		/// An exception is thrown if the given sub-directory already exists.
@@ -138,14 +129,14 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Relative path of the sub-directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the sub-directory and will be checked by future calls to open.</param>
-		Task<FdbDirectorySubspace> TryCreateAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
+		Task<FdbDirectorySubspace?> TryCreateAsync(IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
 
 		/// <summary>Registers an existing prefix as a directory with the given <paramref name="subPath"/> (creating parent directories if necessary). This method is only indented for advanced use cases.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
 		/// <param name="prefix">The directory will be created with the given physical prefix; otherwise a prefix is allocated automatically.</param>
-		Task<FdbDirectorySubspace> RegisterAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer, Slice prefix);
+		Task<FdbDirectorySubspace> RegisterAsync(IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer, Slice prefix);
 
 		/// <summary>Moves the specified sub-directory to <paramref name="newPath"/>.
 		/// There is no effect on the physical prefix of the given directory, or on clients that already have the directory open.
@@ -155,7 +146,7 @@ namespace FoundationDB.Client
 		/// <param name="oldPath">Relative path under this directory of the sub-directory to be moved</param>
 		/// <param name="newPath">Relative path under this directory where the sub-directory will be moved to</param>
 		/// <returns>Returns the directory at its new location if successful.</returns>
-		Task<FdbDirectorySubspace> MoveAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath);
+		Task<FdbDirectorySubspace> MoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath);
 
 		/// <summary>Attempts to move the specified sub-directory to <paramref name="newPath"/>.
 		/// There is no effect on the physical prefix of the given directory, or on clients that already have the directory open.
@@ -165,7 +156,7 @@ namespace FoundationDB.Client
 		/// <param name="oldPath">Relative path under this directory of the sub-directory to be moved</param>
 		/// <param name="newPath">Relative path under this directory where the sub-directory will be moved to</param>
 		/// <returns>Returns the directory at its new location if successful. If the directory doesn't exist, then null is returned.</returns>
-		Task<FdbDirectorySubspace> TryMoveAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath);
+		Task<FdbDirectorySubspace?> TryMoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath);
 		//TODO: merge MoveAsync and TryMoveAsync into a single method!
 
 		/// <summary>Moves the current directory to <paramref name="newAbsolutePath"/>.
@@ -175,7 +166,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="newAbsolutePath">Full path (from the root) where this directory will be moved</param>
 		/// <returns>Returns the directory at its new location if successful.</returns>
-		Task<FdbDirectorySubspace> MoveToAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath newAbsolutePath);
+		Task<FdbDirectorySubspace> MoveToAsync(IFdbTransaction trans, FdbDirectoryPath newAbsolutePath);
 
 		/// <summary>Attempts to move the current directory to <paramref name="newAbsolutePath"/>.
 		/// There is no effect on the physical prefix of the given directory, or on clients that already have the directory open.
@@ -184,7 +175,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="newAbsolutePath">Full path (from the root) where this directory will be moved</param>
 		/// <returns>Returns the directory at its new location if successful. If the directory doesn't exist, then null is returned.</returns>
-		Task<FdbDirectorySubspace> TryMoveToAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath newAbsolutePath);
+		Task<FdbDirectorySubspace?> TryMoveToAsync(IFdbTransaction trans, FdbDirectoryPath newAbsolutePath);
 		//TODO: merge MoveToAsync and TryMoveToAsync into a single method!
 
 		/// <summary>Removes a directory, its contents, and all subdirectories.
@@ -192,32 +183,32 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to remove. Will remove the current directory if <paramref name="subPath"/> is empty</param>
-		Task RemoveAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath subPath = default);
+		Task RemoveAsync(IFdbTransaction trans, FdbDirectoryPath subPath = default);
 
 		/// <summary>Attempts to remove the directory, its contents, and all subdirectories.
 		/// Warning: Clients that have already opened the directory might still insert data into its contents after it is removed.
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to remove. Will remove the current directory if <paramref name="subPath"/> is empty</param>
-		Task<bool> TryRemoveAsync([NotNull] IFdbTransaction trans, FdbDirectoryPath subPath = default);
+		Task<bool> TryRemoveAsync(IFdbTransaction trans, FdbDirectoryPath subPath = default);
 		//TODO: merge RemoveAsync and TryRemoveAsync into a single method!
 
 		/// <summary>Checks if this directory exists</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to test</param>
 		/// <returns>Returns true if the directory exists, otherwise false.</returns>
-		Task<bool> ExistsAsync([NotNull] IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
+		Task<bool> ExistsAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
 
 		/// <summary>Returns the list of all the subdirectories of the current directory.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to list</param>
-		Task<List<string>> ListAsync([NotNull] IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
+		Task<List<string>> ListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
 		//TODO: return a List<FdbDirectoryPath> instead?
 
 		/// <summary>Returns the list of all the subdirectories of the current directory, it it exists.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to list</param>
-		Task<List<string>> TryListAsync([NotNull] IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
+		Task<List<string>?> TryListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
 		//TODO: return a List<FdbDirectoryPath> instead?
 		//TODO: merge ListAsync and TryListAsync into a single method!
 
@@ -231,7 +222,7 @@ namespace FoundationDB.Client
 		/// <summary>Change the layer id of this directory</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="newLayer">New layer id of this directory</param>
-		Task<FdbDirectorySubspace> ChangeLayerAsync([NotNull] IFdbTransaction trans, Slice newLayer);
+		Task<FdbDirectorySubspace> ChangeLayerAsync(IFdbTransaction trans, Slice newLayer);
 
 	}
 

--- a/FoundationDB.Client/Native/FdbFuture.cs
+++ b/FoundationDB.Client/Native/FdbFuture.cs
@@ -75,8 +75,7 @@ namespace FoundationDB.Client.Native
 		/// <param name="selector">Func that will be called to get the result once the future completes (and did not fail)</param>
 		/// <param name="ct">Optional cancellation token that can be used to cancel the future</param>
 		/// <returns>Object that tracks the execution of the FDBFuture handle</returns>
-		[NotNull]
-		public static FdbFutureSingle<T> FromHandle<T>([NotNull] FutureHandle handle, [NotNull] Func<FutureHandle, T> selector, CancellationToken ct)
+		public static FdbFutureSingle<T> FromHandle<T>(FutureHandle handle, Func<FutureHandle, T> selector, CancellationToken ct)
 		{
 			return new FdbFutureSingle<T>(handle, selector, ct);
 		}
@@ -87,8 +86,7 @@ namespace FoundationDB.Client.Native
 		/// <param name="selector">Func that will be called for each future that complete (and did not fail)</param>
 		/// <param name="ct">Optional cancellation token that can be used to cancel the future</param>
 		/// <returns>Object that tracks the execution of all the FDBFuture handles</returns>
-		[NotNull]
-		public static FdbFutureArray<T> FromHandleArray<T>([NotNull] FutureHandle[] handles, [NotNull] Func<FutureHandle, T> selector, CancellationToken ct)
+		public static FdbFutureArray<T> FromHandleArray<T>(FutureHandle[] handles, Func<FutureHandle, T> selector, CancellationToken ct)
 		{
 			return new FdbFutureArray<T>(handles, selector, ct);
 		}
@@ -99,7 +97,7 @@ namespace FoundationDB.Client.Native
 		/// <param name="continuation">Lambda that will be called once the future completes successfully, to extract the result from the future handle.</param>
 		/// <param name="ct">Optional cancellation token that can be used to cancel the future</param>
 		/// <returns>Task that will either return the result of the continuation lambda, or an exception</returns>
-		public static Task<T> CreateTaskFromHandle<T>([NotNull] FutureHandle handle, [NotNull] Func<FutureHandle, T> continuation, CancellationToken ct)
+		public static Task<T> CreateTaskFromHandle<T>(FutureHandle handle, Func<FutureHandle, T> continuation, CancellationToken ct)
 		{
 			return new FdbFutureSingle<T>(handle, continuation, ct).Task;
 		}
@@ -111,8 +109,7 @@ namespace FoundationDB.Client.Native
 		/// <param name="ct">Optional cancellation token that can be used to cancel the future</param>
 		/// <returns>Task that will either return all the results of the continuation lambdas, or an exception</returns>
 		/// <remarks>If at least one future fails, the whole task will fail.</remarks>
-		[ItemNotNull]
-		public static Task<T[]> CreateTaskFromHandleArray<T>([NotNull] FutureHandle[] handles, [NotNull] Func<FutureHandle, T> continuation, CancellationToken ct)
+		public static Task<T[]> CreateTaskFromHandleArray<T>(FutureHandle[] handles, Func<FutureHandle, T> continuation, CancellationToken ct)
 		{
 			// Special case, because FdbFutureArray<T> does not support empty arrays
 			//TODO: technically, there is no reason why FdbFutureArray would not accept an empty array. We should simplify this by handling the case in the ctor (we are already allocating something anyway...)
@@ -377,7 +374,7 @@ namespace FoundationDB.Client.Native
 		/// <param name="future">Future instance</param>
 		/// <returns>Parameter that can be passed to FutureSetCallback and that uniquely identify this future.</returns>
 		/// <remarks>The caller MUST call ClearCallbackHandler to ensure that the future instance is removed from the list</remarks>
-		internal static IntPtr RegisterCallback([NotNull] FdbFuture<T> future)
+		internal static IntPtr RegisterCallback(FdbFuture<T> future)
 		{
 			Contract.Requires(future != null);
 
@@ -401,7 +398,7 @@ namespace FoundationDB.Client.Native
 
 		/// <summary>Remove a future from the callback handler dictionary</summary>
 		/// <param name="future">Future that has just completed, or is being destroyed</param>
-		internal static void UnregisterCallback([NotNull] FdbFuture<T> future)
+		internal static void UnregisterCallback(FdbFuture<T> future)
 		{
 			Contract.Requires(future != null);
 
@@ -422,10 +419,9 @@ namespace FoundationDB.Client.Native
 			}
 		}
 
-		internal static FdbFuture<T> GetFutureFromCallbackParameter(IntPtr parameter)
+		internal static FdbFuture<T>? GetFutureFromCallbackParameter(IntPtr parameter)
 		{
-			FdbFuture<T> future;
-			if (s_futures.TryGetValue(parameter.ToInt64(), out future))
+			if (s_futures.TryGetValue(parameter.ToInt64(), out var future))
 			{
 				if (future != null && Volatile.Read(ref future.m_key) == parameter)
 				{

--- a/FoundationDB.Client/Native/FdbFutureArray.cs
+++ b/FoundationDB.Client/Native/FdbFutureArray.cs
@@ -28,7 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace FoundationDB.Client.Native
 {
-	using JetBrains.Annotations;
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
@@ -50,13 +49,13 @@ namespace FoundationDB.Client.Native
 		private int m_pending;
 
 		/// <summary>Lambda used to extract the result of this FDBFuture</summary>
-		private readonly Func<FutureHandle, T> m_resultSelector;
+		private readonly Func<FutureHandle, T>? m_resultSelector;
 
 		#endregion
 
 		#region Constructors...
 
-		internal FdbFutureArray([NotNull] FutureHandle[] handles, [NotNull] Func<FutureHandle, T> selector, CancellationToken ct)
+		internal FdbFutureArray(FutureHandle[] handles, Func<FutureHandle, T> selector, CancellationToken ct)
 		{
 			Contract.NotNullOrEmpty(handles, nameof(handles));
 			Contract.NotNull(selector, nameof(selector));
@@ -251,7 +250,7 @@ namespace FoundationDB.Client.Native
 			{
 				UnregisterCancellationRegistration();
 
-				List<Exception> errors = null;
+				List<Exception>? errors = null;
 				bool cancellation = false;
 				var selector = m_resultSelector;
 
@@ -269,7 +268,7 @@ namespace FoundationDB.Client.Native
 							if (err != FdbError.OperationCancelled)
 							{ // get the exception from the error code
 								var ex = Fdb.MapToException(err);
-								(errors ?? (errors = new List<Exception>())).Add(ex);
+								(errors ??= new List<Exception>()).Add(ex);
 							}
 							else
 							{
@@ -283,7 +282,7 @@ namespace FoundationDB.Client.Native
 							if (selector != null)
 							{
 								//note: result selector will execute from network thread, but this should be our own code that only calls into some fdb_future_get_XXXX(), which should be safe...
-								results[i] = selector(handle);
+								results![i] = selector(handle);
 							}
 						}
 					}

--- a/FoundationDB.Client/Native/FdbFutureSingle.cs
+++ b/FoundationDB.Client/Native/FdbFutureSingle.cs
@@ -33,7 +33,6 @@ namespace FoundationDB.Client.Native
 	using System;
 	using System.Threading;
 	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 
 	/// <summary>FDBFuture wrapper</summary>
 	/// <typeparam name="T">Type of result</typeparam>
@@ -45,13 +44,13 @@ namespace FoundationDB.Client.Native
 		private readonly FutureHandle m_handle;
 
 		/// <summary>Lambda used to extract the result of this FDBFuture</summary>
-		private readonly Func<FutureHandle, T> m_resultSelector;
+		private readonly Func<FutureHandle, T>? m_resultSelector;
 
 		#endregion
 
 		#region Constructors...
 
-		internal FdbFutureSingle([NotNull] FutureHandle handle, [NotNull] Func<FutureHandle, T> selector, CancellationToken ct)
+		internal FdbFutureSingle(FutureHandle handle, Func<FutureHandle, T> selector, CancellationToken ct)
 		{
 			Contract.NotNull(handle, nameof(handle));
 			Contract.NotNull(selector, nameof(selector));

--- a/FoundationDB.Client/Native/FdbNative.cs
+++ b/FoundationDB.Client/Native/FdbNative.cs
@@ -54,10 +54,10 @@ namespace FoundationDB.Client.Native
 #endif
 
 		/// <summary>Handle on the native FDB C API library</summary>
-		private static readonly UnmanagedLibrary FdbCLib;
+		private static readonly UnmanagedLibrary? FdbCLib;
 
 		/// <summary>Exception that was thrown when we last tried to load the native FDB C library (or null if nothing wrong happened)</summary>
-		private static readonly ExceptionDispatchInfo LibraryLoadError;
+		private static readonly ExceptionDispatchInfo? LibraryLoadError;
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		public delegate void FdbFutureCallback(IntPtr future, IntPtr parameter);
@@ -95,7 +95,7 @@ namespace FoundationDB.Client.Native
 			// Cluster
 
 			[DllImport(FDB_C_DLL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-			public static extern FutureHandle fdb_create_cluster([MarshalAs(UnmanagedType.LPStr)] string clusterFilePath);
+			public static extern FutureHandle fdb_create_cluster([MarshalAs(UnmanagedType.LPStr)] string? clusterFilePath);
 
 			[DllImport(FDB_C_DLL, CallingConvention = CallingConvention.Cdecl)]
 			public static extern void fdb_cluster_destroy(IntPtr cluster);
@@ -109,7 +109,7 @@ namespace FoundationDB.Client.Native
 			// Database
 
 			[DllImport(FDB_C_DLL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-			public static extern FdbError fdb_create_database([MarshalAs(UnmanagedType.LPStr)] string clusterFilePath, out DatabaseHandle database);
+			public static extern FdbError fdb_create_database([MarshalAs(UnmanagedType.LPStr)] string? clusterFilePath, out DatabaseHandle database);
 
 			[DllImport(FDB_C_DLL, CallingConvention = CallingConvention.Cdecl)]
 			public static extern void fdb_database_destroy(IntPtr database);
@@ -258,7 +258,7 @@ namespace FoundationDB.Client.Native
 			}
 			catch (Exception e)
 			{
-				if (FdbCLib != null) FdbCLib.Dispose();
+				FdbCLib?.Dispose();
 				FdbCLib = null;
 				if (e is BadImageFormatException && IntPtr.Size == 4)
 				{
@@ -273,7 +273,7 @@ namespace FoundationDB.Client.Native
 			
 		}
 
-		private static string GetPreloadPath()
+		private static string? GetPreloadPath()
 		{
 			// we need to provide sensible defaults for loading the native library
 			// if this method returns null we'll let PInvoke deal
@@ -316,16 +316,16 @@ namespace FoundationDB.Client.Native
 		private static void EnsureLibraryIsLoaded()
 		{
 			// should be inlined
-			if (LibraryLoadError != null) LibraryLoadError.Throw();
+			FdbNative.LibraryLoadError?.Throw();
 		}
 
-		private static string ToManagedString(byte* nativeString)
+		private static string? ToManagedString(byte* nativeString)
 		{
 			if (nativeString == null) return null;
 			return Marshal.PtrToStringAnsi(new IntPtr(nativeString));
 		}
 
-		private static string ToManagedString(IntPtr nativeString)
+		private static string? ToManagedString(IntPtr nativeString)
 		{
 			if (nativeString == IntPtr.Zero) return null;
 			return Marshal.PtrToStringAnsi(nativeString);
@@ -364,7 +364,7 @@ namespace FoundationDB.Client.Native
 		/// <summary>fdb_get_error</summary>
 		public static string GetError(FdbError code)
 		{
-			return ToManagedString(NativeMethods.fdb_get_error(code));
+			return ToManagedString(NativeMethods.fdb_get_error(code))!;
 		}
 
 		/// <summary>fdb_select_api_impl</summary>
@@ -472,7 +472,7 @@ namespace FoundationDB.Client.Native
 
 		#region Clusters...
 
-		public static FutureHandle CreateCluster(string path)
+		public static FutureHandle CreateCluster(string? path)
 		{
 			var future = NativeMethods.fdb_create_cluster(path);
 			Contract.Assert(future != null);
@@ -510,7 +510,7 @@ namespace FoundationDB.Client.Native
 
 		#region Databases...
 
-		public static FdbError CreateDatabase(string path, out DatabaseHandle database)
+		public static FdbError CreateDatabase(string? path, out DatabaseHandle database)
 		{
 			var err = NativeMethods.fdb_create_database(path, out database);
 #if DEBUG_NATIVE_CALLS
@@ -794,7 +794,7 @@ namespace FoundationDB.Client.Native
 			return err;
 		}
 
-		public static FdbError FutureGetKeyValueArray(FutureHandle future, out KeyValuePair<Slice, Slice>[] result, out bool more)
+		public static FdbError FutureGetKeyValueArray(FutureHandle future, out KeyValuePair<Slice, Slice>[]? result, out bool more)
 		{
 			result = null;
 
@@ -863,7 +863,7 @@ namespace FoundationDB.Client.Native
 			return err;
 		}
 
-		public static FdbError FutureGetKeyValueArrayKeysOnly(FutureHandle future, out KeyValuePair<Slice, Slice>[] result, out bool more)
+		public static FdbError FutureGetKeyValueArrayKeysOnly(FutureHandle future, out KeyValuePair<Slice, Slice>[]? result, out bool more)
 		{
 			result = null;
 
@@ -928,7 +928,7 @@ namespace FoundationDB.Client.Native
 			return err;
 		}
 
-		public static FdbError FutureGetKeyValueArrayValuesOnly(FutureHandle future, out KeyValuePair<Slice, Slice>[] result, out bool more, out Slice first, out Slice last)
+		public static FdbError FutureGetKeyValueArrayValuesOnly(FutureHandle future, out KeyValuePair<Slice, Slice>[]? result, out bool more, out Slice first, out Slice last)
 		{
 			result = null;
 			first = default;
@@ -1010,7 +1010,7 @@ namespace FoundationDB.Client.Native
 		}
 
 
-		public static FdbError FutureGetStringArray(FutureHandle future, out string[] result)
+		public static FdbError FutureGetStringArray(FutureHandle future, out string?[]? result)
 		{
 			result = null;
 

--- a/FoundationDB.Client/Native/FdbNativeDatabase.cs
+++ b/FoundationDB.Client/Native/FdbNativeDatabase.cs
@@ -37,29 +37,25 @@ namespace FoundationDB.Client.Native
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 
 	/// <summary>Wraps a native FDBDatabase* handle</summary>
 	[DebuggerDisplay("Handle={m_handle}, Closed={m_handle.IsClosed}")]
 	internal sealed class FdbNativeDatabase : IFdbDatabaseHandler
 	{
 		/// <summary>Handle that wraps the native FDB_DATABASE*</summary>
-		[NotNull]
 		private readonly DatabaseHandle m_handle;
 
 		/// <summary>Optional Cluster handle (only for API 600 or below)</summary>
-		[CanBeNull]
-		private readonly ClusterHandle m_clusterHandle;
+		private readonly ClusterHandle? m_clusterHandle;
 
 		/// <summary>Path to the cluster file</summary>
-		[CanBeNull]
-		private readonly string m_clusterFile;
+		private readonly string? m_clusterFile;
 
 #if CAPTURE_STACKTRACES
 		private readonly StackTrace m_stackTrace;
 #endif
 
-		public FdbNativeDatabase([NotNull] DatabaseHandle handle, [CanBeNull] string clusterFile, ClusterHandle cluster = null)
+		public FdbNativeDatabase(DatabaseHandle handle, string? clusterFile, ClusterHandle? cluster = null)
 		{
 			Contract.NotNull(handle, nameof(handle));
 
@@ -84,7 +80,7 @@ namespace FoundationDB.Client.Native
 		}
 #endif
 
-		public static ValueTask<IFdbDatabaseHandler> CreateDatabaseAsync(string clusterFile, CancellationToken ct)
+		public static ValueTask<IFdbDatabaseHandler> CreateDatabaseAsync(string? clusterFile, CancellationToken ct)
 		{
 			if (Fdb.GetMaxApiVersion() < 610)
 			{ // Older version used a different way to create a database handle
@@ -101,13 +97,13 @@ namespace FoundationDB.Client.Native
 			return new ValueTask<IFdbDatabaseHandler>(new FdbNativeDatabase(handle, clusterFile));
 		}
 
-		private static async ValueTask<IFdbDatabaseHandler> CreateDatabaseLegacyAsync(string clusterFile, CancellationToken ct)
+		private static async ValueTask<IFdbDatabaseHandler> CreateDatabaseLegacyAsync(string? clusterFile, CancellationToken ct)
 		{
 			// In legacy API versions, you first had to create "cluster" handle and then obtain a database handle that that cluster.
 			// The API is async, but the future always completed inline...
 
-			ClusterHandle cluster = null;
-			DatabaseHandle database = null;
+			ClusterHandle? cluster = null;
+			DatabaseHandle? database = null;
 			try
 			{
 				cluster = await FdbFuture.CreateTaskFromHandle(
@@ -148,7 +144,7 @@ namespace FoundationDB.Client.Native
 			}
 		}
 
-		public string ClusterFile => m_clusterFile;
+		public string? ClusterFile => m_clusterFile;
 
 		public bool IsInvalid => m_handle.IsInvalid;
 
@@ -169,7 +165,7 @@ namespace FoundationDB.Client.Native
 
 		public IFdbTransactionHandler CreateTransaction(FdbOperationContext context)
 		{
-			TransactionHandle handle = null;
+			TransactionHandle? handle = null;
 			try
 			{
 				var err = FdbNative.DatabaseCreateTransaction(m_handle, out handle);

--- a/FoundationDB.Client/Native/FdbNativeTransaction.cs
+++ b/FoundationDB.Client/Native/FdbNativeTransaction.cs
@@ -40,7 +40,6 @@ namespace FoundationDB.Client.Native
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
 	using FoundationDB.Client.Core;
-	using JetBrains.Annotations;
 
 	/// <summary>Wraps a native FDB_TRANSACTION handle</summary>
 	[DebuggerDisplay("Handle={m_handle}, Size={m_payloadBytes}, Closed={m_handle.IsClosed}")]
@@ -57,7 +56,7 @@ namespace FoundationDB.Client.Native
 		private StackTrace m_stackTrace;
 #endif
 
-		public FdbNativeTransaction([NotNull] FdbNativeDatabase db, [NotNull] TransactionHandle handle)
+		public FdbNativeTransaction(FdbNativeDatabase db, TransactionHandle handle)
 		{
 			Contract.NotNull(db, nameof(db));
 			Contract.NotNull(handle, nameof(handle));
@@ -208,7 +207,6 @@ namespace FoundationDB.Client.Native
 		/// <param name="first">Receives the first key in the page, or default if page is empty</param>
 		/// <param name="last">Receives the last key in the page, or default if page is empty</param>
 		/// <returns>Array of key/value pairs, or an exception</returns>
-		[NotNull]
 		private static KeyValuePair<Slice, Slice>[] GetKeyValueArrayResult(FutureHandle h, out bool more, out Slice first, out Slice last)
 		{
 			var err = FdbNative.FutureGetKeyValueArray(h, out var result, out more);
@@ -226,7 +224,6 @@ namespace FoundationDB.Client.Native
 		/// <param name="first">Receives the first key in the page, or default if page is empty</param>
 		/// <param name="last">Receives the last key in the page, or default if page is empty</param>
 		/// <returns>Array of key/value pairs, or an exception</returns>
-		[NotNull]
 		private static KeyValuePair<Slice, Slice>[] GetKeyValueArrayResultKeysOnly(FutureHandle h, out bool more, out Slice first, out Slice last)
 		{
 			var err = FdbNative.FutureGetKeyValueArrayKeysOnly(h, out var result, out more);
@@ -244,7 +241,6 @@ namespace FoundationDB.Client.Native
 		/// <param name="first">Receives the first key in the page, or default if page is empty</param>
 		/// <param name="last">Receives the last key in the page, or default if page is empty</param>
 		/// <returns>Array of key/value pairs, or an exception</returns>
-		[NotNull]
 		private static KeyValuePair<Slice, Slice>[] GetKeyValueArrayResultValuesOnly(FutureHandle h, out bool more, out Slice first, out Slice last)
 		{
 			var err = FdbNative.FutureGetKeyValueArrayValuesOnly(h, out var result, out more, out first, out last);
@@ -392,8 +388,6 @@ namespace FoundationDB.Client.Native
 			Fdb.DieOnError(err);
 		}
 
-		/// <inheritdoc />
-		[NotNull]
 		private static string[] GetStringArrayResult(FutureHandle h)
 		{
 			Contract.Requires(h != null);
@@ -496,13 +490,13 @@ namespace FoundationDB.Client.Native
 		public Task CommitAsync(CancellationToken ct)
 		{
 			var future = FdbNative.TransactionCommit(m_handle);
-			return FdbFuture.CreateTaskFromHandle<object>(future, (h) => null, ct);
+			return FdbFuture.CreateTaskFromHandle<object?>(future, (h) => null, ct);
 		}
 
 		public Task OnErrorAsync(FdbError code, CancellationToken ct)
 		{
 			var future = FdbNative.TransactionOnError(m_handle, code);
-			return FdbFuture.CreateTaskFromHandle<object>(future, (h) => { ResetInternal(); return null; }, ct);
+			return FdbFuture.CreateTaskFromHandle<object?>(future, (h) => { ResetInternal(); return null; }, ct);
 		}
 
 		public void Reset()

--- a/FoundationDB.Client/Native/UnmanagedLibrary.cs
+++ b/FoundationDB.Client/Native/UnmanagedLibrary.cs
@@ -33,7 +33,6 @@ namespace FoundationDB.Client.Native
 	using System.Runtime.InteropServices;
 	using System.Security;
 	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 	using Microsoft.Win32.SafeHandles;
 
 	/// <summary>Native Library Loader</summary>
@@ -125,8 +124,7 @@ namespace FoundationDB.Client.Native
 		/// <param name="path">Path to the native dll.</param>
 		/// <remarks>Throws exceptions on failure. Most common failure would be file-not-found, or that the file is not a  loadable image.</remarks>
 		/// <exception cref="System.IO.FileNotFoundException">if fileName can't be found</exception>
-		[NotNull]
-		public static UnmanagedLibrary Load([NotNull] string path)
+		public static UnmanagedLibrary Load(string path)
 		{
 			Contract.NotNull(path, nameof(path));
 
@@ -143,7 +141,7 @@ namespace FoundationDB.Client.Native
 			return new UnmanagedLibrary(handle, path);
 		}
 
-		/// <summary>Constructor to load a dll and be responible for freeing it.</summary>
+		/// <summary>Constructor to load a dll and be responsible for freeing it.</summary>
 		/// <param name="handle">Handle to the loaded library</param>
 		/// <param name="path">Full path of library to load</param>
 		private UnmanagedLibrary(SafeLibraryHandle handle, string path)
@@ -153,15 +151,13 @@ namespace FoundationDB.Client.Native
 		}
 
 		/// <summary>Path of the native library, as passed to LoadLibrary</summary>
-		[NotNull]
 		public string Path { get; }
 
 		/// <summary>Unmanaged resource. CLR will ensure SafeHandles get freed, without requiring a finalizer on this class.</summary>
-		[NotNull]
 		public SafeLibraryHandle Handle { get; }
 
 		/// <summary>Call FreeLibrary on the unmanaged dll. All function pointers handed out from this class become invalid after this.</summary>
-		/// <remarks>This is very dangerous because it suddenly invalidate everything retrieved from this dll. This includes any functions handed out via GetProcAddress, and potentially any objects returned from those functions (which may have an implemention in the dll)./// </remarks>
+		/// <remarks>This is very dangerous because it suddenly invalidate everything retrieved from this dll. This includes any functions handed out via GetProcAddress, and potentially any objects returned from those functions (which may have an implementation in the dll)./// </remarks>
 		public void Dispose()
 		{
 			if (!this.Handle.IsClosed)

--- a/FoundationDB.Client/Shared/Async/AsyncBuffer.cs
+++ b/FoundationDB.Client/Shared/Async/AsyncBuffer.cs
@@ -57,7 +57,7 @@ namespace Doxense.Async
 
 		#region Constructors...
 
-		public AsyncBuffer([NotNull] Func<TInput, TOutput> transform, int capacity)
+		public AsyncBuffer(Func<TInput, TOutput> transform, int capacity)
 			: base(capacity)
 		{
 			Contract.NotNull(transform, nameof(transform));

--- a/FoundationDB.Client/Shared/Async/AsyncCancellableMutex.cs
+++ b/FoundationDB.Client/Shared/Async/AsyncCancellableMutex.cs
@@ -56,7 +56,7 @@ namespace Doxense.Async
 		}
 
 		/// <summary>Mutex that has already completed</summary>
-		public static AsyncCancelableMutex AlreadyDone { [NotNull] get; } = CreateAlreadyDone();
+		public static AsyncCancelableMutex AlreadyDone { get; } = CreateAlreadyDone();
 
 		private const int STATE_NONE = 0;
 		private const int STATE_SET = 1;

--- a/FoundationDB.Client/Shared/Async/AsyncTaskBuffer.cs
+++ b/FoundationDB.Client/Shared/Async/AsyncTaskBuffer.cs
@@ -124,7 +124,7 @@ namespace Doxense.Async
 		}
 
 		/// <summary>Observe the completion of a task to wake up the consumer</summary>
-		private void ObserveTaskCompletion([NotNull] Task<T> task)
+		private void ObserveTaskCompletion(Task<T> task)
 		{
 			task.ContinueWith(
 				(t, state) =>
@@ -176,7 +176,7 @@ namespace Doxense.Async
 			WakeUpBlockedConsumer_NeedsLocking();
 		}
 
-		private async Task WaitForNextFreeSlotThenEnqueueAsync(Task<T> task, [NotNull] Task wait, CancellationToken ct)
+		private async Task WaitForNextFreeSlotThenEnqueueAsync(Task<T> task, Task wait, CancellationToken ct)
 		{
 			ct.ThrowIfCancellationRequested();
 
@@ -287,7 +287,7 @@ namespace Doxense.Async
 			return Task.FromResult(item);
 		}
 
-		private async Task<Maybe<T>> WaitForTaskToCompleteAsync([NotNull] Task<T> task, CancellationToken ct)
+		private async Task<Maybe<T>> WaitForTaskToCompleteAsync(Task<T> task, CancellationToken ct)
 		{
 			// we just need to wait for this task to complete, and return it
 
@@ -313,7 +313,7 @@ namespace Doxense.Async
 			}
 		}
 
-		private async Task<Maybe<T>> WaitForCompletionOrNextItemAsync([NotNull] Task wait, CancellationToken ct)
+		private async Task<Maybe<T>> WaitForCompletionOrNextItemAsync(Task wait, CancellationToken ct)
 		{
 			// we wait for any activity (new task or one that completes)
 

--- a/FoundationDB.Client/Shared/Async/AsyncTransform.cs
+++ b/FoundationDB.Client/Shared/Async/AsyncTransform.cs
@@ -42,10 +42,10 @@ namespace Doxense.Async
 	{
 		private readonly IAsyncTarget<Task<TOutput>> m_target;
 		private readonly Func<TInput, CancellationToken, Task<TOutput>> m_transform;
-		private readonly TaskScheduler m_scheduler;
+		private readonly TaskScheduler? m_scheduler;
 		private bool m_done;
 
-		public AsyncTransform([NotNull] Func<TInput, CancellationToken, Task<TOutput>> transform, [NotNull] IAsyncTarget<Task<TOutput>> target, TaskScheduler scheduler = null)
+		public AsyncTransform(Func<TInput, CancellationToken, Task<TOutput>> transform, IAsyncTarget<Task<TOutput>> target, TaskScheduler? scheduler = null)
 		{
 			Contract.NotNull(transform, nameof(transform));
 			Contract.NotNull(target, nameof(target));
@@ -59,7 +59,7 @@ namespace Doxense.Async
 		public IAsyncTarget<Task<TOutput>> Target => m_target;
 
 		/// <summary>Optional scheduler used to run the tasks</summary>
-		public TaskScheduler Scheduler => m_scheduler;
+		public TaskScheduler? Scheduler => m_scheduler;
 
 		#region IAsyncTarget<T>...
 

--- a/FoundationDB.Client/Shared/Async/TaskHelpers.cs
+++ b/FoundationDB.Client/Shared/Async/TaskHelpers.cs
@@ -34,7 +34,6 @@ namespace Doxense.Threading.Tasks
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 
 	/// <summary>Helper methods to work on tasks</summary>
 	internal static class TaskHelpers
@@ -44,7 +43,7 @@ namespace Doxense.Threading.Tasks
 		public static class CachedTasks<T>
 		{
 
-			public static readonly Task<T> Default = Task.FromResult<T>(default(T));
+			public static readonly Task<T> Default = Task.FromResult<T>(default!);
 
 			/// <summary>Returns a lambda function that returns the default value of <typeparamref name="T"/></summary>
 			public static Func<T> Nop
@@ -52,7 +51,7 @@ namespace Doxense.Threading.Tasks
 				get
 				{
 					//note: the compiler should but this in a static cache variable
-					return () => default(T);
+					return () => default!;
 				}
 			}
 
@@ -131,27 +130,27 @@ namespace Doxense.Threading.Tasks
 		}
 
 		/// <summary>Continue processing a task, if it succeeded</summary>
-		public static async Task Then<T>(this Task<T> task, [NotNull] Action<T> inlineContinuation)
+		public static async Task Then<T>(this Task<T> task, Action<T> inlineContinuation)
 		{
-			// Note: we use 'await' instead of ContinueWith, so that we can give the caller a nicer callstack in case of errors (instead of an AggregateExecption)
+			// Note: we use 'await' instead of ContinueWith, so that we can give the caller a nicer callstack in case of errors (instead of an AggregateException)
 
 			var value = await task.ConfigureAwait(false);
 			inlineContinuation(value);
 		}
 
 		/// <summary>Continue processing a task, if it succeeded</summary>
-		public static async Task<R> Then<T, R>(this Task<T> task, [NotNull] Func<T, R> inlineContinuation)
+		public static async Task<R> Then<T, R>(this Task<T> task, Func<T, R> inlineContinuation)
 		{
-			// Note: we use 'await' instead of ContinueWith, so that we can give the caller a nicer callstack in case of errors (instead of an AggregateExecption)
+			// Note: we use 'await' instead of ContinueWith, so that we can give the caller a nicer callstack in case of errors (instead of an AggregateException)
 
 			var value = await task.ConfigureAwait(false);
 			return inlineContinuation(value);
 		}
 
 		/// <summary>Continue processing a task, if it succeeded</summary>
-		public static async Task<R> Then<T, R>(this Task<T> task, [NotNull] Func<T, Task<R>> inlineContinuation)
+		public static async Task<R> Then<T, R>(this Task<T> task, Func<T, Task<R>> inlineContinuation)
 		{
-			// Note: we use 'await' instead of ContinueWith, so that we can give the caller a nicer callstack in case of errors (instead of an AggregateExecption)
+			// Note: we use 'await' instead of ContinueWith, so that we can give the caller a nicer callstack in case of errors (instead of an AggregateException)
 
 			var value = await task.ConfigureAwait(false);
 			return await inlineContinuation(value);
@@ -161,9 +160,9 @@ namespace Doxense.Threading.Tasks
 		/// <typeparam name="R">Type of the result of the lambda</typeparam>
 		/// <param name="lambda">Synchronous lambda function that returns a value, or throws exceptions</param>
 		/// <param name="ct">Cancellation token</param>
-		/// <returns>Task that either contains the result of the lambda, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task throwed an OperationCanceledException</returns>
+		/// <returns>Task that either contains the result of the lambda, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task threw an OperationCanceledException</returns>
 		/// <exception cref="System.ArgumentNullException">If <paramref name="lambda"/> is null</exception>
-		public static Task<R> Inline<R>([NotNull] Func<R> lambda, CancellationToken ct = default(CancellationToken))
+		public static Task<R> Inline<R>(Func<R> lambda, CancellationToken ct = default)
 		{
 			if (lambda == null) throw new ArgumentNullException(nameof(lambda));
 
@@ -184,9 +183,9 @@ namespace Doxense.Threading.Tasks
 		/// <param name="action">Synchronous action that takes a value.</param>
 		/// <param name="arg1">Argument that will be passed to <paramref name="action"/></param>
 		/// <param name="ct">Cancellation token</param>
-		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task throwed an OperationCanceledException</returns>
+		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task threw an OperationCanceledException</returns>
 		/// <exception cref="System.ArgumentNullException">If <paramref name="action"/> is null</exception>
-		public static Task Inline<T1>([NotNull] Action<T1> action, T1 arg1, CancellationToken ct = default(CancellationToken))
+		public static Task Inline<T1>(Action<T1> action, T1 arg1, CancellationToken ct = default)
 		{
 			// note: if action is null, then there is a bug in the caller, and it should blow up instantly (will help preserving the call stack)
 			if (action == null) throw new ArgumentNullException(nameof(action));
@@ -210,9 +209,9 @@ namespace Doxense.Threading.Tasks
 		/// <param name="arg1">First argument that will be passed to <paramref name="action"/></param>
 		/// <param name="arg2">Second argument that will be passed to <paramref name="action"/></param>
 		/// <param name="ct">Cancellation token</param>
-		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task throwed an OperationCanceledException</returns>
+		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task threw an OperationCanceledException</returns>
 		/// <exception cref="System.ArgumentNullException">If <paramref name="action"/> is null</exception>
-		public static Task Inline<T1, T2>([NotNull] Action<T1, T2> action, T1 arg1, T2 arg2, CancellationToken ct = default(CancellationToken))
+		public static Task Inline<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, CancellationToken ct = default)
 		{
 			// note: if action is null, then there is a bug in the caller, and it should blow up instantly (will help preserving the call stack)
 			if (action == null) throw new ArgumentNullException(nameof(action));
@@ -238,9 +237,9 @@ namespace Doxense.Threading.Tasks
 		/// <param name="arg2">Second argument that will be passed to <paramref name="action"/></param>
 		/// <param name="arg3">Third argument that will be passed to <paramref name="action"/></param>
 		/// <param name="ct">Cancellation token</param>
-		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task throwed an OperationCanceledException</returns>
+		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task threw an OperationCanceledException</returns>
 		/// <exception cref="System.ArgumentNullException">If <paramref name="action"/> is null</exception>
-		public static Task Inline<T1, T2, T3>([NotNull] Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, CancellationToken ct = default(CancellationToken))
+		public static Task Inline<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, CancellationToken ct = default)
 		{
 			// note: if action is null, then there is a bug in the caller, and it should blow up instantly (will help preserving the call stack)
 			if (action == null) throw new ArgumentNullException(nameof(action));
@@ -268,9 +267,9 @@ namespace Doxense.Threading.Tasks
 		/// <param name="arg3">Third argument that will be passed to <paramref name="action"/></param>
 		/// <param name="arg4">Fourth argument that will be passed to <paramref name="action"/></param>
 		/// <param name="ct">Cancellation token</param>
-		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task throwed an OperationCanceledException</returns>
+		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task threw an OperationCanceledException</returns>
 		/// <exception cref="System.ArgumentNullException">If <paramref name="action"/> is null</exception>
-		public static Task Inline<T1, T2, T3, T4>([NotNull] Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken ct = default(CancellationToken))
+		public static Task Inline<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken ct = default)
 		{
 			// note: if action is null, then there is a bug in the caller, and it should blow up instantly (will help preserving the call stack)
 			if (action == null) throw new ArgumentNullException(nameof(action));
@@ -300,9 +299,9 @@ namespace Doxense.Threading.Tasks
 		/// <param name="arg4">Fourth argument that will be passed to <paramref name="action"/></param>
 		/// <param name="arg5">Fifth argument that will be passed to <paramref name="action"/></param>
 		/// <param name="ct">Cancellation token</param>
-		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task throwed an OperationCanceledException</returns>
+		/// <returns>Task that is either already completed, wraps the exception that was thrown, or is in the cancelled state if the cancellation token fired or if the task threw an OperationCanceledException</returns>
 		/// <exception cref="System.ArgumentNullException">If <paramref name="action"/> is null</exception>
-		public static Task Inline<T1, T2, T3, T4, T5>([NotNull] Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken ct = default(CancellationToken))
+		public static Task Inline<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken ct = default)
 		{
 			// note: if action is null, then there is a bug in the caller, and it should blow up instantly (will help preserving the call stack)
 			if (action == null) throw new ArgumentNullException(nameof(action));
@@ -322,7 +321,7 @@ namespace Doxense.Threading.Tasks
 		/// <summary>Wraps a classic lambda into one that supports cancellation</summary>
 		/// <param name="lambda">Lambda that does not support cancellation</param>
 		/// <returns>New lambda that will check if the token is cancelled before calling <paramref name="lambda"/></returns>
-		public static Func<TSource, CancellationToken, TResult> WithCancellation<TSource, TResult>([NotNull] Func<TSource, TResult> lambda)
+		public static Func<TSource, CancellationToken, TResult> WithCancellation<TSource, TResult>(Func<TSource, TResult> lambda)
 		{
 			Contract.Requires(lambda != null);
 			return (value, ct) =>
@@ -335,7 +334,7 @@ namespace Doxense.Threading.Tasks
 		/// <summary>Wraps a classic lambda into one that supports cancellation</summary>
 		/// <param name="lambda">Lambda that does not support cancellation</param>
 		/// <returns>New lambda that will check if the token is cancelled before calling <paramref name="lambda"/></returns>
-		public static Func<TSource, CancellationToken, Task<TResult>> WithCancellation<TSource, TResult>([NotNull] Func<TSource, Task<TResult>> lambda)
+		public static Func<TSource, CancellationToken, Task<TResult>> WithCancellation<TSource, TResult>(Func<TSource, Task<TResult>> lambda)
 		{
 			Contract.Requires(lambda != null);
 			return (value, ct) =>
@@ -398,7 +397,7 @@ namespace Doxense.Threading.Tasks
 		}
 
 		/// <summary>Update the state of a TaskCompletionSource to reflect the type of error that occurred</summary>
-		public static void PropagateException<T>([NotNull] TaskCompletionSource<T> tcs, Exception e)
+		public static void PropagateException<T>(TaskCompletionSource<T> tcs, Exception e)
 		{
 			if (e is OperationCanceledException)
 			{
@@ -416,7 +415,7 @@ namespace Doxense.Threading.Tasks
 
 		/// <summary>Ensure that a task will be observed by someone, in the event that it would fail</summary>
 		/// <remarks>This helps discard any unhandled task exceptions, for fire&amp;forget tasks</remarks>
-		public static void Observe(Task task)
+		public static void Observe(Task? task)
 		{
 			if (task != null)
 			{
@@ -433,7 +432,7 @@ namespace Doxense.Threading.Tasks
 
 		/// <summary>Safely cancel a CancellationTokenSource</summary>
 		/// <param name="source">CancellationTokenSource that needs to be cancelled</param>
-		public static void SafeCancel(this CancellationTokenSource source)
+		public static void SafeCancel(this CancellationTokenSource? source)
 		{
 			if (source != null && !source.IsCancellationRequested)
 			{
@@ -446,7 +445,7 @@ namespace Doxense.Threading.Tasks
 		}
 		/// <summary>Safely cancel and dispose a CancellationTokenSource</summary>
 		/// <param name="source">CancellationTokenSource that needs to be cancelled and disposed</param>
-		public static void SafeCancelAndDispose(this CancellationTokenSource source)
+		public static void SafeCancelAndDispose(this CancellationTokenSource? source)
 		{
 			if (source != null)
 			{

--- a/FoundationDB.Client/Shared/CodeAnnotations.cs
+++ b/FoundationDB.Client/Shared/CodeAnnotations.cs
@@ -48,7 +48,7 @@ namespace JetBrains.Annotations
 	internal sealed class NotNullAttribute : Attribute { }
 
 	/// <summary>
-	/// Can be appplied to symbols of types derived from IEnumerable as well as to symbols of Task
+	/// Can be applied to symbols of types derived from IEnumerable as well as to symbols of Task
 	/// and Lazy classes to indicate that the value of a collection item, of the Task.Result property
 	/// or of the Lazy.Value property can never be null.
 	/// </summary>
@@ -59,7 +59,7 @@ namespace JetBrains.Annotations
 	internal sealed class ItemNotNullAttribute : Attribute { }
 
 	/// <summary>
-	/// Can be appplied to symbols of types derived from IEnumerable as well as to symbols of Task
+	/// Can be applied to symbols of types derived from IEnumerable as well as to symbols of Task
 	/// and Lazy classes to indicate that the value of a collection item, of the Task.Result property
 	/// or of the Lazy.Value property can be null.
 	/// </summary>
@@ -120,7 +120,6 @@ namespace JetBrains.Annotations
 			Name = name;
 		}
 
-		[NotNull]
 		public string Name { get; }
 	}
 
@@ -186,10 +185,10 @@ namespace JetBrains.Annotations
 	[Conditional("JETBRAINS_ANNOTATIONS")]
 	internal sealed class ContractAnnotationAttribute : Attribute
 	{
-		public ContractAnnotationAttribute([NotNull] string contract)
+		public ContractAnnotationAttribute(string contract)
 		  : this(contract, false) { }
 
-		public ContractAnnotationAttribute([NotNull] string contract, bool forceFullStates)
+		public ContractAnnotationAttribute(string contract, bool forceFullStates)
 		{
 			Contract = contract;
 			ForceFullStates = forceFullStates;
@@ -239,12 +238,11 @@ namespace JetBrains.Annotations
 	[Conditional("JETBRAINS_ANNOTATIONS")]
 	internal sealed class BaseTypeRequiredAttribute : Attribute
 	{
-		public BaseTypeRequiredAttribute([NotNull] Type baseType)
+		public BaseTypeRequiredAttribute(Type baseType)
 		{
 			BaseType = baseType;
 		}
 
-		[NotNull]
 		public Type BaseType { get; set; }
 	}
 
@@ -345,7 +343,7 @@ namespace JetBrains.Annotations
 	internal sealed class PublicAPIAttribute : Attribute
 	{
 		public PublicAPIAttribute() { }
-		public PublicAPIAttribute([NotNull] string comment)
+		public PublicAPIAttribute(string comment)
 		{
 			Comment = comment;
 		}
@@ -385,7 +383,7 @@ namespace JetBrains.Annotations
 	internal sealed class MustUseReturnValueAttribute : Attribute
 	{
 		public MustUseReturnValueAttribute() { }
-		public MustUseReturnValueAttribute([NotNull] string justification)
+		public MustUseReturnValueAttribute(string justification)
 		{
 			Justification = justification;
 		}

--- a/FoundationDB.Client/Shared/CodeAnnotations.cs
+++ b/FoundationDB.Client/Shared/CodeAnnotations.cs
@@ -14,70 +14,6 @@ namespace JetBrains.Annotations
 	//README: these should all be marked as 'internal', so as not to conflict with the same attributes that would exist in the parent application !
 
 	/// <summary>
-	/// Indicates that the value of the marked element could be <c>null</c> sometimes,
-	/// so the check for <c>null</c> is necessary before its usage.
-	/// </summary>
-	/// <example><code>
-	/// [CanBeNull] object Test() => null;
-	///
-	/// void UseTest() {
-	///   var p = Test();
-	///   var s = p.ToString(); // Warning: Possible 'System.NullReferenceException'
-	/// }
-	/// </code></example>
-	[AttributeUsage(
-	  AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
-	  AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event |
-	  AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.GenericParameter)]
-	[Conditional("JETBRAINS_ANNOTATIONS")]
-	internal sealed class CanBeNullAttribute : Attribute { }
-
-	/// <summary>
-	/// Indicates that the value of the marked element could never be <c>null</c>.
-	/// </summary>
-	/// <example><code>
-	/// [NotNull] object Foo() {
-	///   return null; // Warning: Possible 'null' assignment
-	/// }
-	/// </code></example>
-	[AttributeUsage(
-	  AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
-	  AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event |
-	  AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.GenericParameter)]
-	[Conditional("JETBRAINS_ANNOTATIONS")]
-	internal sealed class NotNullAttribute : Attribute { }
-
-	/// <summary>
-	/// Can be applied to symbols of types derived from IEnumerable as well as to symbols of Task
-	/// and Lazy classes to indicate that the value of a collection item, of the Task.Result property
-	/// or of the Lazy.Value property can never be null.
-	/// </summary>
-	[AttributeUsage(
-	  AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
-	  AttributeTargets.Delegate | AttributeTargets.Field)]
-	[Conditional("JETBRAINS_ANNOTATIONS")]
-	internal sealed class ItemNotNullAttribute : Attribute { }
-
-	/// <summary>
-	/// Can be applied to symbols of types derived from IEnumerable as well as to symbols of Task
-	/// and Lazy classes to indicate that the value of a collection item, of the Task.Result property
-	/// or of the Lazy.Value property can be null.
-	/// </summary>
-	[AttributeUsage(
-	  AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
-	  AttributeTargets.Delegate | AttributeTargets.Field)]
-	[Conditional("JETBRAINS_ANNOTATIONS")]
-	internal sealed class ItemCanBeNullAttribute : Attribute { }
-
-	/// <summary>
-	/// Implicitly apply [NotNull]/[ItemNotNull] annotation to all the of type members and parameters
-	/// in particular scope where this annotation is used (type declaration or whole assembly).
-	/// </summary>
-	[AttributeUsage(
-	  AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Assembly)]
-	internal sealed class ImplicitNotNullAttribute : Attribute { }
-
-	/// <summary>
 	/// Indicates that the marked method builds string by format pattern and (optional) arguments.
 	/// Parameter, which contains format string, should be given in constructor. The format string
 	/// should be in <see cref="string.Format(IFormatProvider,string,object[])"/>-like form.
@@ -105,22 +41,6 @@ namespace JetBrains.Annotations
 		}
 
 		public string FormatParameterName { get; }
-	}
-
-	/// <summary>
-	/// For a parameter that is expected to be one of the limited set of values.
-	/// Specify fields of which type should be used as values for this parameter.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Field)]
-	[Conditional("JETBRAINS_ANNOTATIONS")]
-	internal sealed class ValueProviderAttribute : Attribute
-	{
-		public ValueProviderAttribute(string name)
-		{
-			Name = name;
-		}
-
-		public string Name { get; }
 	}
 
 	/// <summary>
@@ -392,27 +312,6 @@ namespace JetBrains.Annotations
 	}
 
 	/// <summary>
-	/// Indicates the type member or parameter of some type, that should be used instead of all other ways
-	/// to get the value that type. This annotation is useful when you have some "context" value evaluated
-	/// and stored somewhere, meaning that all other ways to get this value must be consolidated with existing one.
-	/// </summary>
-	/// <example><code>
-	/// class Foo {
-	///   [ProvidesContext] IBarService _barService = ...;
-	/// 
-	///   void ProcessNode(INode node) {
-	///     DoSomething(node, node.GetGlobalServices().Bar);
-	///     //              ^ Warning: use value of '_barService' field
-	///   }
-	/// }
-	/// </code></example>
-	[AttributeUsage(
-	  AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.Method |
-	  AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.GenericParameter)]
-	[Conditional("JETBRAINS_ANNOTATIONS")]
-	internal sealed class ProvidesContextAttribute : Attribute { }
-
-	/// <summary>
 	/// Indicates how method, constructor invocation or property access
 	/// over collection type affects content of the collection.
 	/// </summary>
@@ -498,23 +397,6 @@ namespace JetBrains.Annotations
 	[AttributeUsage(AttributeTargets.Parameter)]
 	[Conditional("JETBRAINS_ANNOTATIONS")]
 	internal sealed class NoEnumerationAttribute : Attribute { }
-
-	/// <summary>
-	/// Indicates that parameter is regular expression pattern.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Parameter)]
-	[Conditional("JETBRAINS_ANNOTATIONS")]
-	internal sealed class RegexPatternAttribute : Attribute { }
-
-	/// <summary>
-	/// Prevents the Member Reordering feature from tossing members of the marked class.
-	/// </summary>
-	/// <remarks>
-	/// The attribute must be mentioned in your member reordering patterns.
-	/// </remarks>
-	[AttributeUsage(AttributeTargets.All)]
-	[Conditional("JETBRAINS_ANNOTATIONS")]
-	internal sealed class NoReorder : Attribute { }
 
 	// ====================================================
 	// === CUSTOM CONTRACT ATTRIBUTES

--- a/FoundationDB.Client/Shared/Contract.cs
+++ b/FoundationDB.Client/Shared/Contract.cs
@@ -62,11 +62,11 @@ namespace Doxense.Diagnostics.Contracts
 
 		public static bool IsUnitTesting { get; set; }
 
-		private static readonly ConstructorInfo s_constructorNUnitException;
+		private static readonly ConstructorInfo? s_constructorNUnitException;
 
 		static Contract()
 		{
-			// détermine si on est lancé depuis des tests unitaires (pour désactiver les breakpoints et autres opérations intrusivent qui vont parasiter les tests)
+			// test if we are running inside an NUnit test runner (in order to prohibit and breakpoints or any other intrusive operation that could break the test run)
 
 			var nUnitAssert = Type.GetType("NUnit.Framework.AssertionException,nunit.framework");
 			if (nUnitAssert != null)
@@ -77,19 +77,12 @@ namespace Doxense.Diagnostics.Contracts
 			}
 		}
 
-		private static Exception MapToNUnitAssertion(string message)
+		private static Exception? MapToNUnitAssertion(string message)
 		{
-			return (Exception) s_constructorNUnitException?.Invoke(new object[] { message }); // => new NUnit.Framework.AssertionException(...)
+			return (Exception?) s_constructorNUnitException?.Invoke(new object[] { message }); // => new NUnit.Framework.AssertionException(...)
 		}
 
 		#region DEBUG checks...
-
-		/// <summary>[DEBUG ONLY] Dummy method (no-op)</summary>
-		[Conditional("CONTRACTS_FULL")]
-		public static void EndContractBlock()
-		{
-			// cette méthode ne fait rien, et sert juste à émuler la Contract API
-		}
 
 		/// <summary>[DEBUG ONLY] Vérifie qu'une pré-condition est vrai, lors de l'entrée dans une méthode</summary>
 		/// <param name="condition">Condition qui ne doit jamais être fausse</param>
@@ -98,7 +91,7 @@ namespace Doxense.Diagnostics.Contracts
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
 		[DebuggerStepThrough]
-		public static void Requires([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition)
+		public static void Requires([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition)
 		{
 #if DEBUG
 			if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Precondition, null);
@@ -112,7 +105,7 @@ namespace Doxense.Diagnostics.Contracts
 		[Conditional("DEBUG")]
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-		public static void Requires([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage)
+		public static void Requires([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage)
 		{
 #if DEBUG
 			if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Precondition, userMessage);
@@ -125,7 +118,7 @@ namespace Doxense.Diagnostics.Contracts
 		[Conditional("DEBUG")]
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-		public static void Assert([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition)
+		public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition)
 		{
 #if DEBUG
 			if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Assert, null);
@@ -139,27 +132,12 @@ namespace Doxense.Diagnostics.Contracts
 		[Conditional("DEBUG")]
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-		public static void Assert([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage)
+		public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage)
 		{
 #if DEBUG
 			if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Assert, userMessage);
 #endif
 		}
-
-#if DEPRECATED
-		/// <summary>[DEBUG ONLY] Vérifie qu'une condition est toujours vrai, dans le body dans une méthode</summary>
-		/// <param name="actual">Valeur observée</param>
-		/// <param name="expected">Valeur attendue</param>
-		/// <remarks>Ne fait rien si la condition est vrai. Sinon déclenche une ContractException, après avoir essayé de breakpointer le debugger</remarks>
-		[Conditional("DEBUG")]
-		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-		[Obsolete("Use Contract.Assert(actual == expected) instead")]
-		public static void Expect<T>(T actual, T expected)
-		{
-			if (!EqualityComparer<T>.Default.Equals(actual, expected)) RaiseContractFailure(SDC.ContractFailureKind.Assert, String.Format(CultureInfo.InvariantCulture, "Expected value {0} but was {1}", expected, actual));
-		}
-#endif
 
 		/// <summary>[DEBUG ONLY] Vérifie qu'une condition est toujours vrai, lors de la sortie d'une méthode</summary>
 		/// <param name="condition">Condition qui ne doit jamais être fausse</param>
@@ -167,7 +145,7 @@ namespace Doxense.Diagnostics.Contracts
 		[Conditional("DEBUG")]
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-		public static void Ensures([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition)
+		public static void Ensures([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition)
 		{
 #if DEBUG
 			if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Postcondition, null);
@@ -181,7 +159,7 @@ namespace Doxense.Diagnostics.Contracts
 		[Conditional("DEBUG")]
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-		public static void Ensures([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage)
+		public static void Ensures([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage)
 		{
 #if DEBUG
 			if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Postcondition, userMessage);
@@ -195,7 +173,7 @@ namespace Doxense.Diagnostics.Contracts
 		[Conditional("DEBUG")]
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-		public static void Invariant([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage = null)
+		public static void Invariant([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string? userMessage = null)
 		{
 #if DEBUG
 			if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Invariant, userMessage);
@@ -212,7 +190,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <exception cref="ArgumentNullException">if <paramref name="value"/> is null</exception>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNull<TValue>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] TValue value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] TValue value,
 			[InvokerParameterName] string paramName)
 			where TValue : class
 		{
@@ -223,7 +201,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <exception cref="ArgumentNullException">if <paramref name="value"/> is null</exception>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNull(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] string value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] string value,
 			[InvokerParameterName] string paramName)
 		{
 			if (value == null) throw FailArgumentNull(paramName, null);
@@ -233,7 +211,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <exception cref="ArgumentNullException">if <paramref name="value"/> is null</exception>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNull<TValue>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] TValue value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] TValue value,
 			[InvokerParameterName] string paramName,
 			string message)
 			where TValue : class
@@ -245,7 +223,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <remarks>This methods allow structs (that can never be null)</remarks>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullAllowStructs<TValue>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] TValue value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] TValue value,
 			[InvokerParameterName] string paramName)
 		{
 			if (value == null) throw FailArgumentNull(paramName, null);
@@ -256,7 +234,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <exception cref="ArgumentNullException">if <paramref name="value"/> is null</exception>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullAllowStructs<TValue>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] TValue value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] TValue value,
 			[InvokerParameterName] string paramName,
 			string message)
 		{
@@ -267,7 +245,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <exception cref="ArgumentNullException">if <paramref name="pointer"/> is null</exception>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static unsafe void PointerNotNull(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] void* pointer,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] void* pointer,
 			[InvokerParameterName] string paramName)
 		{
 			if (pointer == null) throw FailArgumentNull(paramName, null);
@@ -277,7 +255,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <exception cref="ArgumentNullException">if <paramref name="pointer"/> is null</exception>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static unsafe void PointerNotNull(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] void* pointer,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] void* pointer,
 			[InvokerParameterName] string paramName,
 			string message)
 		{
@@ -295,9 +273,9 @@ namespace Doxense.Diagnostics.Contracts
 		///     set => m_foo = Contract.ValueNotNull(value);
 		/// }
 		/// </code> </example>
-		[Pure, NotNull, AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static T ValueNotNull<T>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] T value
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] T value
 		)
 			where T : class
 		{
@@ -316,9 +294,9 @@ namespace Doxense.Diagnostics.Contracts
 		///     set => m_fooThatIsNeverNull = Contract.ValueNotNull(value, "Foo cannot be set to null");
 		/// }
 		/// </code> </example>
-		[Pure, NotNull, AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static T ValueNotNull<T>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] T value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] T value,
 			string message
 		)
 			where T : class
@@ -330,8 +308,8 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region Contract.NotNullOrEmpty
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailStringNullOrEmpty(string value, string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailStringNullOrEmpty(string value, string paramName, string? message = null)
 		{
 			if (value == null)
 				return ReportFailure(typeof(ArgumentNullException), ContractMessages.ValueCannotBeNull, message, paramName, ContractMessages.ConditionNotNull);
@@ -342,7 +320,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>[RUNTIME] The specified string must not be null or empty (assert: value != null &amp;&amp; value.Length != 0)</summary>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullOrEmpty(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
 			[InvokerParameterName] string paramName
 		)
 		{
@@ -352,15 +330,15 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>[RUNTIME] The specified string must not be null or empty (assert: value != null &amp;&amp; value.Length != 0)</summary>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullOrEmpty(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
 			[InvokerParameterName] string paramName,
 			string message)
 		{
 			if (string.IsNullOrEmpty(value)) throw FailStringNullOrEmpty(value, paramName, message);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailStringNullOrWhiteSpace(string value, string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailStringNullOrWhiteSpace(string value, string paramName, string? message = null)
 		{
 			if (value == null)
 				return ReportFailure(typeof(ArgumentNullException), ContractMessages.ValueCannotBeNull, message, paramName, ContractMessages.ConditionNotNull);
@@ -373,7 +351,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>[RUNTIME] The specified string must not be null, empty or contain only whitespaces (assert: value != null &amp;&amp; value.Length != 0)</summary>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullOrWhiteSpace(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
 			[InvokerParameterName] string paramName)
 		{
 			if (string.IsNullOrWhiteSpace(value)) throw FailStringNullOrWhiteSpace(value, paramName, null);
@@ -382,15 +360,15 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>[RUNTIME] The specified string must not be null, empty or contain only whitespaces (assert: value != null &amp;&amp; value.Length != 0)</summary>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullOrWhiteSpace(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
 			[InvokerParameterName] string paramName,
 			string message)
 		{
 			if (string.IsNullOrWhiteSpace(value)) throw FailStringNullOrWhiteSpace(value, paramName, message);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArrayNullOrEmpty(object collection, string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArrayNullOrEmpty(object? collection, string paramName, string? message = null)
 		{
 			if (collection == null)
 				return ReportFailure(typeof(ArgumentNullException), ContractMessages.ValueCannotBeNull, message, paramName, ContractMessages.ConditionNotNull);
@@ -401,7 +379,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>[RUNTIME] The specified array must not be null or empty (assert: value != null &amp;&amp; value.Count != 0)</summary>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullOrEmpty<T>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] T[] value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] T[] value,
 			[InvokerParameterName] string paramName)
 		{
 			if (value == null || value.Length == 0) throw FailArrayNullOrEmpty(value, paramName, null);
@@ -410,15 +388,15 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>[RUNTIME] The specified array must not be null or empty (assert: value != null &amp;&amp; value.Count != 0)</summary>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullOrEmpty<T>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] T[] value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] T[] value,
 			[InvokerParameterName] string paramName,
 			string message)
 		{
 			if (value == null || value.Length == 0) throw FailArrayNullOrEmpty(value, paramName, message);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailCollectionNullOrEmpty(object collection, string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailCollectionNullOrEmpty(object? collection, string paramName, string? message = null)
 		{
 			if (collection == null)
 				return ReportFailure(typeof(ArgumentNullException), ContractMessages.ValueCannotBeNull, message, paramName, ContractMessages.ConditionNotNull);
@@ -429,7 +407,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>[RUNTIME] The specified collection must not be null or empty (assert: value != null &amp;&amp; value.Count != 0)</summary>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullOrEmpty<T>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] ICollection<T> value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] ICollection<T> value,
 			[InvokerParameterName] string paramName)
 		{
 			if (value == null || value.Count == 0) throw FailCollectionNullOrEmpty(value, paramName, null);
@@ -438,21 +416,21 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>[RUNTIME] The specified collection must not be null or empty (assert: value != null &amp;&amp; value.Count != 0)</summary>
 		[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void NotNullOrEmpty<T>(
-			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] ICollection<T> value,
+			[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] ICollection<T> value,
 			[InvokerParameterName] string paramName,
 			string message)
 		{
 			if (value == null || value.Count == 0) throw FailCollectionNullOrEmpty(value, paramName, message);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailBufferNull(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailBufferNull(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentNullException), ContractMessages.BufferCannotBeNull, message, paramName, ContractMessages.ConditionNotNull);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailBufferNullOrEmpty(object array, string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailBufferNullOrEmpty(object? array, string paramName, string? message = null)
 		{
 			if (array == null)
 				return ReportFailure(typeof(ArgumentNullException), ContractMessages.BufferCannotBeNull, message, paramName, ContractMessages.ConditionNotNull);
@@ -483,64 +461,64 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region Contract.Positive, LessThan[OrEqual], GreaterThen[OrEqual], EqualTo, Between, ...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNotPositive(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNotPositive(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), ContractMessages.PositiveNumberRequired, message, paramName, ContractMessages.ConditionArgPositive);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNotNonNegative(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNotNonNegative(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), ContractMessages.NonNegativeNumberRequired, message, paramName, ContractMessages.ConditionArgPositive);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNotPowerOfTwo(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNotPowerOfTwo(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), ContractMessages.PowerOfTwoRequired, message, paramName, ContractMessages.ConditionArgPositive);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentForbidden<T>(string paramName, T forbidden, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentForbidden<T>(string paramName, T forbidden, string? message = null)
 		{
 			//TODO: need support for two format arguments for conditionTxt !
 			return ReportFailure(typeof(ArgumentException), ContractMessages.ValueIsForbidden, message, paramName, ContractMessages.ConditionArgNotEqualTo);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentExpected<T>(string paramName, T expected, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentExpected<T>(string paramName, T expected, string? message = null)
 		{
 			//TODO: need support for two format arguments for conditionTxt !
 			return ReportFailure(typeof(ArgumentException), ContractMessages.ValueIsExpected, message, paramName, ContractMessages.ConditionArgEqualTo);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNotGreaterThan(string paramName, bool zero, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNotGreaterThan(string paramName, bool zero, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), zero ? ContractMessages.AboveZeroNumberRequired : ContractMessages.ValueIsTooSmall, message, paramName, zero ? ContractMessages.ConditionArgGreaterThanZero : ContractMessages.ConditionArgGreaterThan);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNotGreaterOrEqual(string paramName, bool zero, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNotGreaterOrEqual(string paramName, bool zero, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), zero ? ContractMessages.PositiveNumberRequired : ContractMessages.ValueIsTooSmall, message, paramName, zero ? ContractMessages.ConditionArgGreaterOrEqualZero : ContractMessages.ConditionArgGreaterOrEqual);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNotLessThan(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNotLessThan(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), ContractMessages.ValueIsTooBig, message, paramName, ContractMessages.ConditionArgLessThan);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNotLessOrEqual(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNotLessOrEqual(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), ContractMessages.ValueIsTooBig, message, paramName, ContractMessages.ConditionArgLessThanOrEqual);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentOutOfBounds(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentOutOfBounds(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), ContractMessages.ValueMustBeBetween, message, paramName, ContractMessages.ConditionArgBetween);
 		}
@@ -587,7 +565,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must be a power of two (assert: NextPowerOfTwo(value) == value)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void PowerOfTwo(int value, [InvokerParameterName] string paramName, string message = null)
+		public static void PowerOfTwo(int value, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < 0 || unchecked((value & (value - 1)) != 0))
 			{
@@ -597,7 +575,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must be a power of two (assert: NextPowerOfTwo(value) == value)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void PowerOfTwo(uint value, [InvokerParameterName] string paramName, string message = null)
+		public static void PowerOfTwo(uint value, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (unchecked((value & (value - 1)) != 0))
 			{
@@ -607,7 +585,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must be a power of two (assert: NextPowerOfTwo(value) == value)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void PowerOfTwo(long value, [InvokerParameterName] string paramName, string message = null)
+		public static void PowerOfTwo(long value, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < 0 || unchecked((value & (value - 1)) != 0))
 			{
@@ -617,7 +595,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must be a power of two (assert: NextPowerOfTwo(value) == value)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void PowerOfTwo(ulong value, [InvokerParameterName] string paramName, string message = null)
+		public static void PowerOfTwo(ulong value, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (unchecked((value & (value - 1)) != 0))
 			{
@@ -627,7 +605,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than or equal to the specified lower bound (assert: value > threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterThan(int value, int threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterThan(int value, int threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value <= threshold)
 			{
@@ -637,7 +615,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not equal to the specified constant (assert: value != forbidden)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void EqualTo(long value, long expected, [InvokerParameterName] string paramName, string message = null)
+		public static void EqualTo(long value, long expected, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value != expected)
 			{
@@ -647,7 +625,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not equal to the specified constant (assert: value != forbidden)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void EqualTo(ulong value, ulong expected, [InvokerParameterName] string paramName, string message = null)
+		public static void EqualTo(ulong value, ulong expected, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value != expected)
 			{
@@ -657,7 +635,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not equal to the specified constant (assert: value != forbidden)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void EqualTo(string value, string expected, [InvokerParameterName] string paramName, string message = null)
+		public static void EqualTo(string value, string expected, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value != expected)
 			{
@@ -667,7 +645,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not equal to the specified constant (assert: value != forbidden)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void EqualTo<T>(T value, T expected, [InvokerParameterName] string paramName, string message = null)
+		public static void EqualTo<T>(T value, T expected, [InvokerParameterName] string paramName, string? message = null)
 			where T : struct, IEquatable<T>
 		{
 			if (!value.Equals(expected))
@@ -678,7 +656,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not equal to the specified constant (assert: value != forbidden)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void NotEqualTo(long value, long forbidden, [InvokerParameterName] string paramName, string message = null)
+		public static void NotEqualTo(long value, long forbidden, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value == forbidden)
 			{
@@ -688,7 +666,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not equal to the specified constant (assert: value != forbidden)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void NotEqualTo(ulong value, ulong forbidden, [InvokerParameterName] string paramName, string message = null)
+		public static void NotEqualTo(ulong value, ulong forbidden, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value == forbidden)
 			{
@@ -698,7 +676,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not equal to the specified constant (assert: value != forbidden)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void NotEqualTo(string value, string forbidden, [InvokerParameterName] string paramName, string message = null)
+		public static void NotEqualTo(string value, string forbidden, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value == forbidden)
 			{
@@ -708,7 +686,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not equal to the specified constant (assert: value != forbidden)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void NotEqualTo<T>(T value, T forbidden, [InvokerParameterName] string paramName, string message = null)
+		public static void NotEqualTo<T>(T value, T forbidden, [InvokerParameterName] string paramName, string? message = null)
 			where T : struct, IEquatable<T>
 		{
 			if (value.Equals(forbidden))
@@ -719,7 +697,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than or equal to the specified lower bound (assert: value > threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterThan(uint value, uint threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterThan(uint value, uint threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value <= threshold)
 			{
@@ -729,7 +707,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than or equal to the specified lower bound (assert: value > threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterThan(long value, long threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterThan(long value, long threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value <= threshold)
 			{
@@ -739,7 +717,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than or equal to the specified lower bound (assert: value > threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterThan(ulong value, ulong threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterThan(ulong value, ulong threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value <= threshold)
 			{
@@ -749,7 +727,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than or equal to the specified lower bound (assert: value > threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterThan(float value, float threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterThan(float value, float threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value <= threshold)
 			{
@@ -760,7 +738,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than or equal to the specified lower bound (assert: value > threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterThan(double value, double threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterThan(double value, double threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value <= threshold)
 			{
@@ -771,7 +749,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than the specified lower bound (assert: value >= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterOrEqual(int value, int threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterOrEqual(int value, int threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < threshold)
 			{
@@ -781,7 +759,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than the specified lower bound (assert: value >= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterOrEqual(uint value, uint threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterOrEqual(uint value, uint threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < threshold)
 			{
@@ -791,7 +769,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than the specified lower bound (assert: value >= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterOrEqual(long value, long threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterOrEqual(long value, long threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < threshold)
 			{
@@ -801,7 +779,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than the specified lower bound (assert: value >= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterOrEqual(ulong value, ulong threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterOrEqual(ulong value, ulong threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < threshold)
 			{
@@ -811,7 +789,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than the specified lower bound (assert: value >= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterOrEqual(float value, float threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterOrEqual(float value, float threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < threshold)
 			{
@@ -822,7 +800,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not less than the specified lower bound (assert: value >= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void GreaterOrEqual(double value, double threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void GreaterOrEqual(double value, double threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < threshold)
 			{
@@ -833,7 +811,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than or equal to the specified upper bound</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessThan(int value, int threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessThan(int value, int threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value >= threshold)
 			{
@@ -843,7 +821,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than or equal to the specified upper bound</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessThan(uint value, uint threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessThan(uint value, uint threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value >= threshold)
 			{
@@ -853,7 +831,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than or equal to the specified uppper bound (assert: value &lt; threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessThan(long value, long threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessThan(long value, long threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value >= threshold)
 			{
@@ -863,7 +841,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than or equal to the specified uppper bound (assert: value &lt; threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessThan(ulong value, ulong threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessThan(ulong value, ulong threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value >= threshold)
 			{
@@ -873,7 +851,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than or equal to the specified uppper bound (assert: value &lt; threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessThan(float value, float threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessThan(float value, float threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value >= threshold)
 			{
@@ -883,7 +861,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than or equal to the specified uppper bound (assert: value &lt; threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessThan(double value, double threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessThan(double value, double threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value >= threshold)
 			{
@@ -893,7 +871,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than the specified upper bound (assert: value &lt;= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessOrEqual(int value, int threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessOrEqual(int value, int threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value > threshold)
 			{
@@ -903,7 +881,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than the specified upper bound (assert: value &lt;= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessOrEqual(uint value, uint threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessOrEqual(uint value, uint threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value > threshold)
 			{
@@ -913,7 +891,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than the specified upper bound (assert: value &lt;= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessOrEqual(long value, long threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessOrEqual(long value, long threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value > threshold)
 			{
@@ -923,7 +901,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than the specified upper bound (assert: value &lt;= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessOrEqual(ulong value, ulong threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessOrEqual(ulong value, ulong threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value > threshold)
 			{
@@ -933,7 +911,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than the specified upper bound (assert: value &lt;= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessOrEqual(float value, float threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessOrEqual(float value, float threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value > threshold)
 			{
@@ -943,7 +921,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not greater than the specified upper bound (assert: value &lt;= threshold)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void LessOrEqual(double value, double threshold, [InvokerParameterName] string paramName, string message = null)
+		public static void LessOrEqual(double value, double threshold, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value > threshold)
 			{
@@ -953,7 +931,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not be outside of the specified bounds (assert: min &lt;= value &lt;= max)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Between(int value, int minimumInclusive, int maximumInclusive, [InvokerParameterName] string paramName, string message = null)
+		public static void Between(int value, int minimumInclusive, int maximumInclusive, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < minimumInclusive || value > maximumInclusive)
 			{
@@ -963,7 +941,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not be outside of the specified bounds (assert: min &lt;= value &lt;= max)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Between(uint value, uint minimumInclusive, uint maximumInclusive, [InvokerParameterName] string paramName, string message = null)
+		public static void Between(uint value, uint minimumInclusive, uint maximumInclusive, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < minimumInclusive || value > maximumInclusive)
 			{
@@ -973,7 +951,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not be outside of the specified bounds (assert: min &lt;= value &lt;= max)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Between(long value, long minimumInclusive, long maximumInclusive, [InvokerParameterName] string paramName, string message = null)
+		public static void Between(long value, long minimumInclusive, long maximumInclusive, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < minimumInclusive || value > maximumInclusive)
 			{
@@ -983,7 +961,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not be outside of the specified bounds (assert: min &lt;= value &lt;= max)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Between(ulong value, ulong minimumInclusive, ulong maximumInclusive, [InvokerParameterName] string paramName, string message = null)
+		public static void Between(ulong value, ulong minimumInclusive, ulong maximumInclusive, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < minimumInclusive || value > maximumInclusive)
 			{
@@ -993,7 +971,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not be outside of the specified bounds (assert: min &lt;= value &lt;= max)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Between(float value, float minimumInclusive, float maximumInclusive, [InvokerParameterName] string paramName, string message = null)
+		public static void Between(float value, float minimumInclusive, float maximumInclusive, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < minimumInclusive || value > maximumInclusive)
 			{
@@ -1003,7 +981,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>[RUNTIME] The specified value must not be outside of the specified bounds (assert: min &lt;= value &lt;= max)</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Between(double value, double minimumInclusive, double maximumInclusive, [InvokerParameterName] string paramName, string message = null)
+		public static void Between(double value, double minimumInclusive, double maximumInclusive, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value < minimumInclusive || value > maximumInclusive)
 			{
@@ -1012,7 +990,7 @@ namespace Doxense.Diagnostics.Contracts
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Multiple(int value, int multiple, [InvokerParameterName] string paramName, string message = null)
+		public static void Multiple(int value, int multiple, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value % multiple != 0)
 			{
@@ -1021,7 +999,7 @@ namespace Doxense.Diagnostics.Contracts
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Multiple(uint value, uint multiple, [InvokerParameterName] string paramName, string message = null)
+		public static void Multiple(uint value, uint multiple, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value % multiple != 0)
 			{
@@ -1030,7 +1008,7 @@ namespace Doxense.Diagnostics.Contracts
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Multiple(long value, long multiple, [InvokerParameterName] string paramName, string message = null)
+		public static void Multiple(long value, long multiple, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value % multiple != 0)
 			{
@@ -1039,7 +1017,7 @@ namespace Doxense.Diagnostics.Contracts
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void Multiple(ulong value, ulong multiple, [InvokerParameterName] string paramName, string message = null)
+		public static void Multiple(ulong value, ulong multiple, [InvokerParameterName] string paramName, string? message = null)
 		{
 			if (value % multiple != 0)
 			{
@@ -1047,8 +1025,8 @@ namespace Doxense.Diagnostics.Contracts
 			}
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNotMultiple(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNotMultiple(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), ContractMessages.ValueMustBeMultiple, message, paramName, ContractMessages.ConditionArgMultiple);
 		}
@@ -1063,7 +1041,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <param name="count">Taille (qui ne doit pas être négative)</param>
 		/// <param name="message"></param>
 		[AssertionMethod]
-		public static void DoesNotOverflow([AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string buffer, int index, int count, string message = null)
+		public static void DoesNotOverflow([System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string buffer, int index, int count, string? message = null)
 		{
 			if (buffer == null) throw FailArgumentNull("buffer", message);
 			if (index < 0 || count < 0) throw FailArgumentNotNonNegative(index < 0 ? "index" : "count", message);
@@ -1098,7 +1076,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <param name="count">Taille (qui ne doit pas être négative)</param>
 		/// <param name="message"></param>
 		[AssertionMethod]
-		public static void DoesNotOverflow<TElement>([AssertionCondition(AssertionConditionType.IS_NOT_NULL)] TElement[] buffer, int offset, int count, string message = null)
+		public static void DoesNotOverflow<TElement>([System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] TElement[] buffer, int offset, int count, string? message = null)
 		{
 			if (buffer == null) throw FailArgumentNull("buffer", message);
 			if (offset < 0 || count < 0) throw FailArgumentNotNonNegative(offset < 0 ? "offset" : "count", message);
@@ -1108,7 +1086,7 @@ namespace Doxense.Diagnostics.Contracts
 		/// <summary>Vérifie qu'une couple index/count ne débord pas d'un buffer, et qu'il n'est pas null</summary>
 		/// <param name="buffer">Buffer (qui ne doit pas être null)</param>
 		/// <param name="message"></param>
-		public static void DoesNotOverflow<TElement>(ArraySegment<TElement> buffer, string message = null)
+		public static void DoesNotOverflow<TElement>(ArraySegment<TElement> buffer, string? message = null)
 		{
 			if (buffer.Offset < 0 || buffer.Count < 0) throw FailArgumentNotNonNegative(buffer.Offset < 0 ? "offset" : "count", message);
 			if (buffer.Count > 0)
@@ -1128,15 +1106,15 @@ namespace Doxense.Diagnostics.Contracts
 		/// <param name="count">Taille (qui ne doit pas être négative)</param>
 		/// <param name="message"></param>
 		[AssertionMethod]
-		public static void DoesNotOverflow<TElement>([AssertionCondition(AssertionConditionType.IS_NOT_NULL)] ICollection<TElement> buffer, int offset, int count, string message = null)
+		public static void DoesNotOverflow<TElement>([System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] ICollection<TElement> buffer, int offset, int count, string? message = null)
 		{
 			if (buffer == null) throw FailArgumentNull("buffer", message);
 			if (offset < 0 || count < 0) throw FailArgumentNotNonNegative(offset < 0 ? "offset" : "count", message);
 			if ((buffer.Count - offset) < count) throw FailBufferTooSmall("count", message);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailBufferTooSmall(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailBufferTooSmall(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentException), ContractMessages.OffsetMustBeWithinBuffer, message, paramName, ContractMessages.ConditionArgBufferOverflow);
 		}
@@ -1147,15 +1125,15 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region Internal Helpers...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception FailArgumentNull(string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception FailArgumentNull(string paramName, string? message = null)
 		{
 			return ReportFailure(typeof(ArgumentNullException), ContractMessages.ValueCannotBeNull, message, paramName, ContractMessages.ConditionNotNull);
 		}
 
 		/// <summary>Déclenche une exception suite à l'échec d'une condition</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		internal static Exception ReportFailure(Type exceptionType, string msg, string userMessage, string paramName, string conditionTxt)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		internal static Exception ReportFailure(Type exceptionType, string msg, string? userMessage, string? paramName, string? conditionTxt)
 		{
 			if (conditionTxt != null && conditionTxt.IndexOf('{') >= 0)
 			{ // il y a peut etre un "{0}" dans la condition qu'il faut remplacer le nom du paramètre
@@ -1177,22 +1155,21 @@ namespace Doxense.Diagnostics.Contracts
 #endif
 			string description = userMessage ?? str ?? msg;
 
-			var exception = ThrowHelper.TryMapToKnownException(exceptionType, description, paramName);
+			var exception = ThrowHelper.TryMapToKnownException(exceptionType, description, paramName ?? "value");
 
 			if (exception == null)
 			{ // c'est un type compliqué ??
-				exception = ThrowHelper.TryMapToComplexException(exceptionType, description, paramName);
+				exception = ThrowHelper.TryMapToComplexException(exceptionType, description, paramName ?? "value");
 			}
 
 			if (exception == null)
 			{ // uh? on va quand même envoyer une exception proxy !
-				exception = FallbackForUnknownException(description, paramName);
+				exception = FallbackForUnknownException(description, paramName ?? "value");
 			}
 
 			return exception;
 		}
 
-		[NotNull]
 		private static Exception FallbackForUnknownException(string description, string paramName)
 		{
 #if DEBUG
@@ -1206,11 +1183,11 @@ namespace Doxense.Diagnostics.Contracts
 
 		/// <summary>Signale l'échec d'une condition en déclenchant une ContractException</summary>
 		/// <remarks>Si un debugger est attaché, un breakpoint est déclenché. Sinon, une ContractException est générée</remarks>
-		[Pure, NotNull]
+		[Pure]
 		[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		[DebuggerNonUserCode]
-		internal static Exception RaiseContractFailure(SDC.ContractFailureKind kind, string msg)
+		internal static Exception RaiseContractFailure(SDC.ContractFailureKind kind, string? msg)
 		{
 			string str = SRC.ContractHelper.RaiseContractFailedEvent(kind, msg, null, null);
 			if (str != null)
@@ -1220,18 +1197,17 @@ namespace Doxense.Diagnostics.Contracts
 					// throws une AssertionException si on a réussi a se connecter avec NUnit
 					var ex = MapToNUnitAssertion(str);
 #if DEBUG
-					// README: Si vous breakpointez ici, il faut remonter plus haut dans la callstack, et trouver la fonction invoque Contract.xxx(...)
+					// README: If you are breakpointing here, you have to go up the callstack, and look for the fist callsite that looks like 'Contract.xxx(...)'
 					if (System.Diagnostics.Debugger.IsAttached) System.Diagnostics.Debugger.Break();
-					// note: à partir de VS 2015 Up2, [DebuggerNonUserCode] n'est plus respecté si la regkey AlwaysEnableExceptionCallbacksOutsideMyCode n'est pas égale à 1, pour améliorer les perfs.
+					// note: Starting from VS 2015 Up2, [DebuggerNonUserCode] is not honored if the registry key 'AlwaysEnableExceptionCallbacksOutsideMyCode' is not equal to 1, "for performance reasons"
 					// cf "How to Suppress Ignorable Exceptions with DebuggerNonUserCode" dans https://blogs.msdn.microsoft.com/visualstudioalm/2016/02/12/using-the-debuggernonusercode-attribute-in-visual-studio-2015/
 #endif
 					if (ex != null) return ex;
-					// sinon, on continue
 				}
 #if DEBUG
 				else if (kind == SDC.ContractFailureKind.Assert && Debugger.IsAttached)
 				{
-					// uniquement si on F5 depuis VS, car sinon cela cause problèmes avec le TestRunner de R# (qui popup les assertion fail!)
+					// only when debugging from VS or other debugger, because this can silently break most test runners
 					System.Diagnostics.Debug.Fail(str);
 				}
 #endif
@@ -1244,7 +1220,7 @@ namespace Doxense.Diagnostics.Contracts
 
 		#endregion
 
-		/// <summary>Contracts that are only evaluted in Debug builds</summary>
+		/// <summary>Contracts that are only evaluated in Debug builds</summary>
 		public static class Debug
 		{
 			// ReSharper disable MemberHidesStaticFromOuterClass
@@ -1254,7 +1230,7 @@ namespace Doxense.Diagnostics.Contracts
 
 			[AssertionMethod, Conditional("DEBUG")]
 			public static void NotNull(
-				[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
+				[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
 				[InvokerParameterName] string paramName
 			)
 			{
@@ -1268,7 +1244,7 @@ namespace Doxense.Diagnostics.Contracts
 
 			[AssertionMethod, Conditional("DEBUG")]
 			public static void NotNull(
-				[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
+				[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
 				[InvokerParameterName] string paramName,
 				string message)
 			{
@@ -1282,7 +1258,7 @@ namespace Doxense.Diagnostics.Contracts
 
 			[AssertionMethod, Conditional("DEBUG")]
 			public static void NotNullOrEmpty(
-				[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
+				[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
 				[InvokerParameterName] string paramName
 			)
 			{
@@ -1296,7 +1272,7 @@ namespace Doxense.Diagnostics.Contracts
 
 			[AssertionMethod, Conditional("DEBUG")]
 			public static void NotNullOrEmpty(
-				[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
+				[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string value,
 				[InvokerParameterName] string paramName,
 				string message
 			)
@@ -1311,7 +1287,7 @@ namespace Doxense.Diagnostics.Contracts
 
 			[AssertionMethod, Conditional("DEBUG")]
 			public static void NotNull<T>(
-				[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] T value,
+				[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] T value,
 				[InvokerParameterName] string paramName
 			)
 				where T : class
@@ -1326,7 +1302,7 @@ namespace Doxense.Diagnostics.Contracts
 
 			[AssertionMethod, Conditional("DEBUG")]
 			public static void NotNullAllowStructs<T>(
-				[AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] T value,
+				[System.Diagnostics.CodeAnalysis.DisallowNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), NoEnumeration] T value,
 				[InvokerParameterName] string paramName
 			)
 			{
@@ -1344,7 +1320,7 @@ namespace Doxense.Diagnostics.Contracts
 			[Conditional("DEBUG")]
 			[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 			[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-			public static void Assert([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition)
+			public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition)
 			{
 #if DEBUG
 				if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Assert, null);
@@ -1358,7 +1334,7 @@ namespace Doxense.Diagnostics.Contracts
 			[Conditional("DEBUG")]
 			[AssertionMethod, MethodImpl(MethodImplOptions.AggressiveInlining)]
 			[ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-			public static void Assert([AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage)
+			public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false), AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition, string userMessage)
 			{
 #if DEBUG
 				if (!condition) throw RaiseContractFailure(SDC.ContractFailureKind.Assert, userMessage);

--- a/FoundationDB.Client/Shared/ContractException.cs
+++ b/FoundationDB.Client/Shared/ContractException.cs
@@ -23,7 +23,7 @@ namespace Doxense.Diagnostics.Contracts
 			base.HResult = -2146233022;
 		}
 
-		public ContractException(SDC.ContractFailureKind kind, string failure, string userMessage, string condition, Exception innerException)
+		public ContractException(SDC.ContractFailureKind kind, string failure, string? userMessage, string? condition, Exception? innerException)
 			: base(failure, innerException)
 		{
 			base.HResult = -2146233022;
@@ -44,11 +44,11 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region Public Properties...
 
-		public string Condition { get; }
+		public string? Condition { get; }
 
 		public SDC.ContractFailureKind Kind { get; }
 
-		public string UserMessage { get; }
+		public string? UserMessage { get; }
 
 		public string Failure => this.Message;
 

--- a/FoundationDB.Client/Shared/Converters/ComparisonHelper.cs
+++ b/FoundationDB.Client/Shared/Converters/ComparisonHelper.cs
@@ -122,7 +122,7 @@ namespace Doxense.Runtime.Converters
 		/// <param name="type">Type of the object to adapt</param>
 		/// <param name="result">Double equivalent of the object</param>
 		/// <returns>True if <paramref name="value"/> is compatible with a decimal. False if the type is not compatible</returns>
-		public static bool TryAdaptToDecimal(object value, [NotNull] Type type, out double result)
+		public static bool TryAdaptToDecimal(object value, Type type, out double result)
 		{
 			if (value != null)
 			{
@@ -148,7 +148,7 @@ namespace Doxense.Runtime.Converters
 		/// <param name="type">Type of the object to adapt</param>
 		/// <param name="result">Int64 equivalent of the object</param>
 		/// <returns>True if <paramref name="value"/> is compatible with a decimal. False if the type is not compatible</returns>
-		public static bool TryAdaptToInteger(object value, [NotNull] Type type, out long result)
+		public static bool TryAdaptToInteger(object value, Type type, out long result)
 		{
 			if (value != null)
 			{
@@ -168,8 +168,7 @@ namespace Doxense.Runtime.Converters
 			return false;
 		}
 
-		[NotNull]
-		private static Func<object, object, bool> CreateTypeComparator([NotNull] Type t1, [NotNull] Type t2)
+		private static Func<object, object, bool> CreateTypeComparator(Type t1, Type t2)
 		{
 			Contract.Requires(t1 != null && t2 != null);
 
@@ -290,7 +289,7 @@ namespace Doxense.Runtime.Converters
 
 		/// <summary>Returns true if the specified type is considered to be a "number"</summary>
 		/// <returns>True for integers (8, 16, 32 or 64 bits, signed or unsigned) and their Nullable versions. Bytes and Chars are not considered to be numbers because they a custom serialized</returns>
-		private static bool IsNumericType([NotNull] Type t)
+		private static bool IsNumericType(Type t)
 		{
 			// Return true for valuetypes that are considered numbers.
 			// Notes:

--- a/FoundationDB.Client/Shared/Converters/ITypeConverter.cs
+++ b/FoundationDB.Client/Shared/Converters/ITypeConverter.cs
@@ -37,15 +37,13 @@ namespace Doxense.Runtime.Converters
 	public interface ITypeConverter
 	{
 		/// <summary>Type of the instance to be converted</summary>
-		[NotNull]
 		Type Source { get; }
 
 		/// <summary>Type of the result of the conversion</summary>
-		[NotNull]
 		Type Destination { get; }
 
 		[Pure]
-		object ConvertBoxed(object value);
+		object? ConvertBoxed(object? value);
 	}
 
 	/// <summary>Class that can convert values of type <typeparamref name="TSource"/> into values of type <typeparamref name="TDestination"/></summary>

--- a/FoundationDB.Client/Shared/Converters/SimilarValueComparer.cs
+++ b/FoundationDB.Client/Shared/Converters/SimilarValueComparer.cs
@@ -39,7 +39,7 @@ namespace Doxense.Runtime.Converters
 	/// <remarks>This comparer SHOULD NOT be used in a Dictioanry, because it violates on of the conditions: Two objects could be considered equal, but have different hashcode!</remarks>
 	internal sealed class SimilarValueComparer : IEqualityComparer<object>, IEqualityComparer
 	{
-		[NotNull]
+
 		public static readonly IEqualityComparer Default = new SimilarValueComparer();
 
 		private SimilarValueComparer()

--- a/FoundationDB.Client/Shared/ExceptionExtensions.cs
+++ b/FoundationDB.Client/Shared/ExceptionExtensions.cs
@@ -40,7 +40,7 @@ namespace Doxense
 		/// <param name="self">Exception à tester</param>
 		/// <returns>True s'il s'agit d'une ThreadAbortException, OutOfMemoryException ou StackOverflowException, ou une AggregateException qui contient une de ces erreurs</returns>
 		[Pure]
-		public static bool IsFatalError([CanBeNull] this Exception self)
+		public static bool IsFatalError(this Exception? self)
 		{
 			return self is System.Threading.ThreadAbortException || self is OutOfMemoryException || self is StackOverflowException || (self is AggregateException && IsFatalError(self.InnerException));
 		}

--- a/FoundationDB.Client/Shared/Linq/Async/Expressions/AsyncFilterExpression.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Expressions/AsyncFilterExpression.cs
@@ -84,20 +84,17 @@ namespace Doxense.Linq.Async.Expressions
 			return new InvalidOperationException("Cannot invoke asynchronous filter synchronously.");
 		}
 
-		[NotNull]
-		public AsyncFilterExpression<TSource> AndAlso([NotNull] AsyncFilterExpression<TSource> expr)
+		public AsyncFilterExpression<TSource> AndAlso(AsyncFilterExpression<TSource> expr)
 		{
 			return AndAlso(this, expr);
 		}
 
-		[NotNull]
-		public AsyncFilterExpression<TSource> OrElse([NotNull] AsyncFilterExpression<TSource> expr)
+		public AsyncFilterExpression<TSource> OrElse(AsyncFilterExpression<TSource> expr)
 		{
 			return OrElse(this, expr);
 		}
 
-		[NotNull]
-		public static AsyncFilterExpression<TSource> AndAlso([NotNull] AsyncFilterExpression<TSource> left, [NotNull] AsyncFilterExpression<TSource> right)
+		public static AsyncFilterExpression<TSource> AndAlso(AsyncFilterExpression<TSource> left, AsyncFilterExpression<TSource> right)
 		{
 			Contract.NotNull(left, nameof(left));
 			Contract.NotNull(right, nameof(right));
@@ -138,8 +135,7 @@ namespace Doxense.Linq.Async.Expressions
 			}
 		}
 
-		[NotNull]
-		public static AsyncFilterExpression<TSource> OrElse([NotNull] AsyncFilterExpression<TSource> left, [NotNull] AsyncFilterExpression<TSource> right)
+		public static AsyncFilterExpression<TSource> OrElse(AsyncFilterExpression<TSource> left, AsyncFilterExpression<TSource> right)
 		{
 			Contract.NotNull(left, nameof(left));
 			Contract.NotNull(right, nameof(right));

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/DeferredAsyncEnumerable.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/DeferredAsyncEnumerable.cs
@@ -30,12 +30,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Doxense.Linq.Async.Iterators
 {
-	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 	using System;
 	using System.Collections.Generic;
 	using System.Threading;
 	using System.Threading.Tasks;
+	using Doxense.Diagnostics.Contracts;
 
 	/// <summary>Iterator that will generate the underlying async sequence "just in time" when it is itself iterated</summary>
 	/// <typeparam name="TResult">Type of elements of the async sequence</typeparam>
@@ -46,9 +45,9 @@ namespace Doxense.Linq.Async.Iterators
 
 		public Func<CancellationToken, Task<TCollection>> Generator { get; }
 
-		private IAsyncEnumerator<TResult> Inner { get; set; }
+		private IAsyncEnumerator<TResult>? Inner { get; set; }
 
-		public DeferredAsyncIterator([NotNull] Func<CancellationToken, Task<TCollection>> generator)
+		public DeferredAsyncIterator(Func<CancellationToken, Task<TCollection>> generator)
 		{
 			Contract.NotNull(generator, nameof(generator));
 			this.Generator = generator;
@@ -86,7 +85,7 @@ namespace Doxense.Linq.Async.Iterators
 			{
 				return await Completed();
 			}
-			return Publish(this.Inner.Current);
+			return Publish(inner.Current);
 		}
 
 	}

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/DistinctAsyncIterator.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/DistinctAsyncIterator.cs
@@ -35,7 +35,6 @@ namespace Doxense.Linq.Async.Iterators
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 
 	/// <summary>Filters duplicate items from an async sequence</summary>
 	/// <typeparam name="TSource">Type of elements of the async sequence</typeparam>
@@ -45,7 +44,7 @@ namespace Doxense.Linq.Async.Iterators
 		private readonly IEqualityComparer<TSource> m_comparer;
 		private HashSet<TSource>? m_set;
 
-		public DistinctAsyncIterator([NotNull] IAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
+		public DistinctAsyncIterator(IAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
 			: base(source)
 		{
 			Contract.Requires(comparer != null);

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/ExceptAsyncIterator.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/ExceptAsyncIterator.cs
@@ -40,7 +40,7 @@ namespace Doxense.Linq.Async.Iterators
 	/// <typeparam name="TResult">Type of the elements of resulting async sequence</typeparam>
 	public sealed class ExceptAsyncIterator<TSource, TKey, TResult> : MergeAsyncIterator<TSource, TKey, TResult>
 	{
-		public ExceptAsyncIterator(IEnumerable<IAsyncEnumerable<TSource>> sources, int? limit, Func<TSource, TKey> keySelector, Func<TSource, TResult> resultSelector, IComparer<TKey> comparer)
+		public ExceptAsyncIterator(IEnumerable<IAsyncEnumerable<TSource>> sources, int? limit, Func<TSource, TKey> keySelector, Func<TSource, TResult> resultSelector, IComparer<TKey>? comparer)
 			: base(sources, limit, keySelector, resultSelector, comparer)
 		{ }
 

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/IntersectAsyncIterator.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/IntersectAsyncIterator.cs
@@ -40,7 +40,7 @@ namespace Doxense.Linq.Async.Iterators
 	/// <typeparam name="TResult">Type of the elements of resulting async sequence</typeparam>
 	public sealed class IntersectAsyncIterator<TSource, TKey, TResult> : MergeAsyncIterator<TSource, TKey, TResult>
 	{
-		public IntersectAsyncIterator(IEnumerable<IAsyncEnumerable<TSource>> sources, int? limit, Func<TSource, TKey> keySelector, Func<TSource, TResult> resultSelector, IComparer<TKey> comparer)
+		public IntersectAsyncIterator(IEnumerable<IAsyncEnumerable<TSource>> sources, int? limit, Func<TSource, TKey> keySelector, Func<TSource, TResult> resultSelector, IComparer<TKey>? comparer)
 			: base(sources, limit, keySelector, resultSelector, comparer)
 		{ }
 

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/MergeSortAsyncIterator.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/MergeSortAsyncIterator.cs
@@ -41,7 +41,7 @@ namespace Doxense.Linq.Async.Iterators
 	public sealed class MergeSortAsyncIterator<TSource, TKey, TResult> : MergeAsyncIterator<TSource, TKey, TResult>
 	{
 
-		public MergeSortAsyncIterator(IEnumerable<IAsyncEnumerable<TSource>> sources, int? limit, Func<TSource, TKey> keySelector, Func<TSource, TResult> resultSelector, IComparer<TKey> comparer)
+		public MergeSortAsyncIterator(IEnumerable<IAsyncEnumerable<TSource>> sources, int? limit, Func<TSource, TKey> keySelector, Func<TSource, TResult> resultSelector, IComparer<TKey>? comparer)
 			: base(sources, limit, keySelector, resultSelector, comparer)
 		{ }
 

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/ParallelSelectAsyncIterator.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/ParallelSelectAsyncIterator.cs
@@ -40,7 +40,6 @@ namespace Doxense.Linq.Async.Iterators
 	using Doxense.Async;
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Threading.Tasks;
-	using JetBrains.Annotations;
 
 	/// <summary>[EXPERIMENTAL] Iterates over an async sequence of items, kick off an async task in parallel, and returning the results in order</summary>
 	/// <typeparam name="TSource">Type of elements of the inner async sequence</typeparam>
@@ -70,9 +69,9 @@ namespace Doxense.Linq.Async.Iterators
 		private AsyncTransformQueue<TSource, TResult>? m_processingQueue;
 
 		public ParallelSelectAsyncIterator(
-			[NotNull] IAsyncEnumerable<TSource> source,
-			[NotNull] Func<TSource, CancellationToken, Task<TResult>> taskSelector,
-			[NotNull] ParallelAsyncQueryOptions options
+			IAsyncEnumerable<TSource> source,
+			Func<TSource, CancellationToken, Task<TResult>> taskSelector,
+			ParallelAsyncQueryOptions options
 		)
 			: base(source)
 		{

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/SelectManyAsyncIterator.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/SelectManyAsyncIterator.cs
@@ -35,7 +35,6 @@ namespace Doxense.Linq.Async.Iterators
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Linq.Async.Expressions;
-	using JetBrains.Annotations;
 
 	/// <summary>Iterates over an async sequence of items</summary>
 	/// <typeparam name="TSource">Type of elements of the inner async sequence</typeparam>
@@ -45,7 +44,7 @@ namespace Doxense.Linq.Async.Iterators
 		private readonly AsyncTransformExpression<TSource, IEnumerable<TResult>> m_selector;
 		private IEnumerator<TResult>? m_batch;
 
-		public SelectManyAsyncIterator([NotNull] IAsyncEnumerable<TSource> source, AsyncTransformExpression<TSource, IEnumerable<TResult>> selector)
+		public SelectManyAsyncIterator(IAsyncEnumerable<TSource> source, AsyncTransformExpression<TSource, IEnumerable<TResult>> selector)
 			: base(source)
 		{
 			// Must have at least one, but not both

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/TakeWhileAsyncIterator.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/TakeWhileAsyncIterator.cs
@@ -34,7 +34,6 @@ namespace Doxense.Linq.Async.Iterators
 	using System.Collections.Generic;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 
 	/// <summary>Reads an async sequence of items until a condition becomes false</summary>
 	/// <typeparam name="TSource">Type of elements of the async sequence</typeparam>
@@ -43,7 +42,7 @@ namespace Doxense.Linq.Async.Iterators
 		private readonly Func<TSource, bool> m_condition;
 		//TODO: also accept a Func<TSource, CT, Task<bool>> ?
 
-		public TakeWhileAsyncIterator([NotNull] IAsyncEnumerable<TSource> source, [NotNull] Func<TSource, bool> condition)
+		public TakeWhileAsyncIterator(IAsyncEnumerable<TSource> source, Func<TSource, bool> condition)
 			: base(source)
 		{
 			Contract.Requires(condition != null);

--- a/FoundationDB.Client/Shared/Linq/Async/Iterators/WhereSelectAsyncIterator.cs
+++ b/FoundationDB.Client/Shared/Linq/Async/Iterators/WhereSelectAsyncIterator.cs
@@ -36,7 +36,6 @@ namespace Doxense.Linq.Async.Iterators
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Linq.Async.Expressions;
-	using JetBrains.Annotations;
 
 	/// <summary>Iterates over an async sequence of items</summary>
 	/// <typeparam name="TSource">Type of elements of the inner async sequence</typeparam>
@@ -54,7 +53,7 @@ namespace Doxense.Linq.Async.Iterators
 		private int? m_skipped;
 
 		public WhereSelectAsyncIterator(
-			[NotNull] IAsyncEnumerable<TSource> source,
+			IAsyncEnumerable<TSource> source,
 			AsyncFilterExpression<TSource>? filter,
 			AsyncTransformExpression<TSource, TResult> transform,
 			int? limit,

--- a/FoundationDB.Client/Shared/Linq/AsyncEnumerable.Iterators.cs
+++ b/FoundationDB.Client/Shared/Linq/AsyncEnumerable.Iterators.cs
@@ -126,19 +126,17 @@ namespace Doxense.Linq
 
 		#region Helpers...
 
-		[NotNull]
 		internal static SelectManyAsyncIterator<TSource, TResult> Flatten<TSource, TResult>(
-			[NotNull] IAsyncEnumerable<TSource> source,
-			[NotNull] AsyncTransformExpression<TSource, IEnumerable<TResult>> selector)
+			IAsyncEnumerable<TSource> source,
+			AsyncTransformExpression<TSource, IEnumerable<TResult>> selector)
 		{
 			return new SelectManyAsyncIterator<TSource, TResult>(source, selector);
 		}
 
-		[NotNull]
 		internal static SelectManyAsyncIterator<TSource, TCollection, TResult> Flatten<TSource, TCollection, TResult>(
-			[NotNull] IAsyncEnumerable<TSource> source,
-			[NotNull] AsyncTransformExpression<TSource, IEnumerable<TCollection>> collectionSelector,
-			[NotNull] Func<TSource, TCollection, TResult> resultSelector)
+			IAsyncEnumerable<TSource> source,
+			AsyncTransformExpression<TSource, IEnumerable<TCollection>> collectionSelector,
+			Func<TSource, TCollection, TResult> resultSelector)
 		{
 			return new SelectManyAsyncIterator<TSource, TCollection, TResult>(
 				source,
@@ -147,44 +145,39 @@ namespace Doxense.Linq
 			);
 		}
 
-		[NotNull]
 		internal static WhereSelectAsyncIterator<TSource, TResult> Map<TSource, TResult>(
-			[NotNull] IAsyncEnumerable<TSource> source,
-			[NotNull] AsyncTransformExpression<TSource, TResult> selector,
+			IAsyncEnumerable<TSource> source,
+			AsyncTransformExpression<TSource, TResult> selector,
 			int? limit = null, int?
 			offset = null)
 		{
 			return new WhereSelectAsyncIterator<TSource, TResult>(source, filter: null, transform: selector, limit: limit, offset: offset);
 		}
 
-		[NotNull]
 		internal static WhereAsyncIterator<TResult> Filter<TResult>(
-			[NotNull] IAsyncEnumerable<TResult> source,
-			[NotNull] AsyncFilterExpression<TResult> filter)
+			IAsyncEnumerable<TResult> source,
+			AsyncFilterExpression<TResult> filter)
 		{
 			return new WhereAsyncIterator<TResult>(source, filter);
 		}
 
-		[NotNull]
 		internal static WhereSelectAsyncIterator<TResult, TResult> Offset<TResult>(
-			[NotNull] IAsyncEnumerable<TResult> source,
+			IAsyncEnumerable<TResult> source,
 			int offset)
 		{
 			return new WhereSelectAsyncIterator<TResult, TResult>(source, filter: null, transform: new AsyncTransformExpression<TResult, TResult>(TaskHelpers.CachedTasks<TResult>.Identity), limit: null, offset: offset);
 		}
 
-		[NotNull]
 		internal static WhereSelectAsyncIterator<TResult, TResult> Limit<TResult>(
-			[NotNull] IAsyncEnumerable<TResult> source,
+			IAsyncEnumerable<TResult> source,
 			int limit)
 		{
 			return new WhereSelectAsyncIterator<TResult, TResult>(source, filter: null, transform: new AsyncTransformExpression<TResult, TResult>(TaskHelpers.CachedTasks<TResult>.Identity), limit: limit, offset: null);
 		}
 
-		[NotNull]
 		internal static TakeWhileAsyncIterator<TResult> Limit<TResult>(
-			[NotNull] IAsyncEnumerable<TResult> source,
-			[NotNull] Func<TResult, bool> condition)
+			IAsyncEnumerable<TResult> source,
+			Func<TResult, bool> condition)
 		{
 			return new TakeWhileAsyncIterator<TResult>(source, condition);
 		}
@@ -201,9 +194,9 @@ namespace Doxense.Linq
 		/// <param name="ct">Cancellation token that can be used to cancel the operation</param>
 		/// <returns>Number of items that have been processed</returns>
 		internal static async Task<long> Run<TSource>(
-			[NotNull] IAsyncEnumerable<TSource> source,
+			IAsyncEnumerable<TSource> source,
 			AsyncIterationHint mode,
-			[NotNull, InstantHandle] Action<TSource> action,
+			[InstantHandle] Action<TSource> action,
 			CancellationToken ct)
 		{
 			Contract.NotNull(source, nameof(source));
@@ -233,9 +226,9 @@ namespace Doxense.Linq
 		/// <param name="ct">Cancellation token that can be used to cancel the operation</param>
 		/// <returns>Number of items that have been processed successfully</returns>
 		internal static async Task<long> Run<TSource>(
-			[NotNull] IAsyncEnumerable<TSource> source,
+			IAsyncEnumerable<TSource> source,
 			AsyncIterationHint mode,
-			[NotNull] Func<TSource, bool> action,
+			Func<TSource, bool> action,
 			CancellationToken ct)
 		{
 			Contract.NotNull(source, nameof(source));
@@ -268,9 +261,9 @@ namespace Doxense.Linq
 		/// <param name="ct">Cancellation token that can be used to cancel the operation</param>
 		/// <returns>Number of items that have been processed</returns>
 		internal static async Task<long> Run<TSource>(
-			[NotNull] IAsyncEnumerable<TSource> source,
+			IAsyncEnumerable<TSource> source,
 			AsyncIterationHint mode,
-			[NotNull] Func<TSource, CancellationToken, Task> action,
+			Func<TSource, CancellationToken, Task> action,
 			CancellationToken ct)
 		{
 			ct.ThrowIfCancellationRequested();
@@ -297,9 +290,9 @@ namespace Doxense.Linq
 		/// <param name="ct">Cancellation token that can be used to cancel the operation</param>
 		/// <returns>Number of items that have been processed</returns>
 		internal static async Task<long> Run<TSource>(
-			[NotNull] IAsyncEnumerable<TSource> source,
+			IAsyncEnumerable<TSource> source,
 			AsyncIterationHint mode,
-			[NotNull] Func<TSource, Task> action,
+			Func<TSource, Task> action,
 			CancellationToken ct)
 		{
 			ct.ThrowIfCancellationRequested();
@@ -327,7 +320,7 @@ namespace Doxense.Linq
 		/// <param name="ct">Cancellation token that can be used to cancel the operation</param>
 		/// <returns>Value of the first element of the <param ref="source"/> sequence, or the default value, or an exception (depending on <paramref name="single"/> and <paramref name="orDefault"/></returns>
 		public static async Task<TSource> Head<TSource>(
-			[NotNull] IAsyncEnumerable<TSource> source,
+			IAsyncEnumerable<TSource> source,
 			bool single,
 			bool orDefault,
 			CancellationToken ct)
@@ -416,7 +409,6 @@ namespace Doxense.Linq
 			this.Index = 0;
 		}
 
-		[NotNull]
 		private T[] MergeChunks()
 		{
 			var tmp = new T[this.Count];
@@ -436,7 +428,6 @@ namespace Doxense.Linq
 		/// <summary>Return a buffer containing all of the items</summary>
 		/// <returns>Buffer that contains all the items, and may be larger than required</returns>
 		/// <remarks>This is equivalent to calling ToArray(), except that if the buffer is empty, or if it consists of a single page, then no new allocations will be performed.</remarks>
-		[NotNull]
 		public T[] GetBuffer()
 		{
 			//note: this is called by internal operator like OrderBy
@@ -459,7 +450,6 @@ namespace Doxense.Linq
 
 		/// <summary>Return the content of the buffer</summary>
 		/// <returns>Array of size <see cref="Count"/> containing all the items in this buffer</returns>
-		[NotNull]
 		public T[] ToArray()
 		{
 			if (this.Count == 0)
@@ -478,7 +468,6 @@ namespace Doxense.Linq
 
 		/// <summary>Return the content of the buffer</summary>
 		/// <returns>List of size <see cref="Count"/> containing all the items in this buffer</returns>
-		[NotNull]
 		public List<T> ToList()
 		{
 			int count = this.Count;
@@ -517,7 +506,6 @@ namespace Doxense.Linq
 
 		/// <summary>Return the content of the buffer</summary>
 		/// <returns>List of size <see cref="Count"/> containing all the items in this buffer</returns>
-		[NotNull]
 		public HashSet<T> ToHashSet(IEqualityComparer<T>? comparer = null)
 		{
 			int count = this.Count;

--- a/FoundationDB.Client/Shared/Linq/AsyncEnumerable.OrderedSequence.cs
+++ b/FoundationDB.Client/Shared/Linq/AsyncEnumerable.OrderedSequence.cs
@@ -72,7 +72,6 @@ namespace Doxense.Linq
 				m_parent = parent;
 			}
 
-			[NotNull]
 			internal virtual SequenceSorter<TSource> GetEnumerableSorter(SequenceSorter<TSource>? next)
 			{
 				var sorter = new SequenceByElementSorter<TSource>(m_comparer ?? Comparer<TSource>.Default, m_descending, next);

--- a/FoundationDB.Client/Shared/Linq/AsyncEnumerable.Sorters.cs
+++ b/FoundationDB.Client/Shared/Linq/AsyncEnumerable.Sorters.cs
@@ -48,12 +48,11 @@ namespace Doxense.Linq
 			/// <summary>Fill the array with all the keys extracted from the source</summary>
 			/// <param name="items"></param>
 			/// <param name="count"></param>
-			internal abstract void ComputeKeys([NotNull] TSource[] items, int count);
+			internal abstract void ComputeKeys(TSource[] items, int count);
 
 			internal abstract int CompareKeys(int index1, int index2);
 
-			[NotNull]
-			internal int[] Sort([NotNull] TSource[] items, int count)
+			internal int[] Sort(TSource[] items, int count)
 			{
 				ComputeKeys(items, count);
 				var map = new int[count];
@@ -62,7 +61,7 @@ namespace Doxense.Linq
 				return map;
 			}
 
-			private void QuickSort([NotNull] int[] map, int left, int right)
+			private void QuickSort(int[] map, int left, int right)
 			{
 				do
 				{

--- a/FoundationDB.Client/Shared/Linq/AsyncEnumerable.cs
+++ b/FoundationDB.Client/Shared/Linq/AsyncEnumerable.cs
@@ -794,7 +794,6 @@ namespace Doxense.Linq
 		}
 
 		/// <summary>Returns the first element of an async sequence, or the default value for the type if it is empty</summary>
-		[ItemCanBeNull]
 		public static Task<T> FirstOrDefaultAsync<T>(this IAsyncEnumerable<T> source, CancellationToken ct = default)
 		{
 			Contract.NotNull(source, nameof(source));
@@ -808,7 +807,6 @@ namespace Doxense.Linq
 		}
 
 		/// <summary>Returns the first element of an async sequence, or the default value for the type if it is empty</summary>
-		[ItemCanBeNull]
 		public static Task<T> FirstOrDefaultAsync<T>(this IAsyncEnumerable<T> source, [InstantHandle] Func<T, bool> predicate, CancellationToken ct = default)
 		{
 			Contract.NotNull(source, nameof(source));
@@ -855,7 +853,6 @@ namespace Doxense.Linq
 
 		/// <summary>Returns the first and only element of an async sequence, the default value for the type if it is empty, or an exception if it has two or more elements</summary>
 		/// <remarks>Will need to call MoveNext at least twice to ensure that there is no second element.</remarks>
-		[ItemCanBeNull]
 		public static Task<T> SingleOrDefaultAsync<T>(this IAsyncEnumerable<T> source, CancellationToken ct = default)
 		{
 			Contract.NotNull(source, nameof(source));
@@ -870,7 +867,6 @@ namespace Doxense.Linq
 
 		/// <summary>Returns the first and only element of an async sequence, the default value for the type if it is empty, or an exception if it has two or more elements</summary>
 		/// <remarks>Will need to call MoveNext at least twice to ensure that there is no second element.</remarks>
-		[ItemCanBeNull]
 		public static Task<T> SingleOrDefaultAsync<T>(this IAsyncEnumerable<T> source, [InstantHandle] Func<T, bool> predicate, CancellationToken ct = default)
 		{
 			Contract.NotNull(source, nameof(source));
@@ -924,7 +920,6 @@ namespace Doxense.Linq
 		}
 
 		/// <summary>Returns the last element of an async sequence, or the default value for the type if it is empty</summary>
-		[ItemCanBeNull]
 		public static async Task<T> LastOrDefaultAsync<T>(this IAsyncEnumerable<T> source, CancellationToken ct = default)
 		{
 			Contract.NotNull(source, nameof(source));
@@ -943,7 +938,6 @@ namespace Doxense.Linq
 		}
 
 		/// <summary>Returns the last element of an async sequence, or the default value for the type if it is empty</summary>
-		[ItemCanBeNull]
 		public static async Task<T> LastOrDefaultAsync<T>(this IAsyncEnumerable<T> source, [InstantHandle] Func<T, bool> predicate, CancellationToken ct = default)
 		{
 			Contract.NotNull(source, nameof(source));

--- a/FoundationDB.Client/Shared/Linq/IConfigurableAsyncEnumerable.cs
+++ b/FoundationDB.Client/Shared/Linq/IConfigurableAsyncEnumerable.cs
@@ -43,7 +43,6 @@ namespace Doxense.Linq
 		/// <param name="ct">Token used to cancel the iterator from the outside</param>
 		/// <param name="hint">Defines how the enumerator will be used by the caller. The source provider can use the mode to optimize how the results are produced.</param>
 		/// <returns>Enumerator for asynchronous enumeration over the sequence.</returns>
-		[NotNull]
 		IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken ct, AsyncIterationHint hint);
 	}
 

--- a/FoundationDB.Client/Shared/Memory/MutableSlice.Encoding.cs
+++ b/FoundationDB.Client/Shared/Memory/MutableSlice.Encoding.cs
@@ -606,7 +606,7 @@ namespace System
 		/// Slices encoded by this method are not guaranteed to be decoded without loss. <b>YOU'VE BEEN WARNED!</b>
 		/// </remarks>
 		[Pure]
-		public static MutableSlice FromStringAnsi([CanBeNull] string text)
+		public static MutableSlice FromStringAnsi(string? text)
 		{
 			return text == null ? default
 			     : text.Length == 0 ? MutableSlice.Empty
@@ -621,11 +621,11 @@ namespace System
 		/// </remarks>
 		/// <exception cref="FormatException">If at least one character is greater than 255.</exception>
 		[Pure]
-		public static MutableSlice FromStringAscii([CanBeNull] string value)
+		public static MutableSlice FromStringAscii(string? value)
 		{
 			if (value == null) return default;
 			if (value.Length == 0) return MutableSlice.Empty;
-			byte[] _ = null;
+			byte[]? _ = null;
 			return ConvertByteStringChecked(value.AsSpan(), ref _);
 		}
 
@@ -640,7 +640,7 @@ namespace System
 		public static MutableSlice FromStringAscii(ReadOnlySpan<char> value)
 		{
 			if (value.Length == 0) return MutableSlice.Empty;
-			byte[] _ = null;
+			byte[]? _ = null;
 			return ConvertByteStringChecked(value, ref _);
 		}
 
@@ -652,7 +652,7 @@ namespace System
 		/// </remarks>
 		/// <exception cref="FormatException">If at least one character is greater than 255.</exception>
 		[Pure]
-		public static MutableSlice FromStringAscii(ReadOnlySpan<char> value, ref byte[] buffer)
+		public static MutableSlice FromStringAscii(ReadOnlySpan<char> value, ref byte[]? buffer)
 		{
 			if (value.Length == 0) return MutableSlice.Empty;
 			return ConvertByteStringChecked(value, ref buffer);
@@ -664,10 +664,10 @@ namespace System
 		/// Slices encoded by this method are ONLY compatible with UTF-8 encoding if all characters are between 0 and 127. If this is not the case, then decoding it as an UTF-8 sequence may introduce corruption.
 		/// </remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static MutableSlice FromByteString([CanBeNull] string value)
+		public static MutableSlice FromByteString(string? value)
 		{
 			if (value == null) return default;
-			byte[] _ = null;
+			byte[]? _ = null;
 			return FromByteString(value.AsSpan(), ref _);
 		}
 
@@ -679,7 +679,7 @@ namespace System
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static MutableSlice FromByteString(ReadOnlySpan<char> value)
 		{
-			byte[] _ = default;
+			byte[]? _ = default;
 			return FromByteString(value, ref _);
 		}
 
@@ -689,13 +689,13 @@ namespace System
 		/// Slices encoded by this method are ONLY compatible with UTF-8 encoding if all characters are between 0 and 127. If this is not the case, then decoding it as an UTF-8 sequence may introduce corruption.
 		/// </remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static MutableSlice FromByteString(ReadOnlySpan<char> value, ref byte[] buffer)
+		public static MutableSlice FromByteString(ReadOnlySpan<char> value, ref byte[]? buffer)
 		{
 			return value.Length != 0 ? ConvertByteStringNoCheck(value, ref buffer) : MutableSlice.Empty;
 		}
 
 		[Pure]
-		internal static MutableSlice ConvertByteStringChecked(ReadOnlySpan<char> value, ref byte[] buffer)
+		internal static MutableSlice ConvertByteStringChecked(ReadOnlySpan<char> value, ref byte[]? buffer)
 		{
 			int n = value.Length;
 			if (n == 1)
@@ -749,12 +749,12 @@ namespace System
 		/// For these case, or when you known that the string only contains ASCII only (with 100% certainty), you should use <see cref="FromByteString(string)"/>.
 		/// </remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static MutableSlice FromString([CanBeNull] string value)
+		public static MutableSlice FromString(string? value)
 		{
 			//REVIEW: what if people call FromString"\xFF/some/system/path") by mistake?
 			// Should be special case when the string starts with \xFF (or \xFF\xFF)? What about \xFE ?
 			if (value == null) return default(MutableSlice);
-			byte[] _ = null;
+			byte[]? _ = null;
 			return FromString(value.AsSpan(), ref _);
 		}
 
@@ -767,7 +767,7 @@ namespace System
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static MutableSlice FromString(ReadOnlySpan<char> value)
 		{
-			byte[] _ = null;
+			byte[]? _ = null;
 			return FromString(value, ref _);
 		}
 
@@ -778,7 +778,7 @@ namespace System
 		/// For these case, or when you known that the string only contains ASCII only (with 100% certainty), you should use <see cref="FromByteString(ReadOnlySpan{char})"/>.
 		/// </remarks>
 		[Pure]
-		public static MutableSlice FromString(ReadOnlySpan<char> value, ref byte[] buffer)
+		public static MutableSlice FromString(ReadOnlySpan<char> value, ref byte[]? buffer)
 		{
 			if (value.Length == 0) return Empty;
 			if (UnsafeHelpers.IsAsciiString(value))
@@ -818,7 +818,7 @@ namespace System
 		/// For these case, or when you known that the string only contains ASCII only (with 100% certainty), you should use <see cref="FromByteString(string)"/>.
 		/// </remarks>
 		[Pure]
-		public static MutableSlice FromStringUtf8([CanBeNull] string value)
+		public static MutableSlice FromStringUtf8(string? value)
 		{
 			//REVIEW: what if people call FromString"\xFF/some/system/path") by mistake?
 			// Should be special case when the string starts with \xFF (or \xFF\xFF)? What about \xFE ?
@@ -838,7 +838,7 @@ namespace System
 		/// </remarks>
 		[Pure, ContractAnnotation("=> buffer:notnull")]
 		[Obsolete("Use FromStringUtf8(ReadOnlySpan<char>, ...) instead")]
-		public static MutableSlice FromStringUtf8([NotNull] string value, [Positive] int offset, [Positive] int count, ref byte[] buffer, out bool asciiOnly)
+		public static MutableSlice FromStringUtf8(string value, [Positive] int offset, [Positive] int count, ref byte[]? buffer, out bool asciiOnly)
 		{
 			if (count == 0)
 			{
@@ -860,7 +860,7 @@ namespace System
 		public static MutableSlice FromStringUtf8(ReadOnlySpan<char> value)
 		{
 			if (value.Length == 0) return Empty;
-			byte[] __ = null;
+			byte[]? __ = null;
 			return FromStringUtf8(value, ref __, out _);
 		}
 
@@ -873,7 +873,7 @@ namespace System
 		/// DO NOT call this method to encode special strings that contain binary prefixes, like "\xFF/some/system/path" or "\xFE\x01\x02\x03", because they do not map to UTF-8 directly.
 		/// For these case, or when you known that the string only contains ASCII only (with 100% certainty), you should use <see cref="FromByteString(ReadOnlySpan{char})"/>.
 		/// </remarks>
-		public static MutableSlice FromStringUtf8(ReadOnlySpan<char> value, ref byte[] buffer, out bool asciiOnly)
+		public static MutableSlice FromStringUtf8(ReadOnlySpan<char> value, ref byte[]? buffer, out bool asciiOnly)
 		{
 			if (value.Length == 0)
 			{
@@ -919,12 +919,12 @@ namespace System
 		/// For these case, or when you known that the string only contains ASCII only (with 100% certainty), you should use <see cref="FromByteString(string)"/>.
 		/// </remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static MutableSlice FromStringUtf8WithBom([CanBeNull] string value)
+		public static MutableSlice FromStringUtf8WithBom(string? value)
 		{
 			//REVIEW: what if people call FromString"\xFF/some/system/path") by mistake?
 			// Should be special case when the string starts with \xFF (or \xFF\xFF)? What about \xFE ?
 			if (value == null) return default;
-			byte[] _ = null;
+			byte[]? _ = null;
 			return FromStringUtf8WithBom(value.AsSpan(), ref _);
 		}
 
@@ -938,7 +938,7 @@ namespace System
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static MutableSlice FromStringUtf8WithBom(ReadOnlySpan<char> value)
 		{
-			byte[] _ = null;
+			byte[]? _ = null;
 			return FromStringUtf8WithBom(value, ref _);
 		}
 
@@ -950,7 +950,7 @@ namespace System
 		/// For these case, or when you known that the string only contains ASCII only (with 100% certainty), you should use <see cref="FromByteString(ReadOnlySpan{char})"/>.
 		/// </remarks>
 		[Pure]
-		public static MutableSlice FromStringUtf8WithBom(ReadOnlySpan<char> value, ref byte[] buffer)
+		public static MutableSlice FromStringUtf8WithBom(ReadOnlySpan<char> value, ref byte[]? buffer)
 		{
 			if (value.Length == 0)
 			{
@@ -987,7 +987,7 @@ namespace System
 		/// For these case, or when you known that the string only contains ASCII only (with 100% certainty), you should use <see cref="FromByteString(ReadOnlySpan{char})"/>.
 		/// </remarks>
 		[Pure]
-		private static MutableSlice ConvertByteStringNoCheck(ReadOnlySpan<char> value, ref byte[] buffer)
+		private static MutableSlice ConvertByteStringNoCheck(ReadOnlySpan<char> value, ref byte[]? buffer)
 		{
 			int len = value.Length;
 			if (len == 0) return Empty;
@@ -1023,7 +1023,7 @@ namespace System
 				return FromByte((byte)value);
 			}
 
-			byte[] _ = null;
+			byte[]? _ = null;
 			return FromChar(value, ref _);
 		}
 
@@ -1031,7 +1031,7 @@ namespace System
 		/// <returns>The returned slice is only guaranteed to hold 1 byte for ASCII chars (0..127). For non-ASCII chars, the size can be from 1 to 6 bytes.
 		/// If you need to use ASCII chars, you should use Slice.FromByte() instead</returns>
 		[Pure]
-		public static MutableSlice FromChar(char value, ref byte[] buffer)
+		public static MutableSlice FromChar(char value, ref byte[]? buffer)
 		{
 			if (value < 128)
 			{ // ASCII
@@ -1068,7 +1068,7 @@ namespace System
 			throw FailInputNotValidHexadecimalDigit();
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		private static FormatException FailInputNotValidHexadecimalDigit()
 		{
 			return ThrowHelper.FormatException("Input is not a valid hexadecimal digit");
@@ -1076,34 +1076,34 @@ namespace System
 
 		/// <summary>Convert an hexadecimal encoded string ("1234AA7F") into a slice</summary>
 		/// <param name="hexaString">String contains a sequence of pairs of hexadecimal digits with no separating spaces.</param>
-		/// <returns>Slice containing the decoded byte array, or an exeception if the string is empty or has an odd length</returns>
+		/// <returns>Slice containing the decoded byte array, or an exception if the string is empty or has an odd length</returns>
 		[Pure]
-		public static MutableSlice FromHexa([CanBeNull] string hexaString)
+		public static MutableSlice FromHexa(string? hexaString)
 		{
 			if (string.IsNullOrEmpty(hexaString)) return hexaString == null ? default : Empty;
-			byte[] buffer = null;
+			byte[]? buffer = null;
 			int written = UnsafeHelpers.FromHexa(hexaString.AsSpan(), ref buffer);
 			return new MutableSlice(buffer, 0, written);
 		}
 
 		/// <summary>Convert an hexadecimal encoded string ("1234AA7F") into a slice</summary>
 		/// <param name="hexaString">String contains a sequence of pairs of hexadecimal digits with no separating spaces.</param>
-		/// <returns>Slice containing the decoded byte array, or an exeception if the string is empty or has an odd length</returns>
+		/// <returns>Slice containing the decoded byte array, or an exception if the string is empty or has an odd length</returns>
 		[Pure]
 		public static MutableSlice FromHexa(ReadOnlySpan<char> hexaString)
 		{
 			if (hexaString.Length == 0) return Empty;
-			byte[] buffer = null;
+			byte[]? buffer = null;
 			int written = UnsafeHelpers.FromHexa(hexaString, ref buffer);
 			return new MutableSlice(buffer, 0, written);
 		}
 
 		/// <summary>Decode the string that was generated by slice.ToString() or Slice.Dump(), back into the original slice</summary>
 		/// <remarks>This may not be efficient, so it should only be use for testing/logging/troubleshooting</remarks>
-		public static MutableSlice Unescape([CanBeNull] string value) //REVIEW: rename this to Decode() if we changed Dump() to Encode()
+		public static MutableSlice Unescape(string? value) //REVIEW: rename this to Decode() if we changed Dump() to Encode()
 		{
 			if (string.IsNullOrEmpty(value)) return value == null ? default : Empty;
-			byte[] buffer = null;
+			byte[]? buffer = null;
 			int written = UnsafeHelpers.Unescape(value.AsSpan(), ref buffer);
 			return new MutableSlice(buffer, 0, written);
 		}
@@ -1113,7 +1113,7 @@ namespace System
 		public static MutableSlice Unescape(ReadOnlySpan<char> value) //REVIEW: rename this to Decode() if we changed Dump() to Encode()
 		{
 			if (value.Length == 0) return Empty;
-			byte[] buffer = null;
+			byte[]? buffer = null;
 			int written = UnsafeHelpers.Unescape(value, ref buffer);
 			return new MutableSlice(buffer, 0, written);
 		}
@@ -1132,8 +1132,8 @@ namespace System
 		/// If you are decoding identifiers or keywords that are known to be ASCII only, you should use <see cref="ToStringAscii"/> instead (safe).
 		/// If these identifiers can contain 'special' bytes (like \xFF or \xFE), you should use <see cref="ToByteString"/> instead (unsafe).
 		/// </remarks>
-		[Pure, CanBeNull]
-		public string ToStringAnsi()
+		[Pure]
+		public string? ToStringAnsi()
 		{
 			if (this.Count == 0) return this.Array != null ? string.Empty : null;
 			//note: Encoding.GetString() will do the bound checking for us
@@ -1149,8 +1149,8 @@ namespace System
 		/// If you are decoding natural text, or text from unknown origin, you should use <see cref="ToStringUtf8"/> or <see cref="ToUnicode"/> instead.
 		/// If you are attempting to decode a string obtain from a Win32 or unmanaged library call, you should use <see cref="ToStringAnsi"/> instead.
 		/// </remarks>
-		[Pure, CanBeNull]
-		public string ToStringAscii()
+		[Pure]
+		public string? ToStringAscii()
 		{
 			if (this.Count == 0)
 			{
@@ -1165,8 +1165,8 @@ namespace System
 
 		/// <summary>Stringify a slice containing only ASCII chars</summary>
 		/// <returns>ASCII string, or null if the slice is null</returns>
-		[Pure, CanBeNull]
-		public string ToByteString() //REVIEW: rename to ToStringSOMETHING(): ToStringByte()? ToStringRaw()?
+		[Pure]
+		public string? ToByteString() //REVIEW: rename to ToStringSOMETHING(): ToStringByte()? ToStringRaw()?
 		{
 			return this.Count == 0
 				? (this.Array != null ? string.Empty : null)
@@ -1180,8 +1180,8 @@ namespace System
 		/// This is NOT compatible with slices produced by <see cref="FromStringAnsi"/> or encoded with any specific encoding or code page.
 		/// This method will NOT automatically remove the UTF-8 BOM if present (use <see cref="ToStringUtf8"/> if you need this)
 		/// </remarks>
-		[Pure, CanBeNull]
-		public string ToUnicode() //REVIEW: rename this to ToStringUnicode() ?
+		[Pure]
+		public string? ToUnicode() //REVIEW: rename this to ToStringUnicode() ?
 		{
 			var array = this.Array;
 			int count = this.Count;
@@ -1192,7 +1192,7 @@ namespace System
 		}
 
 		[Pure]
-		private static bool HasUtf8Bom([NotNull] byte[] array, int offset, int count)
+		private static bool HasUtf8Bom(byte[] array, int offset, int count)
 		{
 			return count >= 3
 			    && (uint) (offset + count) <= (uint) array.Length
@@ -1208,8 +1208,8 @@ namespace System
 		/// This method will THROW if the slice does not contain valid UTF-8 sequences.
 		/// This method will remove any UTF-8 BOM if present. If you need to keep the BOM as the first character of the string, use <see cref="ToUnicode"/>
 		/// </remarks>
-		[Pure, CanBeNull]
-		public string ToStringUtf8()
+		[Pure]
+		public string? ToStringUtf8()
 		{
 			int count = this.Count;
 			var array = this.Array;
@@ -1227,8 +1227,8 @@ namespace System
 		}
 
 		/// <summary>Converts a slice using Base64 encoding</summary>
-		[Pure, CanBeNull]
-		public string ToBase64()
+		[Pure]
+		public string? ToBase64()
 		{
 			if (this.Count == 0) return this.Array != null ? string.Empty : null;
 			//note: Convert.ToBase64String() will do the bound checking for us
@@ -1238,7 +1238,7 @@ namespace System
 		/// <summary>Converts a slice into a string with each byte encoded into hexadecimal (lowercase)</summary>
 		/// <param name="lower">If true, produces lowercase hexadecimal (a-f); otherwise, produces uppercase hexadecimal (A-F)</param>
 		/// <returns>"0123456789abcdef"</returns>
-		[Pure, NotNull]
+		[Pure]
 		public string ToHexaString(bool lower = false)
 		{
 			return Slice.FormatHexaString(this.Array, this.Offset, this.Count, '\0', lower);
@@ -1248,7 +1248,7 @@ namespace System
 		/// <param name="sep">Character used to separate the hexadecimal pairs (ex: ' ')</param>
 		/// <param name="lower">If true, produces lowercase hexadecimal (a-f); otherwise, produces uppercase hexadecimal (A-F)</param>
 		/// <returns>"01 23 45 67 89 ab cd ef"</returns>
-		[Pure, NotNull]
+		[Pure]
 		public string ToHexaString(char sep, bool lower = false)
 		{
 			return Slice.FormatHexaString(this.Array, this.Offset, this.Count, sep, lower);
@@ -1256,7 +1256,7 @@ namespace System
 
 		/// <summary>Helper method that dumps the slice as a string (if it contains only printable ascii chars) or an hex array if it contains non printable chars. It should only be used for logging and troubleshooting !</summary>
 		/// <returns>Returns either "'abc'", "&lt;00 42 7F&gt;", or "{ ...JSON... }". Returns "''" for Slice.Empty, and "" for <see cref="MutableSlice.Nil"/></returns>
-		[Pure, NotNull]
+		[Pure]
 		public string PrettyPrint()
 		{
 			if (this.Count == 0) return this.Array != null ? "''" : string.Empty;
@@ -1266,7 +1266,7 @@ namespace System
 		/// <summary>Helper method that dumps the slice as a string (if it contains only printable ascii chars) or an hex array if it contains non printable chars. It should only be used for logging and troubleshooting !</summary>
 		/// <param name="maxLen">Truncate the slice if it exceeds this size</param>
 		/// <returns>Returns either "'abc'", "&lt;00 42 7F&gt;", or "{ ...JSON... }". Returns "''" for Slice.Empty, and "" for <see cref="MutableSlice.Nil"/></returns>
-		[Pure, NotNull]
+		[Pure]
 		public string PrettyPrint(int maxLen)
 		{
 			if (this.Count == 0) return this.Array != null ? "''" : string.Empty;
@@ -1907,7 +1907,7 @@ namespace System
 				case 19: // {hex8-hex8}
 				{
 					// ReSharper disable once AssignNullToNotNullAttribute
-					return Uuid64.Parse(ToByteString());
+					return Uuid64.Parse(ToByteString()!);
 				}
 			}
 
@@ -2073,7 +2073,7 @@ namespace System
 			if (this.Count == 36)
 			{
 				// ReSharper disable once AssignNullToNotNullAttribute
-				return Uuid128.Parse(ToByteString());
+				return Uuid128.Parse(ToByteString()!);
 			}
 
 			throw new FormatException("Cannot convert slice into an Uuid128 because it has an incorrect size.");
@@ -2104,7 +2104,7 @@ namespace System
 				case 24: // {XXXX-XXXXXXXX-XXXXXXXX}
 				{
 					// ReSharper disable once AssignNullToNotNullAttribute
-					return Uuid80.Parse(ToByteString());
+					return Uuid80.Parse(ToByteString()!);
 				}
 			}
 
@@ -2136,7 +2136,7 @@ namespace System
 				case 28: // {XXXXXXXX-XXXXXXXX-XXXXXXXX}
 				{
 					// ReSharper disable once AssignNullToNotNullAttribute
-					return Uuid96.Parse(ToByteString());
+					return Uuid96.Parse(ToByteString()!);
 				}
 			}
 

--- a/FoundationDB.Client/Shared/Memory/Slice.Encoding.cs
+++ b/FoundationDB.Client/Shared/Memory/Slice.Encoding.cs
@@ -612,7 +612,6 @@ namespace System
 		}
 
 		/// <summary>Encoding used to produce UTF-8 slices</summary>
-		[NotNull]
 		internal static readonly UTF8Encoding Utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
 		/// <summary>Dangerously create a slice containing string converted to the local ANSI code page. All non-ANSI characters may be corrupted or converted to '?', and this slice may not decode properly on a different system.</summary>
@@ -853,7 +852,7 @@ namespace System
 		/// </remarks>
 		[Pure, ContractAnnotation("=> buffer:notnull")]
 		[Obsolete("Use FromStringUtf8(ReadOnlySpan<char>, ...) instead")]
-		public static Slice FromStringUtf8([NotNull] string value, [Positive] int offset, [Positive] int count, [System.Diagnostics.CodeAnalysis.NotNull] ref byte[]? buffer, out bool asciiOnly)
+		public static Slice FromStringUtf8(string value, [Positive] int offset, [Positive] int count, [System.Diagnostics.CodeAnalysis.NotNull] ref byte[]? buffer, out bool asciiOnly)
 		{
 			if (count == 0)
 			{
@@ -1183,7 +1182,7 @@ namespace System
 		}
 
 		[Pure]
-		private static bool HasUtf8Bom([NotNull] byte[] array, int offset, int count)
+		private static bool HasUtf8Bom(byte[] array, int offset, int count)
 		{
 			return count >= 3
 			    && (uint) (offset + count) <= (uint) array.Length
@@ -1229,7 +1228,7 @@ namespace System
 		/// <summary>Converts a slice into a string with each byte encoded into hexadecimal (lowercase)</summary>
 		/// <param name="lower">If true, produces lowercase hexadecimal (a-f); otherwise, produces uppercase hexadecimal (A-F)</param>
 		/// <returns>"0123456789abcdef"</returns>
-		[Pure, NotNull]
+		[Pure]
 		public string ToHexaString(bool lower = false)
 		{
 			return FormatHexaString(this.Array, this.Offset, this.Count, '\0', lower);
@@ -1239,13 +1238,13 @@ namespace System
 		/// <param name="sep">Character used to separate the hexadecimal pairs (ex: ' ')</param>
 		/// <param name="lower">If true, produces lowercase hexadecimal (a-f); otherwise, produces uppercase hexadecimal (A-F)</param>
 		/// <returns>"01 23 45 67 89 ab cd ef"</returns>
-		[Pure, NotNull]
+		[Pure]
 		public string ToHexaString(char sep, bool lower = false)
 		{
 			return FormatHexaString(this.Array, this.Offset, this.Count, sep, lower);
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		internal static string FormatHexaString(byte[] buffer, int offset, int count, char sep, bool lower)
 		{
 			if (count == 0) return String.Empty;
@@ -1275,8 +1274,7 @@ namespace System
 			return sb.ToString();
 		}
 
-		[NotNull]
-		internal static StringBuilder EscapeString(StringBuilder sb, [NotNull] byte[] buffer, int offset, int count, [NotNull] Encoding encoding)
+		internal static StringBuilder EscapeString(StringBuilder sb, byte[] buffer, int offset, int count, Encoding encoding)
 		{
 			if (sb == null) sb = new StringBuilder(count + 16);
 			foreach (var c in encoding.GetChars(buffer, offset, count))
@@ -1301,7 +1299,7 @@ namespace System
 
 		/// <summary>Helper method that dumps the slice as a string (if it contains only printable ascii chars) or an hex array if it contains non printable chars. It should only be used for logging and troubleshooting !</summary>
 		/// <returns>Returns either "'abc'", "&lt;00 42 7F&gt;", or "{ ...JSON... }". Returns "''" for Slice.Empty, and "" for <see cref="Slice.Nil"/></returns>
-		[Pure, NotNull]
+		[Pure]
 		public string PrettyPrint()
 		{
 			if (this.Count == 0) return this.Array != null ? "''" : string.Empty;
@@ -1311,15 +1309,15 @@ namespace System
 		/// <summary>Helper method that dumps the slice as a string (if it contains only printable ascii chars) or an hex array if it contains non printable chars. It should only be used for logging and troubleshooting !</summary>
 		/// <param name="maxLen">Truncate the slice if it exceeds this size</param>
 		/// <returns>Returns either "'abc'", "&lt;00 42 7F&gt;", or "{ ...JSON... }". Returns "''" for Slice.Empty, and "" for <see cref="Slice.Nil"/></returns>
-		[Pure, NotNull]
+		[Pure]
 		public string PrettyPrint(int maxLen)
 		{
 			if (this.Count == 0) return this.Array != null ? "''" : string.Empty;
 			return PrettyPrint(this.Array, this.Offset, this.Count, maxLen);
 		}
 
-		[Pure, NotNull]
-		internal static string PrettyPrint([NotNull] byte[] buffer, int offset, int count, int maxLen)
+		[Pure]
+		internal static string PrettyPrint(byte[] buffer, int offset, int count, int maxLen)
 		{
 			if (count == 0) return "''";
 

--- a/FoundationDB.Client/Shared/Memory/SliceBuffer.cs
+++ b/FoundationDB.Client/Shared/Memory/SliceBuffer.cs
@@ -86,7 +86,6 @@ namespace Doxense.Memory
 
 		/// <summary>Return the list of all the pages used by this buffer</summary>
 		/// <returns>Array of pages used by the buffer</returns>
-		[NotNull]
 		public Slice[] GetPages()
 		{
 			var pages = new Slice[this.PageCount];

--- a/FoundationDB.Client/Shared/Memory/SliceListStream.cs
+++ b/FoundationDB.Client/Shared/Memory/SliceListStream.cs
@@ -49,21 +49,21 @@ namespace Doxense.Memory
 		private long m_length;
 		private int m_indexOfCurrentSlice;
 		private int m_offsetInCurrentSlice;
-		private Task<int> m_lastTask;
+		private Task<int>? m_lastTask;
 
-		internal SliceListStream([NotNull] Slice[] slices)
+		internal SliceListStream(Slice[] slices)
 		{
 			Contract.NotNull(slices, nameof(slices));
 			Init(slices);
 		}
 
-		public SliceListStream([NotNull] IEnumerable<Slice> slices)
+		public SliceListStream(IEnumerable<Slice> slices)
 		{
 			Contract.NotNull(slices, nameof(slices));
 			Init(slices.ToArray());
 		}
 
-		private void Init([NotNull] Slice[] slices)
+		private void Init(Slice[] slices)
 		{
 			m_slices = slices;
 			long total = 0;

--- a/FoundationDB.Client/Shared/Memory/SliceReader.cs
+++ b/FoundationDB.Client/Shared/Memory/SliceReader.cs
@@ -101,7 +101,7 @@ namespace Doxense.Memory
 			if (count < 0 || checked(this.Position + count) > this.Buffer.Count) throw ThrowNotEnoughBytes(count);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		[DebuggerNonUserCode]
 		private static Exception ThrowNotEnoughBytes(int count)
 		{
@@ -385,7 +385,7 @@ namespace Doxense.Memory
 		}
 
 		/// <summary>Reads an utf-8 encoded string prefixed by a variable-sized length</summary>
-		[Pure, NotNull]
+		[Pure]
 		public string ReadVarString()
 		{
 			var str = ReadVarBytes();
@@ -394,8 +394,8 @@ namespace Doxense.Memory
 
 		/// <summary>Reads a string prefixed by a variable-sized length, using the specified encoding</summary>
 		/// <remarks>Encoding used for this string (or UTF-8 if null)</remarks>
-		[Pure, NotNull]
-		public string ReadVarString([CanBeNull] Encoding encoding)
+		[Pure]
+		public string ReadVarString(Encoding? encoding)
 		{
 			if (encoding == null || encoding.Equals(Encoding.UTF8))
 			{ // optimized path for utf-8

--- a/FoundationDB.Client/Shared/Memory/SliceReader.cs
+++ b/FoundationDB.Client/Shared/Memory/SliceReader.cs
@@ -68,14 +68,14 @@ namespace Doxense.Memory
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public SliceReader([NotNull] byte[] buffer)
+		public SliceReader(byte[] buffer)
 		{
 			this.Buffer = new Slice(buffer, 0, buffer.Length);
 			this.Position = 0;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public SliceReader([NotNull] byte[] buffer, int offset, int count)
+		public SliceReader(byte[] buffer, int offset, int count)
 		{
 			this.Buffer = new Slice(buffer, offset, count);
 			this.Position = 0;
@@ -187,7 +187,7 @@ namespace Doxense.Memory
 
 		/// <summary>Read until <paramref name="handler"/> returns true, or we reach the end of the buffer</summary>
 		[Pure]
-		public Slice ReadWhile([NotNull] Func<byte, int, bool> handler)
+		public Slice ReadWhile(Func<byte, int, bool> handler)
 		{
 			unsafe
 			{

--- a/FoundationDB.Client/Shared/Memory/SliceStream.cs
+++ b/FoundationDB.Client/Shared/Memory/SliceStream.cs
@@ -253,7 +253,7 @@ namespace Doxense.Memory
 			if ((uint) offset > buffer.Length - count) throw ThrowHelper.ArgumentException(nameof(offset), "Buffer is too small.");
 		}
 
-		[DoesNotReturn, ContractAnnotation("=> halt")]
+		[DoesNotReturn]
 		private static void StreamIsClosed()
 		{
 			throw ThrowHelper.ObjectDisposedException("The stream was already closed");

--- a/FoundationDB.Client/Shared/StringConverters.cs
+++ b/FoundationDB.Client/Shared/StringConverters.cs
@@ -56,7 +56,7 @@ namespace Doxense.Serialization
 		};
 
 		/// <summary>Convert an integer into a string</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static string ToString(int value)
 		{
 			var cache = StringConverters.SmallNumbers;
@@ -64,7 +64,7 @@ namespace Doxense.Serialization
 		}
 
 		/// <summary>Convert an integer into a string</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static string ToString(uint value)
 		{
 			var cache = StringConverters.SmallNumbers;
@@ -72,7 +72,7 @@ namespace Doxense.Serialization
 		}
 
 		/// <summary>Convert an integer into a string</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static string ToString(long value)
 		{
 			var cache = StringConverters.SmallNumbers;
@@ -80,7 +80,7 @@ namespace Doxense.Serialization
 		}
 
 		/// <summary>Convert an integer into a string</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static string ToString(ulong value)
 		{
 			var cache = StringConverters.SmallNumbers;
@@ -88,25 +88,25 @@ namespace Doxense.Serialization
 		}
 
 		/// <summary>Convert a float into a string</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static string ToString(float value)
 		{
 			long x = unchecked((long) value);
 			// ReSharper disable once CompareOfFloatsByEqualityOperator
 			return x != value
-					   ? value.ToString("R", CultureInfo.InvariantCulture)
-					   : (x >= 0 && x < StringConverters.SmallNumbers.Length ? StringConverters.SmallNumbers[(int) x] : x.ToString(NumberFormatInfo.InvariantInfo));
+				? value.ToString("R", CultureInfo.InvariantCulture)
+				: (x >= 0 && x < StringConverters.SmallNumbers.Length ? StringConverters.SmallNumbers[(int) x] : x.ToString(NumberFormatInfo.InvariantInfo));
 		}
 
 		/// <summary>Convert a double into a string</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static string ToString(double value)
 		{
 			long x = unchecked((long)value);
 			// ReSharper disable once CompareOfFloatsByEqualityOperator
 			return x != value
-					   ? value.ToString("R", CultureInfo.InvariantCulture)
-					   : (x >= 0 && x < StringConverters.SmallNumbers.Length ? StringConverters.SmallNumbers[(int)x] : x.ToString(NumberFormatInfo.InvariantInfo));
+				? value.ToString("R", CultureInfo.InvariantCulture)
+				: (x >= 0 && x < StringConverters.SmallNumbers.Length ? StringConverters.SmallNumbers[(int)x] : x.ToString(NumberFormatInfo.InvariantInfo));
 		}
 
 		/// <summary>Convert a string into a boolean</summary>
@@ -164,7 +164,7 @@ namespace Doxense.Serialization
 		/// <param name="newpos">Stores the new position in the buffer (after the separator if found)</param>
 		/// <returns>true if an integer was found; otherwise, false (no more data, malformed integer, ...)</returns>
 		/// <exception cref="System.ArgumentNullException">If <paramref name="buffer"/> is null</exception>
-		public static unsafe bool FastTryGetInt([NotNull] char* buffer, int offset, int length, char separator, int defaultValue, out int result, out int newpos)
+		public static unsafe bool FastTryGetInt(char* buffer, int offset, int length, char separator, int defaultValue, out int result, out int newpos)
 		{
 			Contract.PointerNotNull(buffer, nameof(buffer));
 			result = defaultValue;
@@ -218,7 +218,7 @@ namespace Doxense.Serialization
 		/// <param name="newpos">Stores the new position in the buffer (after the separator if found)</param>
 		/// <returns>true if an integer was found; otherwise, false (no more data, malformed integer, ...)</returns>
 		/// <exception cref="System.ArgumentNullException">If <paramref name="buffer"/> is null</exception>
-		public static unsafe bool FastTryGetLong([NotNull] char* buffer, int offset, int length, char separator, long defaultValue, out long result, out int newpos)
+		public static unsafe bool FastTryGetLong(char* buffer, int offset, int length, char separator, long defaultValue, out long result, out int newpos)
 		{
 			Contract.PointerNotNull(buffer, nameof(buffer));
 			result = defaultValue;
@@ -481,7 +481,7 @@ namespace Doxense.Serialization
 		/// <summary>Convert a date into a string, using the "YYYYMMDDHHMMSS" format</summary>
 		/// <param name="date">Date to convert</param>
 		/// <returns>Formatted date with fixed length 14 and format 'YYYYMMDDHHMMSS'</returns>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static string ToDateTimeString(DateTime date)
 		{
 			return date.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
@@ -490,7 +490,7 @@ namespace Doxense.Serialization
 		/// <summary>Convert a date into a string, using the "YYYYMMDD" format</summary>
 		/// <param name="date">Date to convert (only date will be used)</param>
 		/// <returns>Formatted date width fixed length 8 and format 'YYYYMMDDHHMMSS'</returns>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static string ToDateString(DateTime date)
 		{
 			return date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
@@ -499,7 +499,7 @@ namespace Doxense.Serialization
 		/// <summary>Convert a time of day into a string, using the "HHMMSS" format</summary>
 		/// <param name="date">Date to convert (only time of day will be used)</param>
 		/// <returns>Formatted time width fixed length 6 and format 'HHMMSS'</returns>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static string ToTimeString(DateTime date)
 		{
 			return date.ToString("HHmmss", CultureInfo.InvariantCulture);
@@ -527,7 +527,7 @@ namespace Doxense.Serialization
 			return result;
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		private static Exception FailInvalidDateFormat()
 		{
 			// ReSharper disable once NotResolvedInText
@@ -575,7 +575,7 @@ namespace Doxense.Serialization
 		/// <param name="throwsFail">If <c>false</c>, no exception is thrown and <c>false</c> is returned instead.. If <c>true<c>, re-throw all exceptions</param>
 		/// <returns><c>true</c> if the date was correctly converted; otherwise, <c>false</c>.</returns>
 		[Pure]
-		public static bool TryParseDateTime(string date, CultureInfo culture, out DateTime result, bool throwsFail)
+		public static bool TryParseDateTime(string date, CultureInfo? culture, out DateTime result, bool throwsFail)
 		{
 			result = DateTime.MinValue;
 

--- a/FoundationDB.Client/Shared/ThrowHelper.cs
+++ b/FoundationDB.Client/Shared/ThrowHelper.cs
@@ -43,14 +43,14 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region ArgumentNullException...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static Exception ArgumentNullException([InvokerParameterName] string paramName)
 		{
 			return new ArgumentNullException(paramName);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception ArgumentNullException([InvokerParameterName] string paramName, [NotNull] string message)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception ArgumentNullException([InvokerParameterName] string paramName, string message)
 		{
 			return new ArgumentNullException(paramName, message);
 		}
@@ -59,28 +59,28 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region ArgumentException...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception ArgumentException([InvokerParameterName] string paramName, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception ArgumentException([InvokerParameterName] string paramName, string? message = null)
 		{
 			// oui, c'est inversé :)
 			return new ArgumentException(message, paramName);
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static Exception ArgumentException([InvokerParameterName] string paramName, string message, object arg0)
 		{
 			// oui, c'est inversé :)
 			return new ArgumentException(string.Format(message, arg0), paramName);
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static Exception ArgumentException([InvokerParameterName] string paramName, string message, object arg0, object arg1)
 		{
 			// oui, c'est inversé :)
 			return new ArgumentException(string.Format(message, arg0, arg1), paramName);
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static Exception ArgumentException([InvokerParameterName] string paramName, string message, params object[] args)
 		{
 			// oui, c'est inversé :)
@@ -91,14 +91,14 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region ArgumentOutOfRangeException...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception ArgumentOutOfRangeException([InvokerParameterName] string paramName, object actualValue, string message = null)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception ArgumentOutOfRangeException([InvokerParameterName] string paramName, object actualValue, string? message = null)
 		{
 			return new ArgumentOutOfRangeException(paramName, actualValue, message);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception ArgumentOutOfRangeException([InvokerParameterName, NotNull] string paramName)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception ArgumentOutOfRangeException([InvokerParameterName] string paramName)
 		{
 			return new ArgumentOutOfRangeException(paramName);
 		}
@@ -107,77 +107,77 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region ObjectDisposedException...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static ObjectDisposedException ObjectDisposedException<TDisposed>(TDisposed disposed)
 		{
 			return new ObjectDisposedException(disposed.GetType().Name);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static ObjectDisposedException ObjectDisposedException(Type type)
 		{
 			return new ObjectDisposedException(type.Name);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static ObjectDisposedException ObjectDisposedException(Type type, string message)
 		{
 			return new ObjectDisposedException(type.Name, message);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static ObjectDisposedException ObjectDisposedException<TDisposed>(TDisposed disposed, string message)
 		{
 			return new ObjectDisposedException(disposed.GetType().Name, message);
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static ObjectDisposedException ObjectDisposedException<TDisposed>(string message)
 		{
 			return new ObjectDisposedException(typeof(TDisposed).Name, message);
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static ObjectDisposedException ObjectDisposedException<TDisposed>(string message, object arg0)
 		{
 			return new ObjectDisposedException(typeof(TDisposed).Name, string.Format(CultureInfo.InvariantCulture, message, arg0));
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static ObjectDisposedException ObjectDisposedException<TDisposed>(string message, params object[] args)
 		{
 			return new ObjectDisposedException(typeof(TDisposed).Name, string.Format(CultureInfo.InvariantCulture, message, args));
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static ObjectDisposedException ObjectDisposedException(string message, Exception innnerException)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static ObjectDisposedException ObjectDisposedException(string message, Exception innerException)
 		{
-			return new ObjectDisposedException(message, innnerException);
+			return new ObjectDisposedException(message, innerException);
 		}
 
 		#endregion
 
 		#region InvalidOperationException...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static InvalidOperationException InvalidOperationException(string message)
 		{
 			return new InvalidOperationException(message);
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static InvalidOperationException InvalidOperationException(string message, object arg0)
 		{
 			return new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, message, arg0));
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static InvalidOperationException InvalidOperationException(string message, object arg0, object arg1)
 		{
 			return new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, message, arg0, arg1));
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static InvalidOperationException InvalidOperationException(string message, params object[] args)
 		{
 			return new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, message, args));
@@ -223,25 +223,25 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region FormatException...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static FormatException FormatException(string message)
 		{
 			return new FormatException(message);
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static FormatException FormatException(string message, object arg0)
 		{
 			return new FormatException(String.Format(CultureInfo.InvariantCulture, message, arg0));
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static FormatException FormatException(string message, object arg0, object arg1)
 		{
 			return new FormatException(String.Format(CultureInfo.InvariantCulture, message, arg0, arg1));
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static FormatException FormatException(string message, params object[] args)
 		{
 			return new FormatException(String.Format(CultureInfo.InvariantCulture, message, args));
@@ -251,19 +251,19 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region OperationCanceledException...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static OperationCanceledException OperationCanceledException(string message)
 		{
 			return new OperationCanceledException(message);
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static OperationCanceledException OperationCanceledException(string message, object arg0)
 		{
 			return new OperationCanceledException(String.Format(CultureInfo.InvariantCulture, message, arg0));
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static OperationCanceledException OperationCanceledException(string message, params object[] args)
 		{
 			return new OperationCanceledException(String.Format(CultureInfo.InvariantCulture, message, args));
@@ -273,13 +273,13 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region NotSupportedException...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static NotSupportedException NotSupportedException(string message)
 		{
 			return new NotSupportedException(message);
 		}
 
-		[Pure, NotNull, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, StringFormatMethod("message"), MethodImpl(MethodImplOptions.NoInlining)]
 		public static NotSupportedException NotSupportedException(string message, params object[] args)
 		{
 			return new NotSupportedException(String.Format(CultureInfo.InvariantCulture, message, args));
@@ -287,8 +287,8 @@ namespace Doxense.Diagnostics.Contracts
 
 		#endregion
 
-		[CanBeNull, Pure, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception TryMapToKnownException(Type exceptionType, string message, string paramName)
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception? TryMapToKnownException(Type exceptionType, string message, string paramName)
 		{
 			// d'abord on regarde si c'est un type "simple"
 			if (exceptionType == typeof(ArgumentNullException))
@@ -318,8 +318,8 @@ namespace Doxense.Diagnostics.Contracts
 			return null;
 		}
 
-		[CanBeNull, MethodImpl(MethodImplOptions.NoInlining)]
-		public static Exception TryMapToComplexException(Type exceptionType, string message, string paramName)
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static Exception? TryMapToComplexException(Type exceptionType, string message, string? paramName)
 		{
 			ConstructorInfo constructor;
 
@@ -358,19 +358,19 @@ namespace Doxense.Diagnostics.Contracts
 
 		#region Collection Errors...
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static InvalidOperationException InvalidOperationNoElements()
 		{
 			return new InvalidOperationException("Sequence contains no elements.");
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static InvalidOperationException InvalidOperationNoMatchingElements()
 		{
 			return new InvalidOperationException("Sequence contains no matching element.");
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static IndexOutOfRangeException IndexOutOfRangeException()
 		{
 			return new IndexOutOfRangeException("Index was out of range. Must be non-negative and less than the size of the collection.");
@@ -382,7 +382,7 @@ namespace Doxense.Diagnostics.Contracts
 			throw IndexOutOfRangeException();
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static ArgumentOutOfRangeException ArgumentOutOfRangeIndex(int index)
 		{
 			// ArgumentOutOfRange_NeedNonNegNum
@@ -390,21 +390,21 @@ namespace Doxense.Diagnostics.Contracts
 			return new ArgumentOutOfRangeException("index", index, "Index was out of range. Must be non-negative and less than the size of the collection.");
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static ArgumentOutOfRangeException ArgumentOutOfRangeNeedNonNegNum([InvokerParameterName] string paramName)
 		{
 			// ArgumentOutOfRange_NeedNonNegNum
 			return new ArgumentOutOfRangeException(paramName, "Non-negative number required");
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static ArgumentException ArgumentInvalidOffLen()
 		{
 			// Argument_InvalidOffLen
 			return new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
 		}
 
-		[Pure, NotNull, MethodImpl(MethodImplOptions.NoInlining)]
+		[Pure, MethodImpl(MethodImplOptions.NoInlining)]
 		public static NotSupportedException NotSupportedReadOnlyCollection()
 		{
 			// NotSupported_ReadOnlyCollection

--- a/FoundationDB.Client/Shared/Tuples/Encoding/TuPack.cs
+++ b/FoundationDB.Client/Shared/Tuples/Encoding/TuPack.cs
@@ -367,56 +367,56 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Pack a 1-tuple directly into a slice</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodeKey<T1>([AllowNull] T1 item1)
+		public static Slice EncodeKey<T1>(T1 item1)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), item1);
 		}
 
 		/// <summary>Pack a 2-tuple directly into a slice</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodeKey<T1, T2>([AllowNull] T1 item1, [AllowNull] T2 item2)
+		public static Slice EncodeKey<T1, T2>(T1 item1, T2 item2)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), item1, item2);
 		}
 
 		/// <summary>Pack a 3-tuple directly into a slice</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodeKey<T1, T2, T3>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3)
+		public static Slice EncodeKey<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), item1, item2, item3);
 		}
 
 		/// <summary>Pack a 4-tuple directly into a slice</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodeKey<T1, T2, T3, T4>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4)
+		public static Slice EncodeKey<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), item1, item2, item3, item4);
 		}
 
 		/// <summary>Pack a 5-tuple directly into a slice</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodeKey<T1, T2, T3, T4, T5>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5)
+		public static Slice EncodeKey<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), item1, item2, item3, item4, item5);
 		}
 
 		/// <summary>Pack a 6-tuple directly into a slice</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodeKey<T1, T2, T3, T4, T5, T6>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6)
+		public static Slice EncodeKey<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), item1, item2, item3, item4, item5, item6);
 		}
 
 		/// <summary>Pack a 6-tuple directly into a slice</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodeKey<T1, T2, T3, T4, T5, T6, T7>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6, [AllowNull] T7 item7)
+		public static Slice EncodeKey<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), item1, item2, item3, item4, item5, item6, item7);
 		}
 
 		/// <summary>Pack a 6-tuple directly into a slice</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodeKey<T1, T2, T3, T4, T5, T6, T7, T8>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6, [AllowNull] T7 item7, [AllowNull] T8 item8)
+		public static Slice EncodeKey<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), item1, item2, item3, item4, item5, item6, item7, item8);
 		}
@@ -579,7 +579,7 @@ namespace Doxense.Collections.Tuples
 		/// <summary>Create a range that selects all the tuples of greater length than the specified element, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		/// <example>ToRange(STuple.Create("a", "b")) includes all tuples ("a", "b", ...), but not the tuple ("a", "b") itself.</example>
 		[Pure]
-		public static (Slice Begin, Slice End) ToKeyRange<T1>([AllowNull] T1 item1)
+		public static (Slice Begin, Slice End) ToKeyRange<T1>(T1 item1)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(default(Slice), item1);
@@ -592,7 +592,7 @@ namespace Doxense.Collections.Tuples
 		/// <summary>Create a range that selects all the tuples of greater length than the specified element, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		/// <example>ToRange(STuple.Create("a", "b")) includes all tuples ("a", "b", ...), but not the tuple ("a", "b") itself.</example>
 		[Pure]
-		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1>(Slice prefix, [AllowNull] T1 item1)
+		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1>(Slice prefix, T1 item1)
 		{
 			// tuple => [ prefix.packed."\0", prefix.packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(prefix, item1);
@@ -634,7 +634,7 @@ namespace Doxense.Collections.Tuples
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		/// <example>ToKeyRange("a", "b") includes all tuples ("a", "b", ...), but not the tuple ("a", "b") itself.</example>
 		[Pure]
-		public static (Slice Begin, Slice End) ToKeyRange<T1, T2>([AllowNull] T1 item1, [AllowNull] T2 item2)
+		public static (Slice Begin, Slice End) ToKeyRange<T1, T2>(T1 item1, T2 item2)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(default, item1, item2);
@@ -647,7 +647,7 @@ namespace Doxense.Collections.Tuples
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		/// <example>ToPrefixedKeyRange(..., "a", "b")) includes all tuples ("a", "b", ...), but not the tuple ("a", "b") itself.</example>
 		[Pure]
-		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2>(Slice prefix, [AllowNull] T1 item1, [AllowNull] T2 item2)
+		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2>(Slice prefix, T1 item1, T2 item2)
 		{
 			// tuple => [ prefix.packed."\0", prefix.packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(prefix, item1, item2);
@@ -685,7 +685,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3)
+		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(default, item1, item2, item3);
@@ -697,7 +697,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3>(Slice prefix, [AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3)
+		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3>(Slice prefix, T1 item1, T2 item2, T3 item3)
 		{
 			// tuple => [ prefix.packed."\0", prefix.packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(prefix, item1, item2, item3);
@@ -736,7 +736,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4)
+		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(default, item1, item2, item3, item4);
@@ -748,7 +748,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4>(Slice prefix, [AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4)
+		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4>(Slice prefix, T1 item1, T2 item2, T3 item3, T4 item4)
 		{
 			// tuple => [ prefix.packed."\0", prefix.packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(prefix, item1, item2, item3, item4);
@@ -787,7 +787,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4, T5>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5)
+		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(default, item1, item2, item3, item4, item5);
@@ -799,7 +799,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4, T5>(Slice prefix, [AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5)
+		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4, T5>(Slice prefix, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
 		{
 			// tuple => [ prefix.packed."\0", prefix.packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(prefix, item1, item2, item3, item4, item5);
@@ -837,7 +837,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4, T5, T6>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6)
+		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(default, item1, item2, item3, item4, item5, item6);
@@ -849,7 +849,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4, T5, T6>(Slice prefix, [AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6)
+		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4, T5, T6>(Slice prefix, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
 		{
 			// tuple => [ prefix.packed."\0", prefix.packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(prefix, item1, item2, item3, item4, item5, item6);
@@ -861,7 +861,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4, T5, T6, T7>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6, [AllowNull] T7 item7)
+		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(default, item1, item2, item3, item4, item5, item6, item7);
@@ -873,7 +873,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4, T5, T6, T7>(Slice prefix, [AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6, [AllowNull] T7 item7)
+		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4, T5, T6, T7>(Slice prefix, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
 		{
 			// tuple => [ prefix.packed."\0", prefix.packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(prefix, item1, item2, item3, item4, item5, item6, item7);
@@ -885,7 +885,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4, T5, T6, T7, T8>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6, [AllowNull] T7 item7, [AllowNull] T8 item8)
+		public static (Slice Begin, Slice End) ToKeyRange<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(default, item1, item2, item3, item4, item5, item6, item7, item8);
@@ -897,7 +897,7 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a range that selects all the tuples of greater length than the specified items, and that start with the specified elements: packed(tuple)+'\x00' &lt;= k &lt; packed(tuple)+'\xFF'</summary>
 		[Pure]
-		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4, T5, T6, T7, T8>(Slice prefix, [AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6, [AllowNull] T7 item7, [AllowNull] T8 item8)
+		public static (Slice Begin, Slice End) ToPrefixedKeyRange<T1, T2, T3, T4, T5, T6, T7, T8>(Slice prefix, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
 		{
 			// tuple => [ packed."\0", packed."\xFF" )
 			var packed = TupleEncoder.EncodeKey(prefix, item1, item2, item3, item4, item5, item6, item7, item8);
@@ -1173,56 +1173,56 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Efficiently concatenate a prefix with the packed representation of a 1-tuple</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodePrefixedKey<T1>(Slice prefix, [AllowNull] T1 value)
+		public static Slice EncodePrefixedKey<T1>(Slice prefix, T1 value)
 		{
 			return TupleEncoder.EncodeKey(prefix, value);
 		}
 
 		/// <summary>Efficiently concatenate a prefix with the packed representation of a 2-tuple</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodePrefixedKey<T1, T2>(Slice prefix, [AllowNull] T1 value1, [AllowNull] T2 value2)
+		public static Slice EncodePrefixedKey<T1, T2>(Slice prefix, T1 value1, T2 value2)
 		{
 			return TupleEncoder.EncodeKey(prefix, value1, value2);
 		}
 
 		/// <summary>Efficiently concatenate a prefix with the packed representation of a 3-tuple</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodePrefixedKey<T1, T2, T3>(Slice prefix, [AllowNull] T1 value1, [AllowNull] T2 value2, [AllowNull] T3 value3)
+		public static Slice EncodePrefixedKey<T1, T2, T3>(Slice prefix, T1 value1, T2 value2, T3 value3)
 		{
 			return TupleEncoder.EncodeKey(prefix, value1, value2, value3);
 		}
 
 		/// <summary>Efficiently concatenate a prefix with the packed representation of a 4-tuple</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodePrefixedKey<T1, T2, T3, T4>(Slice prefix, [AllowNull] T1 value1, [AllowNull] T2 value2, [AllowNull] T3 value3, [AllowNull] T4 value4)
+		public static Slice EncodePrefixedKey<T1, T2, T3, T4>(Slice prefix, T1 value1, T2 value2, T3 value3, T4 value4)
 		{
 			return TupleEncoder.EncodeKey(prefix, value1, value2, value3, value4);
 		}
 
 		/// <summary>Efficiently concatenate a prefix with the packed representation of a 5-tuple</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodePrefixedKey<T1, T2, T3, T4, T5>(Slice prefix, [AllowNull] T1 value1, [AllowNull] T2 value2, [AllowNull] T3 value3, [AllowNull] T4 value4, [AllowNull] T5 value5)
+		public static Slice EncodePrefixedKey<T1, T2, T3, T4, T5>(Slice prefix, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
 		{
 			return TupleEncoder.EncodeKey(prefix, value1, value2, value3, value4, value5);
 		}
 
 		/// <summary>Efficiently concatenate a prefix with the packed representation of a 6-tuple</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodePrefixedKey<T1, T2, T3, T4, T5, T6>(Slice prefix, [AllowNull] T1 value1, [AllowNull] T2 value2, [AllowNull] T3 value3, [AllowNull] T4 value4, [AllowNull] T5 value5, [AllowNull] T6 value6)
+		public static Slice EncodePrefixedKey<T1, T2, T3, T4, T5, T6>(Slice prefix, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
 		{
 			return TupleEncoder.EncodeKey(prefix, value1, value2, value3, value4, value5, value6);
 		}
 
 		/// <summary>Efficiently concatenate a prefix with the packed representation of a 7-tuple</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodePrefixedKey<T1, T2, T3, T4, T5, T6, T7>(Slice prefix, T1 value1, T2 value2, [AllowNull] T3 value3, [AllowNull] T4 value4, [AllowNull] T5 value5, [AllowNull] T6 value6, [AllowNull] T7 value7)
+		public static Slice EncodePrefixedKey<T1, T2, T3, T4, T5, T6, T7>(Slice prefix, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
 		{
 			return TupleEncoder.EncodeKey(prefix, value1, value2, value3, value4, value5, value6, value7);
 		}
 
 		/// <summary>Efficiently concatenate a prefix with the packed representation of a 8-tuple</summary>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice EncodePrefixedKey<T1, T2, T3, T4, T5, T6, T7, T8>(Slice prefix, [AllowNull] T1 value1, [AllowNull] T2 value2, [AllowNull] T3 value3, [AllowNull] T4 value4, [AllowNull] T5 value5, [AllowNull] T6 value6, [AllowNull] T7 value7, [AllowNull] T8 value8)
+		public static Slice EncodePrefixedKey<T1, T2, T3, T4, T5, T6, T7, T8>(Slice prefix, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
 		{
 			return TupleEncoder.EncodeKey(prefix, value1, value2, value3, value4, value5, value6, value7, value8);
 		}

--- a/FoundationDB.Client/Shared/Tuples/Encoding/TupleCodec`1.cs
+++ b/FoundationDB.Client/Shared/Tuples/Encoding/TupleCodec`1.cs
@@ -40,22 +40,21 @@ namespace Doxense.Collections.Tuples.Encoding
 
 		private static volatile TupleCodec<T>? s_defaultSerializer;
 
-		public static TupleCodec<T> Default => s_defaultSerializer ??= new TupleCodec<T>(default);
+		public static TupleCodec<T> Default => s_defaultSerializer ??= new TupleCodec<T>(default!);
 
-		[MaybeNull]
 		private readonly T m_missingValue;
 
-		public TupleCodec([AllowNull] T missingValue)
+		public TupleCodec(T missingValue)
 		{
 			m_missingValue = missingValue;
 		}
 
-		public override Slice EncodeOrdered([AllowNull] T value)
+		public override Slice EncodeOrdered(T value)
 		{
 			return TupleEncoder.EncodeKey(default(Slice), value);
 		}
 
-		public override void EncodeOrderedSelfTerm(ref SliceWriter output, [AllowNull] T value)
+		public override void EncodeOrderedSelfTerm(ref SliceWriter output, T value)
 		{
 			//HACKHACK: we lose the current depth!
 			var writer = new TupleWriter(output);
@@ -78,7 +77,7 @@ namespace Doxense.Collections.Tuples.Encoding
 			return res ? value : m_missingValue;
 		}
 
-		public Slice EncodeValue([AllowNull] T value)
+		public Slice EncodeValue(T value)
 		{
 			return EncodeUnordered(value);
 		}

--- a/FoundationDB.Client/Shared/Tuples/Encoding/TupleEncoder.cs
+++ b/FoundationDB.Client/Shared/Tuples/Encoding/TupleEncoder.cs
@@ -998,7 +998,7 @@ namespace Doxense.Collections.Tuples.Encoding
 					: TuPack.DecodeKey<T>(reader.ReadToEnd());
 			}
 
-			public Slice EncodeValue([AllowNull] T key)
+			public Slice EncodeValue(T key)
 			{
 				return TupleEncoder.EncodeKey(default(Slice), key);
 			}
@@ -1006,7 +1006,7 @@ namespace Doxense.Collections.Tuples.Encoding
 			[return:MaybeNull]
 			public T DecodeValue(Slice encoded)
 			{
-				if (encoded.IsNullOrEmpty) return default; //BUGBUG
+				if (encoded.IsNullOrEmpty) return default!; //BUGBUG
 				return TuPack.DecodeKey<T>(encoded);
 			}
 

--- a/FoundationDB.Client/Shared/Tuples/Encoding/TuplePackers.cs
+++ b/FoundationDB.Client/Shared/Tuples/Encoding/TuplePackers.cs
@@ -48,7 +48,7 @@ namespace Doxense.Collections.Tuples.Encoding
 
 		#region Serializers...
 
-		public delegate void Encoder<in T>(ref TupleWriter writer, [AllowNull] T value);
+		public delegate void Encoder<in T>(ref TupleWriter writer, T value);
 
 		/// <summary>Returns a lambda that will be able to serialize values of type <typeparamref name="T"/></summary>
 		/// <typeparam name="T">Type of values to serialize</typeparam>
@@ -188,7 +188,7 @@ namespace Doxense.Collections.Tuples.Encoding
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal static void SerializeTo<T>(ref TupleWriter writer, [AllowNull] T value)
+		internal static void SerializeTo<T>(ref TupleWriter writer, T value)
 		{
 			//<JIT_HACK>
 			// - In Release builds, this will be cleaned up and inlined by the JIT as a direct invocation of the correct WriteXYZ method

--- a/FoundationDB.Client/Shared/Tuples/IVarTuple.cs
+++ b/FoundationDB.Client/Shared/Tuples/IVarTuple.cs
@@ -106,7 +106,7 @@ namespace Doxense.Collections.Tuples
 		/// <example>("Hello,").Append("World") => ("Hello", "World",)</example>
 		/// <remarks>If <typeparamref name="TItem"/> is an <see cref="IVarTuple"/>, then it will be appended as a single element. If you need to append the *items* of a tuple, you must call <see cref="IVarTuple.Concat"/></remarks>
 		[Pure]
-		IVarTuple Append<TItem>([AllowNull] TItem value);
+		IVarTuple Append<TItem>(TItem value);
 
 		/// <summary>Create a new Tuple by appending the items of another tuple at the end of this tuple</summary>
 		/// <param name="tuple">Tuple whose items must be appended at the end of the current tuple</param>

--- a/FoundationDB.Client/Shared/Tuples/JoinedTuple.cs
+++ b/FoundationDB.Client/Shared/Tuples/JoinedTuple.cs
@@ -153,7 +153,7 @@ namespace Doxense.Collections.Tuples
 			return new LinkedTuple<T>(this, value);
 		}
 
-		public LinkedTuple<T> Append<T>([AllowNull] T value)
+		public LinkedTuple<T> Append<T>(T value)
 		{
 			return new LinkedTuple<T>(this, value);
 		}

--- a/FoundationDB.Client/Shared/Tuples/LinkedTuple.cs
+++ b/FoundationDB.Client/Shared/Tuples/LinkedTuple.cs
@@ -61,7 +61,7 @@ namespace Doxense.Collections.Tuples
 		public readonly int Depth;
 
 		/// <summary>Append a new value at the end of an existing tuple</summary>
-		public LinkedTuple(IVarTuple head, [AllowNull] T tail)
+		public LinkedTuple(IVarTuple head, T tail)
 		{
 			Contract.NotNull(head, nameof(head));
 

--- a/FoundationDB.Client/Shared/Tuples/ListTuple.cs
+++ b/FoundationDB.Client/Shared/Tuples/ListTuple.cs
@@ -34,7 +34,6 @@ namespace Doxense.Collections.Tuples
 	using System.Collections;
 	using System.Collections.Generic;
 	using System.Linq;
-	using System.Runtime.InteropServices;
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Runtime.Converters;
 	using JetBrains.Annotations;
@@ -53,7 +52,7 @@ namespace Doxense.Collections.Tuples
 		private int? m_hashCode;
 
 		/// <summary>Create a new tuple from a sequence of items (copied)</summary>
-		public ListTuple([NotNull, InstantHandle] IEnumerable<T> items)
+		public ListTuple([InstantHandle] IEnumerable<T> items)
 			: this(items.ToArray().AsMemory())
 		{ }
 

--- a/FoundationDB.Client/Shared/Tuples/STuple.cs
+++ b/FoundationDB.Client/Shared/Tuples/STuple.cs
@@ -159,42 +159,42 @@ namespace Doxense.Collections.Tuples
 
 		/// <summary>Create a new 1-tuple, holding only one item</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining), DebuggerStepThrough]
-		public static STuple<T1> Create<T1>([AllowNull] T1 item1)
+		public static STuple<T1> Create<T1>(T1 item1)
 		{
 			return new STuple<T1>(item1);
 		}
 
 		/// <summary>Create a new 2-tuple, holding two items</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining), DebuggerStepThrough]
-		public static STuple<T1, T2> Create<T1, T2>([AllowNull] T1 item1, [AllowNull] T2 item2)
+		public static STuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2)
 		{
 			return new STuple<T1, T2>(item1, item2);
 		}
 
 		/// <summary>Create a new 3-tuple, holding three items</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining), DebuggerStepThrough]
-		public static STuple<T1, T2, T3> Create<T1, T2, T3>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3)
+		public static STuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
 		{
 			return new STuple<T1, T2, T3>(item1, item2, item3);
 		}
 
 		/// <summary>Create a new 4-tuple, holding four items</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining), DebuggerStepThrough]
-		public static STuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4)
+		public static STuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
 		{
 			return new STuple<T1, T2, T3, T4>(item1, item2, item3, item4);
 		}
 
 		/// <summary>Create a new 5-tuple, holding five items</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining), DebuggerStepThrough]
-		public static STuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5)
+		public static STuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
 		{
 			return new STuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
 		}
 
 		/// <summary>Create a new 6-tuple, holding six items</summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining), DebuggerStepThrough]
-		public static STuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6)
+		public static STuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
 		{
 			return new STuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
 		}
@@ -540,7 +540,7 @@ namespace Doxense.Collections.Tuples
 			/// Stringify&lt;Slice&gt;((...) => hexa decimal string ("01 23 45 67 89 AB CD EF")
 			/// </example>
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-			public static string Stringify<T>([AllowNull] T item)
+			public static string Stringify<T>(T item)
 			{
 				if (default(T) == null)
 				{

--- a/FoundationDB.Client/Shared/Tuples/STuple`1.cs
+++ b/FoundationDB.Client/Shared/Tuples/STuple`1.cs
@@ -52,11 +52,10 @@ namespace Doxense.Collections.Tuples
 		// Please note that if you return an STuple<T> as an ITuple, it will be boxed by the CLR and all memory gains will be lost
 
 		/// <summary>First and only item in the tuple</summary>
-		[AllowNull]
 		public readonly T1 Item1;
 
 		[DebuggerStepThrough]
-		public STuple([AllowNull] T1 item1)
+		public STuple(T1 item1)
 		{
 			this.Item1 = item1;
 		}
@@ -88,7 +87,7 @@ namespace Doxense.Collections.Tuples
 		{
 			get
 			{
-				(int offset, int count) = range.GetOffsetAndLength(1);
+				(_, int count) = range.GetOffsetAndLength(1);
 				return count == 0 ? STuple.Empty : this;
 			}
 		}
@@ -106,7 +105,7 @@ namespace Doxense.Collections.Tuples
 			return TypeConverters.Convert<T1, TItem>(this.Item1);
 		}
 
-		IVarTuple IVarTuple.Append<T2>([AllowNull] T2 value)
+		IVarTuple IVarTuple.Append<T2>(T2 value)
 		{
 			return new STuple<T1, T2>(this.Item1, value);
 		}
@@ -116,7 +115,7 @@ namespace Doxense.Collections.Tuples
 		/// <returns>New tuple with one extra item</returns>
 		/// <remarks>If <paramref name="value"/> is a tuple, and you want to append the *items* of this tuple, and not the tuple itself, please call <see cref="Concat"/>!</remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public STuple<T1, T2> Append<T2>([AllowNull] T2 value)
+		public STuple<T1, T2> Append<T2>(T2 value)
 		{
 			return new STuple<T1, T2>(this.Item1, value);
 		}
@@ -127,7 +126,7 @@ namespace Doxense.Collections.Tuples
 		/// <returns>New tuple with one extra item</returns>
 		/// <remarks>If any of <paramref name="value1"/> or <paramref name="value2"/> is a tuple, and you want to append the *items* of this tuple, and not the tuple itself, please call <see cref="Concat"/>!</remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public STuple<T1, T2, T3> Append<T2, T3>([AllowNull] T2 value1, [AllowNull] T3 value2)
+		public STuple<T1, T2, T3> Append<T2, T3>(T2 value1, T3 value2)
 		{
 			return new STuple<T1, T2, T3>(this.Item1, value1, value2);
 		}
@@ -201,7 +200,7 @@ namespace Doxense.Collections.Tuples
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{
-			return this.GetEnumerator();
+			return GetEnumerator();
 		}
 
 		public override string ToString()

--- a/FoundationDB.Client/Shared/Tuples/STuple`2.cs
+++ b/FoundationDB.Client/Shared/Tuples/STuple`2.cs
@@ -53,15 +53,13 @@ namespace Doxense.Collections.Tuples
 		// Please note that if you return an STuple<T> as an ITuple, it will be boxed by the CLR and all memory gains will be lost
 
 		/// <summary>First element of the pair</summary>
-		[MaybeNull]
 		public readonly T1 Item1;
 
-		/// <summary>Seconde element of the pair</summary>
-		[MaybeNull]
+		/// <summary>Second element of the pair</summary>
 		public readonly T2 Item2;
 
 		[DebuggerStepThrough]
-		public STuple([AllowNull] T1 item1, [AllowNull] T2 item2)
+		public STuple(T1 item1, T2 item2)
 		{
 			this.Item1 = item1;
 			this.Item2 = item2;
@@ -148,7 +146,7 @@ namespace Doxense.Collections.Tuples
 			get => new STuple<T2>(this.Item2);
 		}
 
-		IVarTuple IVarTuple.Append<T3>([AllowNull] T3 value)
+		IVarTuple IVarTuple.Append<T3>(T3 value)
 		{
 			return new STuple<T1, T2, T3>(this.Item1, this.Item2, value);
 		}
@@ -158,7 +156,7 @@ namespace Doxense.Collections.Tuples
 		/// <returns>New tuple with one extra item</returns>
 		/// <remarks>If <paramref name="value"/> is a tuple, and you want to append the *items* of this tuple, and not the tuple itself, please call <see cref="Concat"/>!</remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public STuple<T1, T2, T3> Append<T3>([AllowNull] T3 value)
+		public STuple<T1, T2, T3> Append<T3>(T3 value)
 		{
 			return new STuple<T1, T2, T3>(this.Item1, this.Item2, value);
 			// Note: By create a STuple<T1, T2, T3> we risk an explosion of the number of combinations of Ts which could potentially cause problems at runtime (too many variants of the same generic types).
@@ -172,7 +170,7 @@ namespace Doxense.Collections.Tuples
 		/// <returns>New tuple with two extra item</returns>
 		/// <remarks>If any of <paramref name="value1"/> or <paramref name="value2"/> is a tuple, and you want to append the *items* of this tuple, and not the tuple itself, please call <see cref="Concat"/>!</remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public STuple<T1, T2, T3, T4> Append<T3, T4>([AllowNull] T3 value1, [AllowNull] T4 value2)
+		public STuple<T1, T2, T3, T4> Append<T3, T4>(T3 value1, T4 value2)
 		{
 			return new STuple<T1, T2, T3, T4>(this.Item1, this.Item2, value1, value2);
 			// Note: By create a STuple<T1, T2, T3> we risk an explosion of the number of combinations of Ts which could potentially cause problems at runtime (too many variants of the same generic types).
@@ -247,7 +245,7 @@ namespace Doxense.Collections.Tuples
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{
-			return this.GetEnumerator();
+			return GetEnumerator();
 		}
 
 		public override string ToString()

--- a/FoundationDB.Client/Shared/Tuples/STuple`3.cs
+++ b/FoundationDB.Client/Shared/Tuples/STuple`3.cs
@@ -54,19 +54,16 @@ namespace Doxense.Collections.Tuples
 		// Please note that if you return an STuple<T> as an ITuple, it will be boxed by the CLR and all memory gains will be lost
 
 		/// <summary>First element of the triplet</summary>
-		[MaybeNull]
 		public readonly T1 Item1;
 
 		/// <summary>Second element of the triplet</summary>
-		[MaybeNull]
 		public readonly T2 Item2;
 
 		/// <summary>Third and last element of the triplet</summary>
-		[MaybeNull]
 		public readonly T3 Item3;
 
 		[DebuggerStepThrough]
-		public STuple([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3)
+		public STuple(T1 item1, T2 item2, T3 item3)
 		{
 			this.Item1 = item1;
 			this.Item2 = item2;
@@ -252,7 +249,7 @@ namespace Doxense.Collections.Tuples
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{
-			return this.GetEnumerator();
+			return GetEnumerator();
 		}
 
 		public override string ToString()

--- a/FoundationDB.Client/Shared/Tuples/STuple`4.cs
+++ b/FoundationDB.Client/Shared/Tuples/STuple`4.cs
@@ -55,24 +55,20 @@ namespace Doxense.Collections.Tuples
 		// Please note that if you return an STuple<T> as an ITuple, it will be boxed by the CLR and all memory gains will be lost
 
 		/// <summary>First element of the quartet</summary>
-		[MaybeNull]
 		public readonly T1 Item1;
 
 		/// <summary>Second element of the quartet</summary>
-		[MaybeNull]
 		public readonly T2 Item2;
 
 		/// <summary>Third element of the quartet</summary>
-		[MaybeNull]
 		public readonly T3 Item3;
 
 		/// <summary>Fourth and last element of the quartet</summary>
-		[MaybeNull]
 		public readonly T4 Item4;
 
 		/// <summary>Create a tuple containing for items</summary>
 		[DebuggerStepThrough]
-		public STuple([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4)
+		public STuple(T1 item1, T2 item2, T3 item3, T4 item4)
 		{
 			this.Item1 = item1;
 			this.Item2 = item2;
@@ -271,7 +267,7 @@ namespace Doxense.Collections.Tuples
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{
-			return this.GetEnumerator();
+			return GetEnumerator();
 		}
 
 		public override string ToString()

--- a/FoundationDB.Client/Shared/Tuples/STuple`5.cs
+++ b/FoundationDB.Client/Shared/Tuples/STuple`5.cs
@@ -56,28 +56,23 @@ namespace Doxense.Collections.Tuples
 		// Please note that if you return an STuple<T> as an ITuple, it will be boxed by the CLR and all memory gains will be lost
 
 		/// <summary>First element of the tuple</summary>
-		[MaybeNull]
 		public readonly T1 Item1;
 
 		/// <summary>Second element of the tuple</summary>
-		[MaybeNull]
 		public readonly T2 Item2;
 
 		/// <summary>Third element of the tuple</summary>
-		[MaybeNull]
 		public readonly T3 Item3;
 
 		/// <summary>Fourth element of the tuple</summary>
-		[MaybeNull]
 		public readonly T4 Item4;
 
 		/// <summary>Fifth and last element of the tuple</summary>
-		[MaybeNull]
 		public readonly T5 Item5;
 
 		/// <summary>Create a tuple containing for items</summary>
 		[DebuggerStepThrough]
-		public STuple([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5)
+		public STuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
 		{
 			this.Item1 = item1;
 			this.Item2 = item2;
@@ -275,7 +270,7 @@ namespace Doxense.Collections.Tuples
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{
-			return this.GetEnumerator();
+			return GetEnumerator();
 		}
 
 		public override string ToString()

--- a/FoundationDB.Client/Shared/Tuples/STuple`6.cs
+++ b/FoundationDB.Client/Shared/Tuples/STuple`6.cs
@@ -57,32 +57,26 @@ namespace Doxense.Collections.Tuples
 		// Please note that if you return an STuple<T> as an ITuple, it will be boxed by the CLR and all memory gains will be lost
 
 		/// <summary>First element of the tuple</summary>
-		[MaybeNull]
 		public readonly T1 Item1;
 
 		/// <summary>Second element of the tuple</summary>
-		[MaybeNull]
 		public readonly T2 Item2;
 
 		/// <summary>Third element of the tuple</summary>
-		[MaybeNull]
 		public readonly T3 Item3;
 
 		/// <summary>Fourth element of the tuple</summary>
-		[MaybeNull]
 		public readonly T4 Item4;
 
 		/// <summary>Fifth of the tuple</summary>
-		[MaybeNull]
 		public readonly T5 Item5;
 
 		/// <summary>Sixth and last element of the tuple</summary>
-		[MaybeNull]
 		public readonly T6 Item6;
 
 		/// <summary>Create a tuple containing for items</summary>
 		[DebuggerStepThrough]
-		public STuple([AllowNull] T1 item1, [AllowNull] T2 item2, [AllowNull] T3 item3, [AllowNull] T4 item4, [AllowNull] T5 item5, [AllowNull] T6 item6)
+		public STuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
 		{
 			this.Item1 = item1;
 			this.Item2 = item2;
@@ -221,7 +215,7 @@ namespace Doxense.Collections.Tuples
 		/// <returns>New tuple with one extra item</returns>
 		/// <remarks>If <paramref name="value"/> is a tuple, and you want to append the *items*  of this tuple, and not the tuple itself, please call <see cref="Concat"/>!</remarks>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public IVarTuple Append<T7>([AllowNull] T7 value)
+		public IVarTuple Append<T7>(T7 value)
 		{
 			// the caller probably cares about the return type, since it is using a struct, but whatever tuple type we use will end up boxing this tuple on the heap, and we will loose type information.
 			// but, by returning a LinkedTuple<T6>, the tuple will still remember the exact type, and efficiently serializer/convert the values (without having to guess the type)
@@ -299,7 +293,7 @@ namespace Doxense.Collections.Tuples
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{
-			return this.GetEnumerator();
+			return GetEnumerator();
 		}
 
 		public override string ToString()

--- a/FoundationDB.Client/Shared/Tuples/TupleComparisons.cs
+++ b/FoundationDB.Client/Shared/Tuples/TupleComparisons.cs
@@ -59,7 +59,7 @@ namespace Doxense.Collections.Tuples
 			public bool Equals(IVarTuple? x, IVarTuple? y)
 			{
 				if (object.ReferenceEquals(x, y)) return true;
-				if (object.ReferenceEquals(x, null) || object.ReferenceEquals(y, null)) return false;
+				if (x ==  null || y == null) return false;
 
 				return x.Equals(y, m_comparer);
 			}
@@ -74,10 +74,8 @@ namespace Doxense.Collections.Tuples
 				if (object.ReferenceEquals(x, y)) return true;
 				if (x == null || y == null) return false;
 
-				if (x is IVarTuple t) return t.Equals(y, m_comparer);
-
-				t = y as IVarTuple;
-				if (t != null) return t.Equals(x, m_comparer);
+				if (x is IVarTuple tx) return tx.Equals(y, m_comparer);
+				if (y is IVarTuple ty) return ty.Equals(x, m_comparer);
 
 				return false;
 			}
@@ -86,8 +84,7 @@ namespace Doxense.Collections.Tuples
 			{
 				if (obj == null) return 0;
 
-				var t = obj as IVarTuple;
-				if (!object.ReferenceEquals(t, null)) return t.GetHashCode(m_comparer);
+				if (obj is IVarTuple t) return t.GetHashCode(m_comparer);
 
 				// returns a hash base on the pointers
 				return RuntimeHelpers.GetHashCode(obj);

--- a/FoundationDB.Client/Shared/Tuples/TupleExtensions.cs
+++ b/FoundationDB.Client/Shared/Tuples/TupleExtensions.cs
@@ -649,9 +649,9 @@ namespace Doxense.Collections.Tuples
 		#region ValueTuple
 
 		[Pure]
-		public static STuple ToSTuple(this ValueTuple tuple)
+		public static STuple ToSTuple(this ValueTuple _)
 		{
-			return default(STuple);
+			return default;
 		}
 
 		[Pure]

--- a/FoundationDB.Client/Shared/Tuples/TupleHelpers.cs
+++ b/FoundationDB.Client/Shared/Tuples/TupleHelpers.cs
@@ -232,13 +232,13 @@ namespace Doxense.Collections.Tuples
 
 		public static bool Equals(IVarTuple? left, object? other, IEqualityComparer comparer)
 		{
-			return object.ReferenceEquals(left, null) ? other == null : Equals(left, other as IVarTuple, comparer);
+			return left == null ? other == null : Equals(left, other as IVarTuple, comparer);
 		}
 
 		public static bool Equals(IVarTuple? x, IVarTuple? y, IEqualityComparer comparer)
 		{
 			if (object.ReferenceEquals(x, y)) return true;
-			if (object.ReferenceEquals(x, null) || object.ReferenceEquals(y, null)) return false;
+			if (x == null || y == null) return false;
 
 			return x.Count == y.Count && DeepEquals(x, y, comparer);
 		}
@@ -264,7 +264,7 @@ namespace Doxense.Collections.Tuples
 		{
 			Contract.Requires(comparer != null);
 
-			if (object.ReferenceEquals(tuple, null))
+			if (tuple == null)
 			{
 				return comparer.GetHashCode(null);
 			}
@@ -282,8 +282,8 @@ namespace Doxense.Collections.Tuples
 			Contract.Requires(comparer != null);
 
 			if (object.ReferenceEquals(x, y)) return 0;
-			if (object.ReferenceEquals(x, null)) return -1;
-			if (object.ReferenceEquals(y, null)) return 1;
+			if (x ==  null) return -1;
+			if (y == null) return +1;
 
 			using (var xs = x.GetEnumerator())
 			using (var ys = y.GetEnumerator())

--- a/FoundationDB.Client/Shared/TypeSystem/Encoders/BinaryEncoding.cs
+++ b/FoundationDB.Client/Shared/TypeSystem/Encoders/BinaryEncoding.cs
@@ -46,47 +46,36 @@ namespace Doxense.Serialization.Encoders
 		IValueEncoder<VersionStamp>
 	{
 
-		[NotNull]
 		public static readonly BinaryEncoding Instance = new BinaryEncoding();
 
 		/// <summary>Identity encoder</summary>
-		[NotNull]
 		public static IValueEncoder<Slice> SliceEncoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes Unicode string as UTF-8 bytes</summary>
-		[NotNull]
 		public static IValueEncoder<string> StringEncoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes 32-bits signed integers as 4 bytes (high-endian)</summary>
-		[NotNull]
 		public static IValueEncoder<int> Int32Encoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes 32-bits unsigned integers as 4 bytes (high-endian)</summary>
-		[NotNull]
 		public static IValueEncoder<uint> UInt32Encoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes 64-bits signed integers as 4 bytes (high-endian)</summary>
-		[NotNull]
 		public static IValueEncoder<long> Int64Encoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes 64-bits unsigned integers as 4 bytes (high-endian)</summary>
-		[NotNull]
 		public static IValueEncoder<ulong> UInt64Encoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes 128-bits GUIDs as 16 bytes</summary>
-		[NotNull]
 		public static IValueEncoder<Guid> GuidEncoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes 128-bits UUIDs as 16 bytes</summary>
-		[NotNull]
 		public static IValueEncoder<Uuid128> Uuid128Encoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes 64-bits UUIDs as 16 bytes</summary>
-		[NotNull]
 		public static IValueEncoder<Uuid64> Uuid64Encoder => BinaryEncoding.Instance;
 
 		/// <summary>Encodes 80-bit or 85-bits VersionStamp as 16 bytes</summary>
-		[NotNull]
 		public static IValueEncoder<VersionStamp> VersionStampEncoder => BinaryEncoding.Instance;
 
 		public IValueEncoder<TValue, TStorage> GetValueEncoder<TValue, TStorage>()

--- a/FoundationDB.Client/Shared/TypeSystem/Encoders/IKeyEncoder.cs
+++ b/FoundationDB.Client/Shared/TypeSystem/Encoders/IKeyEncoder.cs
@@ -32,13 +32,11 @@ namespace Doxense.Serialization.Encoders
 {
 	using System;
 	using Doxense.Memory;
-	using JetBrains.Annotations;
 
 	/// <summary>Base interface for all key encoders</summary>
 	public interface IKeyEncoder
 	{
 		/// <summary>Parent encoding</summary>
-		[NotNull]
 		IKeyEncoding Encoding { get; }
 	}
 

--- a/FoundationDB.Client/Shared/TypeSystem/Encoders/IValueEncoder.cs
+++ b/FoundationDB.Client/Shared/TypeSystem/Encoders/IValueEncoder.cs
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Doxense.Serialization.Encoders
 {
 	using System;
-	using JetBrains.Annotations;
+	using System.Diagnostics.CodeAnalysis;
 
 	/// <summary>Class that know how to encode and decode values of a fixed type into a lower format</summary>
 	/// <typeparam name="TValue">Type of the values</typeparam>
@@ -40,11 +40,11 @@ namespace Doxense.Serialization.Encoders
 	{
 
 		/// <summary>Encode a single value into a compact binary representation</summary>
-		TStorage EncodeValue(TValue value);
+		TStorage EncodeValue([AllowNull] TValue value);
 
 		/// <summary>Decode a single value from a compact binary representation</summary>
 		/// <param name="encoded">Packed value</param>
-		[CanBeNull]
+		[return:MaybeNull]
 		TValue DecodeValue(TStorage encoded);
 
 	}

--- a/FoundationDB.Client/Shared/TypeSystem/Encoders/KeyEncoderExtensions.cs
+++ b/FoundationDB.Client/Shared/TypeSystem/Encoders/KeyEncoderExtensions.cs
@@ -43,7 +43,7 @@ namespace Doxense.Serialization.Encoders
 
 		#region Dynamic...
 
-		public static Slice Pack<TTuple>([NotNull] this IDynamicKeyEncoder encoder, TTuple tuple)
+		public static Slice Pack<TTuple>(this IDynamicKeyEncoder encoder, TTuple tuple)
 			where TTuple : IVarTuple
 		{
 			var writer = new SliceWriter(checked(tuple.Count * 8));
@@ -51,7 +51,7 @@ namespace Doxense.Serialization.Encoders
 			return writer.ToSlice();
 		}
 
-		public static Slice Pack<TTuple>([NotNull] this IDynamicKeyEncoder encoder, Slice prefix, TTuple tuple)
+		public static Slice Pack<TTuple>(this IDynamicKeyEncoder encoder, Slice prefix, TTuple tuple)
 			where TTuple : IVarTuple
 		{
 			var writer = new SliceWriter(checked(prefix.Count + tuple.Count * 8));
@@ -64,14 +64,14 @@ namespace Doxense.Serialization.Encoders
 
 		#region <T1>
 
-		public static Slice EncodeKey<T1>([NotNull] this IKeyEncoder<T1> encoder, T1 value)
+		public static Slice EncodeKey<T1>(this IKeyEncoder<T1> encoder, T1 value)
 		{
 			var writer = default(SliceWriter);
 			encoder.WriteKeyTo(ref writer, value);
 			return writer.ToSlice();
 		}
 
-		public static Slice EncodeKey<T1>([NotNull] this IKeyEncoder<T1> encoder, Slice prefix, T1 value)
+		public static Slice EncodeKey<T1>(this IKeyEncoder<T1> encoder, Slice prefix, T1 value)
 		{
 			var writer = new SliceWriter(prefix.Count + 16); // ~16 bytes si T1 = Guid
 			writer.WriteBytes(prefix);
@@ -79,7 +79,7 @@ namespace Doxense.Serialization.Encoders
 			return writer.ToSlice();
 		}
 
-		public static T1 DecodeKey<T1>([NotNull] this IKeyEncoder<T1> decoder, Slice encoded)
+		public static T1 DecodeKey<T1>(this IKeyEncoder<T1> decoder, Slice encoded)
 		{
 			var reader = new SliceReader(encoded);
 			decoder.ReadKeyFrom(ref reader, out T1 item);
@@ -302,8 +302,7 @@ namespace Doxense.Serialization.Encoders
 		#region Batched...
 
 		/// <summary>Convert an array of <typeparamref name="T"/>s into an array of slices, using the specified serializer</summary>
-		[NotNull]
-		public static Slice[] EncodeKeys<T>([NotNull] this IKeyEncoder<T> encoder, [NotNull] params T[] values)
+		public static Slice[] EncodeKeys<T>(this IKeyEncoder<T> encoder, params T[] values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -317,8 +316,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Convert an array of <typeparamref name="T"/>s into an array of prefixed slices, using the specified serializer</summary>
-		[NotNull]
-		public static Slice[] EncodeKeys<T>([NotNull] this IKeyEncoder<T> encoder, Slice prefix, [NotNull] params T[] values)
+		public static Slice[] EncodeKeys<T>(this IKeyEncoder<T> encoder, Slice prefix, params T[] values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -336,8 +334,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Convert an array of <typeparamref name="TElement"/>s into an array of slices, using a serializer (or the default serializer if none is provided)</summary>
-		[NotNull]
-		public static Slice[] EncodeKeys<TKey, TElement>([NotNull] this IKeyEncoder<TKey> encoder, [NotNull] IEnumerable<TElement> elements, Func<TElement, TKey> selector)
+		public static Slice[] EncodeKeys<TKey, TElement>(this IKeyEncoder<TKey> encoder, IEnumerable<TElement> elements, Func<TElement, TKey> selector)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(elements, nameof(elements));
@@ -365,8 +362,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Convert an array of <typeparamref name="TElement"/>s into an array of slices, using a serializer (or the default serializer if none is provided)</summary>
-		[NotNull]
-		public static Slice[] EncodeKeys<TKey, TElement>([NotNull] this IKeyEncoder<TKey> encoder, [NotNull] TElement[] elements, Func<TElement, TKey> selector)
+		public static Slice[] EncodeKeys<TKey, TElement>(this IKeyEncoder<TKey> encoder, TElement[] elements, Func<TElement, TKey> selector)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(elements, nameof(elements));
@@ -381,8 +377,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Transform a sequence of <typeparamref name="T"/>s into a sequence of slices, using a serializer (or the default serializer if none is provided)</summary>
-		[NotNull]
-		public static IEnumerable<Slice> EncodeKeys<T>([NotNull] this IKeyEncoder<T> encoder, [NotNull] IEnumerable<T> values)
+		public static IEnumerable<Slice> EncodeKeys<T>(this IKeyEncoder<T> encoder, IEnumerable<T> values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -412,8 +407,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Convert a sequence of <typeparamref name="T"/>s into an array of prefixed slices, using the specified serializer</summary>
-		[NotNull]
-		public static IEnumerable<Slice> EncodeKeys<T>([NotNull] this IKeyEncoder<T> encoder, Slice prefix, IEnumerable<T> values)
+		public static IEnumerable<Slice> EncodeKeys<T>(this IKeyEncoder<T> encoder, Slice prefix, IEnumerable<T> values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -449,8 +443,7 @@ namespace Doxense.Serialization.Encoders
 
 
 		/// <summary>Convert an array of slices back into an array of <typeparamref name="T"/>s, using a serializer (or the default serializer if none is provided)</summary>
-		[NotNull]
-		public static T[] DecodeKeys<T>([NotNull] this IKeyEncoder<T> encoder, [NotNull] params Slice[] slices)
+		public static T[] DecodeKeys<T>(this IKeyEncoder<T> encoder, params Slice[] slices)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(slices, nameof(slices));
@@ -464,8 +457,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Convert the keys of an array of key value pairs of slices back into an array of <typeparamref name="T"/>s, using a serializer (or the default serializer if none is provided)</summary>
-		[NotNull]
-		public static T[] DecodeKeys<T>([NotNull] this IKeyEncoder<T> encoder, [NotNull] KeyValuePair<Slice, Slice>[] items)
+		public static T[] DecodeKeys<T>(this IKeyEncoder<T> encoder, KeyValuePair<Slice, Slice>[] items)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(items, nameof(items));
@@ -479,8 +471,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Transform a sequence of slices back into a sequence of <typeparamref name="T"/>s, using a serializer (or the default serializer if none is provided)</summary>
-		[NotNull]
-		public static IEnumerable<T> DecodeKeys<T>([NotNull] this IKeyEncoder<T> encoder, [NotNull] IEnumerable<Slice> slices)
+		public static IEnumerable<T> DecodeKeys<T>(this IKeyEncoder<T> encoder, IEnumerable<Slice> slices)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(slices, nameof(slices));

--- a/FoundationDB.Client/Shared/TypeSystem/Encoders/ValueEncoderExtensions.cs
+++ b/FoundationDB.Client/Shared/TypeSystem/Encoders/ValueEncoderExtensions.cs
@@ -41,8 +41,7 @@ namespace Doxense.Serialization.Encoders
 		#region Encoding...
 
 		/// <summary>Encode a array of <typeparamref name="TValue"/> into an array of <typeparamref name="TStorage"/></summary>
-		[NotNull]
-		public static TStorage[] EncodeValues<TValue, TStorage>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] params TValue[] values)
+		public static TStorage[] EncodeValues<TValue, TStorage>(this IValueEncoder<TValue, TStorage> encoder, params TValue[] values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -57,8 +56,8 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Encode the values of a sequence of Key/Value pairs into a list of <typeparamref name="TStorage"/>, discarding the keys in the process</summary>
-		[NotNull, LinqTunnel]
-		public static List<TStorage> EncodeValues<TValue, TStorage>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull, InstantHandle] IEnumerable<TValue> values)
+		[LinqTunnel]
+		public static List<TStorage> EncodeValues<TValue, TStorage>(this IValueEncoder<TValue, TStorage> encoder, [InstantHandle] IEnumerable<TValue> values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -77,8 +76,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Encode a sequence of <paramref name="items"/> into a list of <typeparamref name="TStorage"/> by extracting one field using the specified <paramref name="selector"/></summary>
-		[NotNull]
-		public static List<TStorage> EncodeValues<TValue, TStorage, TElement>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull, InstantHandle] IEnumerable<TElement> items, [NotNull, InstantHandle] Func<TElement, TValue> selector)
+		public static List<TStorage> EncodeValues<TValue, TStorage, TElement>(this IValueEncoder<TValue, TStorage> encoder, [InstantHandle] IEnumerable<TElement> items, [InstantHandle] Func<TElement, TValue> selector)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(items, nameof(items));
@@ -98,8 +96,8 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Transform a sequence of <typeparamref name="TValue"/> into a sequence of <typeparamref name="TStorage"/></summary>
-		[NotNull, LinqTunnel]
-		public static IEnumerable<TStorage> SelectValues<TValue, TStorage>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] IEnumerable<TValue> values)
+		[LinqTunnel]
+		public static IEnumerable<TStorage> SelectValues<TValue, TStorage>(this IValueEncoder<TValue, TStorage> encoder, IEnumerable<TValue> values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -108,8 +106,8 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Transform the values a sequence of Key/Value pairs into a sequence of <typeparamref name="TStorage"/>, discarding the keys in the process</summary>
-		[NotNull, LinqTunnel]
-		public static IEnumerable<TStorage> SelectValues<TValue, TStorage, TAny>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] IEnumerable<KeyValuePair<TAny, TValue>> items)
+		[LinqTunnel]
+		public static IEnumerable<TStorage> SelectValues<TValue, TStorage, TAny>(this IValueEncoder<TValue, TStorage> encoder, IEnumerable<KeyValuePair<TAny, TValue>> items)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(items, nameof(items));
@@ -118,8 +116,8 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Transform a sequence of <paramref name="items"/> into a sequence of <typeparamref name="TStorage"/> by extracting one field using the specified <paramref name="selector"/></summary>
-		[NotNull, LinqTunnel]
-		public static IEnumerable<TStorage> SelectValues<TValue, TStorage, TElement>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] IEnumerable<TElement> items, [NotNull] Func<TElement, TValue> selector)
+		[LinqTunnel]
+		public static IEnumerable<TStorage> SelectValues<TValue, TStorage, TElement>(this IValueEncoder<TValue, TStorage> encoder, IEnumerable<TElement> items, Func<TElement, TValue> selector)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(items, nameof(items));
@@ -132,9 +130,8 @@ namespace Doxense.Serialization.Encoders
 
 		#region Decoding...
 
-		/// <summary>Decode an array of <typeparamref name="TStorage"/> into an arror of <typeparamref name="TValue"/></summary>
-		[NotNull]
-		public static TValue[] DecodeValues<TValue, TStorage>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] params TStorage[] values)
+		/// <summary>Decode an array of <typeparamref name="TStorage"/> into an array of <typeparamref name="TValue"/></summary>
+		public static TValue[] DecodeValues<TValue, TStorage>(this IValueEncoder<TValue, TStorage> encoder, params TStorage[] values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -148,8 +145,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Decode the values from a sequence of Key/Value pairs into a list of <typeparamref name="TValue"/>, discarding the keys in the process.</summary>
-		[NotNull]
-		public static TValue[] DecodeValues<TValue, TStorage, TAny>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] IEnumerable<KeyValuePair<TAny, TStorage>> items)
+		public static TValue[] DecodeValues<TValue, TStorage, TAny>(this IValueEncoder<TValue, TStorage> encoder, IEnumerable<KeyValuePair<TAny, TStorage>> items)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(items, nameof(items));
@@ -189,8 +185,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Decode a sequence of <typeparamref name="TStorage"/> into a list of <typeparamref name="TValue"/></summary>
-		[NotNull]
-		public static TValue[] DecodeValues<TValue, TStorage>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull, InstantHandle] IEnumerable<TStorage> values)
+		public static TValue[] DecodeValues<TValue, TStorage>(this IValueEncoder<TValue, TStorage> encoder, [InstantHandle] IEnumerable<TStorage> values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -230,8 +225,7 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Decode a sequence of <paramref name="items"/> into a list of <typeparamref name="TValue"/> by extracting one field using the specified <paramref name="selector"/></summary>
-		[NotNull]
-		public static TValue[] DecodeValues<TValue, TStorage, TElement>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull, InstantHandle] IEnumerable<TElement> items, [NotNull, InstantHandle] Func<TElement, TStorage> selector)
+		public static TValue[] DecodeValues<TValue, TStorage, TElement>(this IValueEncoder<TValue, TStorage> encoder, [InstantHandle] IEnumerable<TElement> items, [InstantHandle] Func<TElement, TStorage> selector)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(items, nameof(items));
@@ -271,8 +265,8 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Transform a sequence of slices back into a sequence of <typeparamref name="TValue"/>s, using a serializer (or the default serializer if none is provided)</summary>
-		[NotNull, LinqTunnel]
-		public static IEnumerable<TValue> SelectValues<TValue, TStorage>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] IEnumerable<TStorage> values)
+		[LinqTunnel]
+		public static IEnumerable<TValue> SelectValues<TValue, TStorage>(this IValueEncoder<TValue, TStorage> encoder, IEnumerable<TStorage> values)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(values, nameof(values));
@@ -281,8 +275,8 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Transform the values from a sequence of Key/Value pairs, into another sequence of <typeparamref name="TValue"/>, discarding the keys in the process.</summary>
-		[NotNull, LinqTunnel]
-		public static IEnumerable<TValue> SelectValues<TValue, TStorage, TAny>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] IEnumerable<KeyValuePair<TAny, TStorage>> items)
+		[LinqTunnel]
+		public static IEnumerable<TValue> SelectValues<TValue, TStorage, TAny>(this IValueEncoder<TValue, TStorage> encoder, IEnumerable<KeyValuePair<TAny, TStorage>> items)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(items, nameof(items));
@@ -291,8 +285,8 @@ namespace Doxense.Serialization.Encoders
 		}
 
 		/// <summary>Transform a sequence of <paramref name="items"/> into another sequence of <typeparamref name="TValue"/> by extracting one field using the specified <paramref name="selector"/></summary>
-		[NotNull, LinqTunnel]
-		public static IEnumerable<TValue> SelectValues<TValue, TStorage, TElement>([NotNull] this IValueEncoder<TValue, TStorage> encoder, [NotNull] IEnumerable<TElement> items, [NotNull] Func<TElement, TStorage> selector)
+		[LinqTunnel]
+		public static IEnumerable<TValue> SelectValues<TValue, TStorage, TElement>(this IValueEncoder<TValue, TStorage> encoder, IEnumerable<TElement> items, Func<TElement, TStorage> selector)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			Contract.NotNull(items, nameof(items));

--- a/FoundationDB.Client/Shared/TypeSystem/IKeyEncoding.cs
+++ b/FoundationDB.Client/Shared/TypeSystem/IKeyEncoding.cs
@@ -31,27 +31,24 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Doxense.Serialization.Encoders
 {
 	using System;
-	using JetBrains.Annotations;
 
 	/// <summary>Type system that handles encoding and decoding of different types of keys</summary>
 	/// <remarks>
 	/// An implementation of this interface knows to create different types of Key Encoders that will all use the same "binary format" to encode and decode keys of various shapes.
 	/// A good analogy for values would be a 'JSON' encoding, or 'XML' encoding.
 	/// </remarks>
-	public interface IKeyEncoding //REVIEW: rename to "IKeyEncodingScheme"? "IKeyTypeSystem"?
+	public interface IKeyEncoding
 	{
 
 		/// <summary>Returns an encoder which can process keys of any size and types</summary>
 		/// <returns>Encoder that encodes dynamic keys</returns>
 		/// <exception cref="NotSupportedException">If this encoding does not support dynamic keys</exception>
-		[NotNull]
 		IDynamicKeyEncoder GetDynamicKeyEncoder();
 
 		/// <summary>Returns an encoder which can process keys composed of a single element of a fixed type</summary>
 		/// <typeparam name="T1">Type of the element to encode</typeparam>
 		/// <returns>Key encoder</returns>
 		/// <exception cref="NotSupportedException">If this encoding does not support static keys</exception>
-		[NotNull]
 		IKeyEncoder<T1> GetKeyEncoder<T1>();
 
 		/// <summary>Returns an encoder which can process keys composed of a two elements of fixed types</summary>
@@ -59,7 +56,6 @@ namespace Doxense.Serialization.Encoders
 		/// <typeparam name="T2">Type of the second element to encode</typeparam>
 		/// <returns>Composite key encoder</returns>
 		/// <exception cref="NotSupportedException">If this encoding does not support static keys of size 2</exception>
-		[NotNull]
 		ICompositeKeyEncoder<T1, T2> GetKeyEncoder<T1, T2>();
 
 		/// <summary>Returns an encoder which can process keys composed of a three elements of fixed types</summary>
@@ -68,7 +64,6 @@ namespace Doxense.Serialization.Encoders
 		/// <typeparam name="T3">Type of the third element to encode</typeparam>
 		/// <returns>Composite key encoder</returns>
 		/// <exception cref="NotSupportedException">If this encoding does not support static keys of size 3</exception>
-		[NotNull]
 		ICompositeKeyEncoder<T1, T2, T3> GetKeyEncoder<T1, T2, T3>();
 
 		/// <summary>Returns an encoder which can process keys composed of a four elements of fixed types</summary>
@@ -78,7 +73,6 @@ namespace Doxense.Serialization.Encoders
 		/// <typeparam name="T4">Type of the fourth element to encode</typeparam>
 		/// <returns>Composite key encoder</returns>
 		/// <exception cref="NotSupportedException">If this encoding does not support static keys of size 4</exception>
-		[NotNull]
 		ICompositeKeyEncoder<T1, T2, T3, T4> GetKeyEncoder<T1, T2, T3, T4>();
 
 	}

--- a/FoundationDB.Client/Shared/TypeSystem/ITypeSystem.cs
+++ b/FoundationDB.Client/Shared/TypeSystem/ITypeSystem.cs
@@ -31,14 +31,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Doxense.Serialization.Encoders
 {
 	using System;
-	using JetBrains.Annotations;
 
 	/// <summary>Represents a particular encoding scheme that can convert keys and values into binary literals</summary>
 	public interface ITypeSystem : IKeyEncoding, IValueEncoding
 	{
 
 		/// <summary>Name of the encoding</summary>
-		[NotNull]
 		string Name { get; }
 
 	}

--- a/FoundationDB.Client/Shared/TypeSystem/IValueEncoding.cs
+++ b/FoundationDB.Client/Shared/TypeSystem/IValueEncoding.cs
@@ -31,7 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Doxense.Serialization.Encoders
 {
 	using System;
-	using JetBrains.Annotations;
 
 	public interface IValueEncoding
 	{
@@ -39,7 +38,6 @@ namespace Doxense.Serialization.Encoders
 		/// <typeparam name="TValue">Type of the element to encode</typeparam>
 		/// <typeparam name="TStorage">Type of the encoded form of the values (Slice, string, ...)</typeparam>
 		/// <returns>Value encoder</returns>
-		[NotNull]
 		IValueEncoder<TValue, TStorage> GetValueEncoder<TValue, TStorage>();
 
 		/// <summary>Returns an encoder which can process values of a fixed type</summary>

--- a/FoundationDB.Client/Shared/Uuid128.cs
+++ b/FoundationDB.Client/Shared/Uuid128.cs
@@ -486,7 +486,7 @@ namespace System
 			return m_packed;
 		}
 
-		[Pure, NotNull]
+		[Pure]
 		public byte[] ToByteArray()
 		{
 			// We must use Big Endian when serializing the UUID

--- a/FoundationDB.Client/Shared/Uuid64.cs
+++ b/FoundationDB.Client/Shared/Uuid64.cs
@@ -475,8 +475,7 @@ namespace System
 			return a > 9 ? (char)(a - 10 + 'a') : (char)(a + '0');
 		}
 
-		[NotNull]
-		private static unsafe char* HexsToLowerChars([NotNull] char* ptr, int a)
+		private static unsafe char* HexsToLowerChars(char* ptr, int a)
 		{
 			Contract.Requires(ptr != null);
 			ptr[0] = HexToLowerChar(a >> 28);
@@ -497,8 +496,7 @@ namespace System
 			return a > 9 ? (char)(a - 10 + 'A') : (char)(a + '0');
 		}
 
-		[NotNull]
-		private static unsafe char* HexsToUpperChars([NotNull] char* ptr, int a)
+		private static unsafe char* HexsToUpperChars(char* ptr, int a)
 		{
 			Contract.Requires(ptr != null);
 			ptr[0] = HexToUpperChar(a >> 28);

--- a/FoundationDB.Client/Shared/Uuid80.cs
+++ b/FoundationDB.Client/Shared/Uuid80.cs
@@ -412,8 +412,7 @@ namespace System
 			return a > 9 ? (char)(a - 10 + 'a') : (char)(a + '0');
 		}
 
-		[NotNull]
-		private static unsafe char* HexsToLowerChars([NotNull] char* ptr, ushort a)
+		private static unsafe char* HexsToLowerChars(char* ptr, ushort a)
 		{
 			Contract.Requires(ptr != null);
 			ptr[0] = HexToLowerChar((uint) a >> 12);
@@ -423,8 +422,7 @@ namespace System
 			return ptr + 4;
 		}
 
-		[NotNull]
-		private static unsafe char* HexsToLowerChars([NotNull] char* ptr, uint a)
+		private static unsafe char* HexsToLowerChars(char* ptr, uint a)
 		{
 			Contract.Requires(ptr != null);
 			ptr[0] = HexToLowerChar(a >> 28);
@@ -445,8 +443,7 @@ namespace System
 			return a > 9 ? (char)(a - 10 + 'A') : (char)(a + '0');
 		}
 
-		[NotNull]
-		private static unsafe char* Hex16ToUpperChars([NotNull] char* ptr, ushort a)
+		private static unsafe char* Hex16ToUpperChars(char* ptr, ushort a)
 		{
 			Contract.Requires(ptr != null);
 			ptr[0] = HexToUpperChar((uint) a >> 12);
@@ -456,8 +453,7 @@ namespace System
 			return ptr + 4;
 		}
 
-		[NotNull]
-		private static unsafe char* Hex32ToUpperChars([NotNull] char* ptr, uint a)
+		private static unsafe char* Hex32ToUpperChars(char* ptr, uint a)
 		{
 			Contract.Requires(ptr != null);
 			ptr[0] = HexToUpperChar(a >> 28);

--- a/FoundationDB.Client/Status/FdbSystemStatus.cs
+++ b/FoundationDB.Client/Status/FdbSystemStatus.cs
@@ -29,12 +29,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // ReSharper disable UnusedMember.Global
 namespace FoundationDB.Client.Status
 {
-	using FoundationDB.Client.Utils;
-	using JetBrains.Annotations;
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Globalization;
+	using FoundationDB.Client.Utils;
+	using JetBrains.Annotations;
 
 	/// <summary>Snapshot of the state of a FoundationDB cluster</summary>
 	[PublicAPI]
@@ -291,7 +291,7 @@ namespace FoundationDB.Client.Status
 	{
 		internal ClientStatus(Dictionary<string, object> data) : base(data) { }
 
-		private Message[] m_messages;
+		private Message[]? m_messages;
 
 		/// <summary>Path to the '.cluster' file used by the client to connect to the cluster</summary>
 		public string ClusterFilePath => GetString("cluster_file", "path");
@@ -301,8 +301,7 @@ namespace FoundationDB.Client.Status
 
 		/// <summary>Liste of active messages for the client</summary>
 		/// <remarks>The most common client messages are listed in <see cref="ClientMessages"/>.</remarks>
-		[NotNull]
-		public Message[] Messages => m_messages ?? (m_messages = Message.FromArray(m_data, "messages"));
+		public Message[] Messages => m_messages ??= Message.FromArray(m_data, "messages");
 
 		/// <summary>Timestamp of the local client (unix time)</summary>
 		/// <remarks>Number of seconds since 1970-01-01Z, using the local system clock</remarks>
@@ -345,15 +344,15 @@ namespace FoundationDB.Client.Status
 			: base(data)
 		{ }
 
-		private Message[] m_messages;
-		private ClusterConfiguration m_configuration;
-		private DataMetrics m_dataMetrics;
-		private LatencyMetrics m_latency;
-		private QosMetrics m_qos;
-		private WorkloadMetrics m_workload;
-		private ClusterClientsMetrics m_clients;
-		private Dictionary<string, ProcessStatus> m_processes;
-		private Dictionary<string, MachineStatus> m_machines;
+		private Message[]? m_messages;
+		private ClusterConfiguration? m_configuration;
+		private DataMetrics? m_dataMetrics;
+		private LatencyMetrics? m_latency;
+		private QosMetrics? m_qos;
+		private WorkloadMetrics? m_workload;
+		private ClusterClientsMetrics? m_clients;
+		private Dictionary<string, ProcessStatus>? m_processes;
+		private Dictionary<string, MachineStatus>? m_machines;
 
 		/// <summary>Unix time of the cluster controller</summary>
 		/// <remarks>Number of seconds since the Unix epoch (1970-01-01Z)</remarks>
@@ -370,30 +369,28 @@ namespace FoundationDB.Client.Status
 		public long Generation => GetInt64("generation") ?? 0;
 
 		/// <summary>License string of the cluster</summary>
-		[NotNull]
 		public string License => GetString("license") ?? String.Empty;
 
 		/// <summary>List of currently active messages</summary>
 		/// <remarks>Includes notifications, warnings, errors, ...</remarks>
-		[NotNull]
-		public Message[] Messages => m_messages ?? (m_messages = Message.FromArray(m_data, "messages"));
+		public Message[] Messages => m_messages ??= Message.FromArray(m_data, "messages");
 
 		/// <summary>Recovery state of the cluster</summary>
 		public Message RecoveryState => Message.From(m_data, "recovery_state");
 
-		public ClusterConfiguration Configuration => m_configuration ?? (m_configuration = new ClusterConfiguration(GetMap("configuration")));
+		public ClusterConfiguration Configuration => m_configuration ??= new ClusterConfiguration(GetMap("configuration"));
 
-		public DataMetrics Data => m_dataMetrics ?? (m_dataMetrics = new DataMetrics(GetMap("data")));
+		public DataMetrics Data => m_dataMetrics ??= new DataMetrics(GetMap("data"));
 
-		public LatencyMetrics Latency => m_latency ?? (m_latency = new LatencyMetrics(GetMap("latency_probe")));
+		public LatencyMetrics Latency => m_latency ??= new LatencyMetrics(GetMap("latency_probe"));
 
 		/// <summary>QoS metrics</summary>
-		public QosMetrics Qos => m_qos ?? (m_qos = new QosMetrics(GetMap("qos")));
+		public QosMetrics Qos => m_qos ??= new QosMetrics(GetMap("qos"));
 
 		/// <summary>Workload metrics</summary>
-		public WorkloadMetrics Workload => m_workload ?? (m_workload = new WorkloadMetrics(GetMap("workload")));
+		public WorkloadMetrics Workload => m_workload ??= new WorkloadMetrics(GetMap("workload"));
 
-		public ClusterClientsMetrics Clients => m_clients ?? (m_clients = new ClusterClientsMetrics(GetMap("clients")));
+		public ClusterClientsMetrics Clients => m_clients ??= new ClusterClientsMetrics(GetMap("clients"));
 
 		/// <summary>List of the processes that are currently active in the cluster</summary>
 		public IReadOnlyDictionary<string, ProcessStatus> Processes
@@ -464,7 +461,7 @@ namespace FoundationDB.Client.Status
 			this.RedundancyFactor = GetString("redundancy", "factor") ?? String.Empty;
 		}
 
-		private string[] m_excludedServers;
+		private string[]? m_excludedServers;
 
 		public int CoordinatorsCount { get; }
 
@@ -556,18 +553,18 @@ namespace FoundationDB.Client.Status
 	{
 		internal WorkloadMetrics(Dictionary<string, object> data) : base(data) { }
 
-		private WorkloadBytesMetrics m_bytes;
-		private WorkloadOperationsMetrics m_operations;
-		private WorkloadTransactionsMetrics m_transactions;
+		private WorkloadBytesMetrics? m_bytes;
+		private WorkloadOperationsMetrics? m_operations;
+		private WorkloadTransactionsMetrics? m_transactions;
 
 		/// <summary>Performance counters for the volume of data processed by the database</summary>
-		public WorkloadBytesMetrics Bytes => m_bytes ?? (m_bytes = new WorkloadBytesMetrics(GetMap("bytes")));
+		public WorkloadBytesMetrics Bytes => m_bytes ??= new WorkloadBytesMetrics(GetMap("bytes"));
 
 		/// <summary>Performance counters for the operations on the keys in the database</summary>
-		public WorkloadOperationsMetrics Operations => m_operations ?? (m_operations = new WorkloadOperationsMetrics(GetMap("operations")));
+		public WorkloadOperationsMetrics Operations => m_operations ??= new WorkloadOperationsMetrics(GetMap("operations"));
 
 		/// <summary>Performance counters for the transactions.</summary>
-		public WorkloadTransactionsMetrics Transactions => m_transactions ?? (m_transactions = new WorkloadTransactionsMetrics(GetMap("transactions")));
+		public WorkloadTransactionsMetrics Transactions => m_transactions ??= new WorkloadTransactionsMetrics(GetMap("transactions"));
 	}
 
 	/// <summary>Throughput of a FoundationDB cluster</summary>
@@ -650,80 +647,65 @@ namespace FoundationDB.Client.Status
 			this.Id = id;
 		}
 
-		private string m_machineId;
-		private string m_address;
-		private Message[] m_messages;
-		private ProcessNetworkMetrics m_network;
-		private ProcessCpuMetrics m_cpu;
-		private ProcessDiskMetrics m_disk;
-		private ProcessMemoryMetrics m_memory;
-		private LocalityConfiguration m_locality;
-		private ProcessRoleMetrics[] m_roles;
+		private string? m_machineId;
+		private string? m_address;
+		private Message[]? m_messages;
+		private ProcessNetworkMetrics? m_network;
+		private ProcessCpuMetrics? m_cpu;
+		private ProcessDiskMetrics? m_disk;
+		private ProcessMemoryMetrics? m_memory;
+		private LocalityConfiguration? m_locality;
+		private ProcessRoleMetrics[]? m_roles;
 
 		/// <summary>Unique identifier for this process.</summary>
 		//TODO: is it stable across reboots? what are the conditions for a process to change its ID ?
-		[NotNull]
 		public string Id { get; }
 
 		/// <summary>Identifier of the machine that is hosting this process</summary>
 		/// <remarks>All processes that have the same MachineId are running on the same (physical) machine.</remarks>
-		[NotNull]
-		public string MachineId => m_machineId ?? (m_machineId = GetString("machine_id") ?? string.Empty);
+		public string MachineId => m_machineId ??= GetString("machine_id") ?? string.Empty;
 
 		/// <summary>Version of this process</summary>
 		/// <example>"3.0.4"</example>
-		[NotNull]
 		public string Version => GetString("version") ?? string.Empty;
 
 		public TimeSpan Uptime => TimeSpan.FromSeconds(GetDouble("uptime_seconds") ?? 0);
 
 		/// <summary>Address and port of this process, with syntax "IP_ADDRESS:port"</summary>
 		/// <example>"10.1.2.34:4500"</example>
-		[NotNull]
-		public string Address => m_address ?? (m_address = GetString("address") ?? string.Empty);
+		public string Address => m_address ??= GetString("address") ?? string.Empty;
 
-		[NotNull]
 		public string ClassSource => GetString("class_source") ?? string.Empty;
 
-		[NotNull]
 		public string ClassType => GetString("class_type") ?? string.Empty;
 
 		/// <summary>Command line that was used to start this process</summary>
-		[NotNull]
 		public string CommandLine => GetString("command_line") ?? string.Empty;
 
 		/// <summary>If true, this process is currently excluded from the cluster</summary>
 		public bool Excluded => GetBoolean("excluded") ?? false;
 
-		[NotNull]
 		public string FaultDomain => GetString("fault_domain") ?? string.Empty;
 
 		/// <summary>List of messages that are currently published by this process</summary>
-		[NotNull]
-		public Message[] Messages => m_messages ?? (m_messages = Message.FromArray(m_data, "messages"));
+		public Message[] Messages => m_messages ??= Message.FromArray(m_data, "messages");
 
 		/// <summary>Network performance counters</summary>
-		[NotNull]
-		public ProcessNetworkMetrics Network => m_network ?? (m_network = new ProcessNetworkMetrics(GetMap("network")));
+		public ProcessNetworkMetrics Network => m_network ??= new ProcessNetworkMetrics(GetMap("network"));
 
 		/// <summary>CPU performance counters</summary>
-		[NotNull]
-		public ProcessCpuMetrics Cpu => m_cpu ?? (m_cpu = new ProcessCpuMetrics(GetMap("cpu")));
+		public ProcessCpuMetrics Cpu => m_cpu ??= new ProcessCpuMetrics(GetMap("cpu"));
 
 		/// <summary>Disk performance counters</summary>
-		[NotNull]
-		public ProcessDiskMetrics Disk => m_disk ?? (m_disk = new ProcessDiskMetrics(GetMap("disk")));
+		public ProcessDiskMetrics Disk => m_disk ??= new ProcessDiskMetrics(GetMap("disk"));
 
 		/// <summary>Memory performance counters</summary>
-		[NotNull]
-		public ProcessMemoryMetrics Memory => m_memory ?? (m_memory = new ProcessMemoryMetrics(GetMap("memory")));
+		public ProcessMemoryMetrics Memory => m_memory ??= new ProcessMemoryMetrics(GetMap("memory"));
 
-		[NotNull]
-		public LocalityConfiguration Locality => m_locality ?? (m_locality = new LocalityConfiguration(GetMap("locality")));
+		public LocalityConfiguration Locality => m_locality ??= new LocalityConfiguration(GetMap("locality"));
 
 		/// <summary>List of the roles assumed by this process</summary>
 		/// <remarks>The key is the unique role ID in the cluster, and the value is the type of the role itself</remarks>
-		[NotNull, ItemNotNull]
 		public ProcessRoleMetrics[] Roles
 		{
 			get
@@ -761,7 +743,6 @@ namespace FoundationDB.Client.Status
 
 		//TODO: values will vary depending on the "Role" !
 
-		[NotNull]
 		public static ProcessRoleMetrics Create(Dictionary<string, object> data)
 		{
 			string role = TinyJsonParser.GetStringField(data, "role");
@@ -903,7 +884,7 @@ namespace FoundationDB.Client.Status
 		public const string ProcessError = "process_error";
 	}
 
-	/// <summary>Memory performane counters for a FoundationDB process</summary>
+	/// <summary>Memory performance counters for a FoundationDB process</summary>
 	public sealed class ProcessMemoryMetrics : MetricsBase
 	{
 		internal ProcessMemoryMetrics(Dictionary<string, object> data)
@@ -925,7 +906,7 @@ namespace FoundationDB.Client.Status
 
 	}
 
-	/// <summary>CPU performane counters for a FoundationDB process</summary>
+	/// <summary>CPU performance counters for a FoundationDB process</summary>
 	public sealed class ProcessCpuMetrics : MetricsBase
 	{
 		internal ProcessCpuMetrics(Dictionary<string, object> data)
@@ -1003,45 +984,42 @@ namespace FoundationDB.Client.Status
 			this.Id = id;
 		}
 
-		private string m_address;
-		private MachineNetworkMetrics m_network;
-		private MachineCpuMetrics m_cpu;
-		private MachineMemoryMetrics m_memory;
-		private LocalityConfiguration m_locality;
+		private string? m_address;
+		private MachineNetworkMetrics? m_network;
+		private MachineCpuMetrics? m_cpu;
+		private MachineMemoryMetrics? m_memory;
+		private LocalityConfiguration? m_locality;
 
 		/// <summary>Unique identifier for this machine.</summary>
 		//TODO: is it stable across reboots? what are the conditions for a process to change its ID ?
-		[NotNull]
 		public string Id { get; }
 
 		/// <summary>Identifier of the data center that is hosting this machine</summary>
 		/// <remarks>All machines that have the same DataCenterId are probably running on the same (physical) network.</remarks>
-		[NotNull]
 		public string DataCenterId => GetString("datacenter_id") ?? string.Empty;
 
 		/// <summary>Address of this machine</summary>
 		/// <example>"10.1.2.34"</example>
-		[NotNull]
-		public string Address => m_address ?? (m_address = GetString("address") ?? string.Empty);
+		public string Address => m_address ??= GetString("address") ?? string.Empty;
 
 		/// <summary>If true, this process is currently excluded from the cluster</summary>
 		public bool Excluded => GetBoolean("excluded") ?? false;
 
 		/// <summary>Network performance counters</summary>
-		public MachineNetworkMetrics Network => m_network ?? (m_network = new MachineNetworkMetrics(GetMap("network")));
+		public MachineNetworkMetrics Network => m_network ??= new MachineNetworkMetrics(GetMap("network"));
 
 		/// <summary>CPU performance counters</summary>
-		public MachineCpuMetrics Cpu => m_cpu ?? (m_cpu = new MachineCpuMetrics(GetMap("cpu")));
+		public MachineCpuMetrics Cpu => m_cpu ??= new MachineCpuMetrics(GetMap("cpu"));
 
 		/// <summary>Memory performance counters</summary>
-		public MachineMemoryMetrics Memory => m_memory ?? (m_memory = new MachineMemoryMetrics(GetMap("memory")));
+		public MachineMemoryMetrics Memory => m_memory ??= new MachineMemoryMetrics(GetMap("memory"));
 
-		public LocalityConfiguration Locality => m_locality ?? (m_locality = new LocalityConfiguration(GetMap("locality")));
+		public LocalityConfiguration Locality => m_locality ??= new LocalityConfiguration(GetMap("locality"));
 
 		public int ContributingWorkers => (int) (GetInt64("contributing_workers") ?? 0);
 	}
 
-	/// <summary>Memory performane counters for machine hosting one or more FoundationDB processes</summary>
+	/// <summary>Memory performance counters for machine hosting one or more FoundationDB processes</summary>
 	public sealed class MachineMemoryMetrics : MetricsBase
 	{
 		internal MachineMemoryMetrics(Dictionary<string, object> data)
@@ -1060,7 +1038,7 @@ namespace FoundationDB.Client.Status
 
 	}
 
-	/// <summary>CPU performane counters for machine hosting one or more FoundationDB processes</summary>
+	/// <summary>CPU performance counters for machine hosting one or more FoundationDB processes</summary>
 	public sealed class MachineCpuMetrics : MetricsBase
 	{
 		internal MachineCpuMetrics(Dictionary<string, object> data)
@@ -1073,7 +1051,7 @@ namespace FoundationDB.Client.Status
 
 	}
 
-	/// <summary>Network performane counters for machine hosting one or more FoundationDB processes</summary>
+	/// <summary>Network performance counters for machine hosting one or more FoundationDB processes</summary>
 	public sealed class MachineNetworkMetrics : MetricsBase
 	{
 		internal MachineNetworkMetrics(Dictionary<string, object> data)

--- a/FoundationDB.Client/Subspaces/BinaryKeySubspace.cs
+++ b/FoundationDB.Client/Subspaces/BinaryKeySubspace.cs
@@ -60,11 +60,11 @@ namespace FoundationDB.Client
 	public sealed class BinaryKeySubspace : KeySubspace, IBinaryKeySubspace
 	{
 
-		internal BinaryKeySubspace(Slice prefix, [NotNull] ISubspaceContext context)
+		internal BinaryKeySubspace(Slice prefix, ISubspaceContext context)
 			: base(prefix, context)
 		{ }
 
-		internal BinaryKeySubspace(Slice prefix, KeyRange range, [NotNull] ISubspaceContext context)
+		internal BinaryKeySubspace(Slice prefix, KeyRange range, ISubspaceContext context)
 			: base(prefix, range, context)
 		{ }
 

--- a/FoundationDB.Client/Subspaces/DynamicKeySubspace.cs
+++ b/FoundationDB.Client/Subspaces/DynamicKeySubspace.cs
@@ -54,13 +54,12 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Returns an helper object that knows how to create sub-partitions of this subspace</summary>
-		[NotNull]
 		DynamicPartition Partition { get; }
 
 		/// <summary>Encoder used to generate and parse the keys of this subspace</summary>
-		[NotNull] IDynamicKeyEncoder KeyEncoder { get; }
+		IDynamicKeyEncoder KeyEncoder { get; }
 
-		Slice this[[NotNull] IVarTuple tuple] { [Pure] get; }
+		Slice this[IVarTuple tuple] { [Pure] get; }
 
 		/// <summary>Convert a tuple into a key of this subspace</summary>
 		/// <param name="tuple">Tuple that will be packed and appended to the subspace prefix</param>
@@ -95,7 +94,7 @@ namespace FoundationDB.Client
 		/// <param name="prefix">Prefix of the new subspace</param>
 		/// <param name="encoder">Encoder that will be used by this subspace</param>
 		/// <param name="context">Context that controls the lifetime of this subspace</param>
-		internal DynamicKeySubspace(Slice prefix, [NotNull] IDynamicKeyEncoder encoder, [NotNull] ISubspaceContext context)
+		internal DynamicKeySubspace(Slice prefix, IDynamicKeyEncoder encoder, ISubspaceContext context)
 			: base(prefix, context)
 		{
 			Contract.Requires(encoder != null);
@@ -115,7 +114,7 @@ namespace FoundationDB.Client
 		/// <summary>Convert a tuple into a key of this subspace</summary>
 		/// <param name="tuple">Tuple that will be packed and appended to the subspace prefix</param>
 		[Pure]
-		public Slice Pack<TTuple>([NotNull] TTuple tuple)
+		public Slice Pack<TTuple>(TTuple tuple)
 			where TTuple : IVarTuple
 		{
 			Contract.NotNullAllowStructs(tuple, nameof(tuple));
@@ -172,7 +171,7 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Encode a batch of tuples</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static Slice[] PackMany<TTuple>(this IDynamicKeySubspace self, IEnumerable<TTuple> items)
 			where TTuple : IVarTuple
 		{
@@ -185,7 +184,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode a batch of tuples extracted from each elements</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static Slice[] PackMany<TSource, TTuple>(this IDynamicKeySubspace self, IEnumerable<TSource> items, Func<TSource, TTuple> selector)
 			where TTuple : IVarTuple
 		{
@@ -240,8 +239,7 @@ namespace FoundationDB.Client
 		#region ToRange()...
 
 		/// <summary>Return a key range that encompass all the keys inside a partition of this subspace, according to the current key encoder</summary>
-		/// <param name="tuple">Tuple used as a prefix for the range</param>
-		public static KeyRange PackRange(this IDynamicKeySubspace self, [NotNull] IVarTuple tuple)
+		public static KeyRange PackRange(this IDynamicKeySubspace self, IVarTuple tuple)
 		{
 			return self.KeyEncoder.ToRange(self.GetPrefix(), tuple);
 		}
@@ -361,7 +359,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode a batch of keys, each one composed of a single element</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static Slice[] EncodeMany<T>(this IDynamicKeySubspace self, IEnumerable<T> items)
 		{
 			return Batched<T, IDynamicKeyEncoder>.Convert(
@@ -373,7 +371,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode a batch of keys, each one composed of a single value extracted from each elements</summary>
-		[Pure, NotNull]
+		[Pure]
 		public static Slice[] EncodeMany<TSource, T>(this IDynamicKeySubspace self, IEnumerable<TSource> items, Func<TSource, T> selector)
 		{
 			return Batched<TSource, IDynamicKeyEncoder>.Convert(
@@ -385,6 +383,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode a key which is composed of a two elements</summary>
+		[Pure]
 		public static Slice Encode<T1, T2>(this IDynamicKeySubspace self, T1 item1, T2 item2)
 		{
 			var sw = self.OpenWriter();
@@ -393,6 +392,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode a key which is composed of three elements</summary>
+		[Pure]
 		public static Slice Encode<T1, T2, T3>(this IDynamicKeySubspace self, T1 item1, T2 item2, T3 item3)
 		{
 			var sw = self.OpenWriter();
@@ -401,6 +401,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode a key which is composed of four elements</summary>
+		[Pure]
 		public static Slice Encode<T1, T2, T3, T4>(this IDynamicKeySubspace self, T1 item1, T2 item2, T3 item3, T4 item4)
 		{
 			var sw = self.OpenWriter();
@@ -409,6 +410,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode a key which is composed of five elements</summary>
+		[Pure]
 		public static Slice Encode<T1, T2, T3, T4, T5>(this IDynamicKeySubspace self, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
 		{
 			var sw = self.OpenWriter();
@@ -417,6 +419,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode a key which is composed of six elements</summary>
+		[Pure]
 		public static Slice Encode<T1, T2, T3, T4, T5, T6>(this IDynamicKeySubspace self, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
 		{
 			var sw = self.OpenWriter();
@@ -487,10 +490,9 @@ namespace FoundationDB.Client
 	public sealed class DynamicPartition
 	{
 
-		[NotNull]
 		public IDynamicKeySubspace Subspace { get; }
 
-		internal DynamicPartition([NotNull] DynamicKeySubspace subspace)
+		internal DynamicPartition(DynamicKeySubspace subspace)
 		{
 			Contract.Requires(subspace != null);
 			this.Subspace = subspace;
@@ -498,13 +500,13 @@ namespace FoundationDB.Client
 
 		public IDynamicKeySubspace this[Slice binarySuffix]
 		{
-			[Pure, NotNull]
+			[Pure]
 			get => new DynamicKeySubspace(this.Subspace.Append(binarySuffix), this.Subspace.KeyEncoder, this.Subspace.Context);
 		}
 
 		public IDynamicKeySubspace this[IVarTuple suffix]
 		{
-			[Pure, NotNull]
+			[Pure]
 			get => new DynamicKeySubspace(this.Subspace.Pack(suffix), this.Subspace.KeyEncoder, this.Subspace.Context);
 		}
 
@@ -516,7 +518,7 @@ namespace FoundationDB.Client
 		/// <example>
 		/// new FdbSubspace(["Users", ]).Partition("Contacts") == new FdbSubspace(["Users", "Contacts", ])
 		/// </example>
-		[Pure, NotNull]
+		[Pure]
 		public IDynamicKeySubspace ByKey<T>(T value)
 		{
 			return new DynamicKeySubspace(this.Subspace.Encode<T>(value), this.Subspace.KeyEncoder, this.Subspace.Context);
@@ -532,7 +534,7 @@ namespace FoundationDB.Client
 		/// <example>
 		/// new FdbSubspace(["Users", ]).Partition("Contacts", "Friends") == new FdbSubspace(["Users", "Contacts", "Friends", ])
 		/// </example>
-		[Pure, NotNull]
+		[Pure]
 		public IDynamicKeySubspace ByKey<T1, T2>(T1 value1, T2 value2)
 		{
 			return new DynamicKeySubspace(this.Subspace.Encode<T1, T2>(value1, value2), this.Subspace.KeyEncoder, this.Subspace.Context);
@@ -549,7 +551,7 @@ namespace FoundationDB.Client
 		/// <example>
 		/// new FdbSubspace(["Users", ]).Partition("John Smith", "Contacts", "Friends") == new FdbSubspace(["Users", "John Smith", "Contacts", "Friends", ])
 		/// </example>
-		[Pure, NotNull]
+		[Pure]
 		public IDynamicKeySubspace ByKey<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
 		{
 			return new DynamicKeySubspace(this.Subspace.Encode<T1, T2, T3>(value1, value2, value3), this.Subspace.KeyEncoder, this.Subspace.Context);
@@ -568,7 +570,7 @@ namespace FoundationDB.Client
 		/// <example>
 		/// new FdbSubspace(["Users", ]).Partition("John Smith", "Contacts", "Friends", "Messages") == new FdbSubspace(["Users", "John Smith", "Contacts", "Friends", "Messages", ])
 		/// </example>
-		[Pure, NotNull]
+		[Pure]
 		public IDynamicKeySubspace ByKey<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
 		{
 			return new DynamicKeySubspace(this.Subspace.Encode<T1, T2, T3, T4>(value1, value2, value3, value4), this.Subspace.KeyEncoder, this.Subspace.Context);

--- a/FoundationDB.Client/Subspaces/IKeySubspace.cs
+++ b/FoundationDB.Client/Subspaces/IKeySubspace.cs
@@ -56,7 +56,6 @@ namespace FoundationDB.Client
 		/// It can also be the <see cref="SubspaceContext.Default"/> context for keys created outside of any context
 		/// The context is used to track the origin of a subspace, and optionally revoke access to it once the context becomes invalid (ex: cached context no longer being valid)
 		/// </remarks>
-		[NotNull]
 		ISubspaceContext Context { get; }
 
 		/// <summary>Returns the prefix of this subspace</summary>

--- a/FoundationDB.Client/Subspaces/KeySubspace.cs
+++ b/FoundationDB.Client/Subspaces/KeySubspace.cs
@@ -48,19 +48,17 @@ namespace FoundationDB.Client
 		/// <summary>Precomputed range that encompass all the keys in this subspace</summary>
 		private readonly KeyRange Range;
 
-		[NotNull]
 		public ISubspaceContext Context { get; }
 
 		#region Constructors...
 
-		[NotNull]
 		public static IKeySubspace Empty => new KeySubspace(Slice.Empty, SubspaceContext.Default);
 
 		#region FromKey...
 
 		/// <summary>Initializes a new generic subspace with the given prefix.</summary>
-		[Pure, NotNull]
-		public static IKeySubspace FromKey(Slice prefix, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static IKeySubspace FromKey(Slice prefix, ISubspaceContext? context = null)
 		{
 			return new KeySubspace(prefix.Memoize(), context ?? SubspaceContext.Default);
 		}
@@ -76,8 +74,8 @@ namespace FoundationDB.Client
 
 		/// <summary>Initializes a new dynamic subspace with the given binary <paramref name="prefix"/> and key <paramref name="encoder"/>.</summary>
 		/// <returns>A subspace that can handle keys of any types and size.</returns>
-		[Pure, NotNull]
-		public static IDynamicKeySubspace CreateDynamic(Slice prefix, [NotNull] IDynamicKeyEncoder encoder, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static IDynamicKeySubspace CreateDynamic(Slice prefix, IDynamicKeyEncoder encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			return new DynamicKeySubspace(prefix, encoder, context ?? SubspaceContext.Default);
@@ -85,22 +83,22 @@ namespace FoundationDB.Client
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a dynamic key <paramref name="encoding"/>.</summary>
 		/// <returns>A subspace that can handle keys of any types and size.</returns>
-		[Pure, NotNull]
-		public static IDynamicKeySubspace CreateDynamic(Slice prefix, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static IDynamicKeySubspace CreateDynamic(Slice prefix, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			return new DynamicKeySubspace(prefix, (encoding ?? TuPack.Encoding).GetDynamicKeyEncoder(), context ?? SubspaceContext.Default);
 		}
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a typed key <paramref name="encoding"/>.</summary>
 		/// <returns>A subspace that can handle keys of type <typeparamref name="T1"/>.</returns>
-		public static ITypedKeySubspace<T1> CreateTyped<T1>(Slice prefix, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		public static ITypedKeySubspace<T1> CreateTyped<T1>(Slice prefix, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			return new TypedKeySubspace<T1>(prefix, (encoding ?? TuPack.Encoding).GetKeyEncoder<T1>(), context ?? SubspaceContext.Default);
 		}
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a typed key <paramref name="encoder"/>.</summary>
 		/// <returns>A subspace that can handle keys of type <typeparamref name="T1"/>.</returns>
-		public static ITypedKeySubspace<T1> CreateTyped<T1>(Slice prefix, [NotNull] IKeyEncoder<T1> encoder, [CanBeNull] ISubspaceContext context = null)
+		public static ITypedKeySubspace<T1> CreateTyped<T1>(Slice prefix, IKeyEncoder<T1> encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			return new TypedKeySubspace<T1>(prefix, encoder, context ?? SubspaceContext.Default);
@@ -108,14 +106,14 @@ namespace FoundationDB.Client
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a typed key <paramref name="encoding"/>.</summary>
 		/// <returns>A subspace that can handle composite keys of type (<typeparamref name="T1"/>, <typeparamref name="T2"/>).</returns>
-		public static ITypedKeySubspace<T1, T2> CreateTyped<T1, T2>(Slice prefix, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		public static ITypedKeySubspace<T1, T2> CreateTyped<T1, T2>(Slice prefix, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			return new TypedKeySubspace<T1, T2>(prefix, (encoding ?? TuPack.Encoding).GetKeyEncoder<T1, T2>(), context ?? SubspaceContext.Default);
 		}
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a typed key <paramref name="encoder"/>.</summary>
 		/// <returns>A subspace that can handle composite keys of type (<typeparamref name="T1"/>, <typeparamref name="T2"/>).</returns>
-		public static ITypedKeySubspace<T1, T2> CreateTyped<T1, T2>(Slice prefix, [NotNull] ICompositeKeyEncoder<T1, T2> encoder, [CanBeNull] ISubspaceContext context = null)
+		public static ITypedKeySubspace<T1, T2> CreateTyped<T1, T2>(Slice prefix, ICompositeKeyEncoder<T1, T2> encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			return new TypedKeySubspace<T1, T2>(prefix, encoder, context ?? SubspaceContext.Default);
@@ -123,14 +121,14 @@ namespace FoundationDB.Client
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a typed key <paramref name="encoding"/>.</summary>
 		/// <returns>A subspace that can handle composite keys of type (<typeparamref name="T1"/>, <typeparamref name="T2"/>, <typeparamref name="T3"/>).</returns>
-		public static ITypedKeySubspace<T1, T2, T3> CreateTyped<T1, T2, T3>(Slice prefix, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		public static ITypedKeySubspace<T1, T2, T3> CreateTyped<T1, T2, T3>(Slice prefix, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			return new TypedKeySubspace<T1, T2, T3>(prefix, (encoding ?? TuPack.Encoding).GetKeyEncoder<T1, T2, T3>(), context ?? SubspaceContext.Default);
 		}
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a typed key <paramref name="encoder"/>.</summary>
 		/// <returns>A subspace that can handle composite keys of type (<typeparamref name="T1"/>, <typeparamref name="T2"/>, <typeparamref name="T3"/>).</returns>
-		public static ITypedKeySubspace<T1, T2, T3> CreateTyped<T1, T2, T3>(Slice prefix, [NotNull] ICompositeKeyEncoder<T1, T2, T3> encoder, [CanBeNull] ISubspaceContext context = null)
+		public static ITypedKeySubspace<T1, T2, T3> CreateTyped<T1, T2, T3>(Slice prefix, ICompositeKeyEncoder<T1, T2, T3> encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			return new TypedKeySubspace<T1, T2, T3>(prefix, encoder, context ?? SubspaceContext.Default);
@@ -138,14 +136,14 @@ namespace FoundationDB.Client
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a typed key <paramref name="encoding"/>.</summary>
 		/// <returns>A subspace that can handle composite keys of type (<typeparamref name="T1"/>, <typeparamref name="T2"/>, <typeparamref name="T3"/>).</returns>
-		public static ITypedKeySubspace<T1, T2, T3, T4> CreateTyped<T1, T2, T3, T4>(Slice prefix, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		public static ITypedKeySubspace<T1, T2, T3, T4> CreateTyped<T1, T2, T3, T4>(Slice prefix, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			return new TypedKeySubspace<T1, T2, T3, T4>(prefix, (encoding ?? TuPack.Encoding).GetKeyEncoder<T1, T2, T3, T4>(), context ?? SubspaceContext.Default);
 		}
 
 		/// <summary>Initializes a new subspace with the given binary <paramref name="prefix"/>, that uses a typed key <paramref name="encoder"/>.</summary>
 		/// <returns>A subspace that can handle composite keys of type (<typeparamref name="T1"/>, <typeparamref name="T2"/>, <typeparamref name="T3"/>).</returns>
-		public static ITypedKeySubspace<T1, T2, T3, T4> CreateTyped<T1, T2, T3, T4>(Slice prefix, [NotNull] ICompositeKeyEncoder<T1, T2, T3, T4> encoder, [CanBeNull] ISubspaceContext context = null)
+		public static ITypedKeySubspace<T1, T2, T3, T4> CreateTyped<T1, T2, T3, T4>(Slice prefix, ICompositeKeyEncoder<T1, T2, T3, T4> encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(encoder, nameof(encoder));
 			return new TypedKeySubspace<T1, T2, T3, T4>(prefix, encoder, context ?? SubspaceContext.Default);
@@ -153,14 +151,14 @@ namespace FoundationDB.Client
 
 		#endregion
 
-		internal KeySubspace(Slice prefix, [NotNull] ISubspaceContext context)
+		internal KeySubspace(Slice prefix, ISubspaceContext context)
 		{
 			this.Key = prefix;
 			this.Range = KeyRange.StartsWith(prefix);
 			this.Context = context ?? throw new ArgumentNullException(nameof(context));
 		}
 
-		internal KeySubspace(Slice prefix, KeyRange range, [NotNull] ISubspaceContext context)
+		internal KeySubspace(Slice prefix, KeyRange range, ISubspaceContext context)
 		{
 			this.Key = prefix;
 			this.Range = range;
@@ -278,7 +276,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Test if both subspaces have the same prefix</summary>
-		public bool Equals(IKeySubspace other)
+		public bool Equals(IKeySubspace? other)
 		{
 			if (other == null) return false;
 			if (object.ReferenceEquals(this, other)) return true;
@@ -289,7 +287,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Test if an object is a subspace with the same prefix</summary>
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			return Equals(obj as KeySubspace);
 		}
@@ -374,7 +372,6 @@ namespace FoundationDB.Client
 		/// <summary>Return a user-friendly representation of a key from this subspace</summary>
 		/// <param name="key">Key that is contained in this subspace</param>
 		/// <returns>Printable version of this key, minus the subspace prefix</returns>
-		[NotNull]
 		public virtual string DumpKey(Slice key)
 		{
 			// note: we can't use ExtractAndCheck(...) because it may throw in derived classes

--- a/FoundationDB.Client/Subspaces/KeySubspaceExtensions.cs
+++ b/FoundationDB.Client/Subspaces/KeySubspaceExtensions.cs
@@ -48,8 +48,8 @@ namespace FoundationDB.Client
 		/// <param name="subspace">Instance of a generic subspace</param>
 		/// <param name="context">If non-null, overrides the current subspace context.</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static IBinaryKeySubspace AsBinary([NotNull] this IKeySubspace subspace, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static IBinaryKeySubspace AsBinary(this IKeySubspace subspace, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			if (subspace is IBinaryKeySubspace bin && (context == null || context == bin.Context))
@@ -64,8 +64,8 @@ namespace FoundationDB.Client
 		/// <param name="encoding">If non-null, uses this specific instance of the TypeSystem. If null, uses the default instance for this particular TypeSystem</param>
 		/// <param name="context">If non-null, overrides the current subspace context.</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static IDynamicKeySubspace AsDynamic([NotNull] this IKeySubspace subspace, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static IDynamicKeySubspace AsDynamic(this IKeySubspace subspace, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			if (subspace is IDynamicKeySubspace dyn && (context == null || context == dyn.Context) && (encoding == null || encoding == dyn.KeyEncoder.Encoding))
@@ -80,8 +80,8 @@ namespace FoundationDB.Client
 		/// <param name="encoding">Encoding by the keys of this subspace. If not specified, the <see cref="TuPack">Tuple Encoding</see> will be used to generate an encoder.</param>
 		/// <param name="context">If non-null, overrides the current subspace context.</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static ITypedKeySubspace<T> AsTyped<T>([NotNull] this IKeySubspace subspace, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static ITypedKeySubspace<T> AsTyped<T>(this IKeySubspace subspace, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			if (subspace is ITypedKeySubspace<T> typed && (context == null || context == typed.Context) && encoding == null)
@@ -96,8 +96,8 @@ namespace FoundationDB.Client
 		/// <param name="encoding">Encoding used by the keys of this subspace. If not specified, the <see cref="TuPack">Tuple Encoding</see> will be used to generate an encoder.</param>
 		/// <param name="context">If non-null, overrides the current subspace context.</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static ITypedKeySubspace<T1, T2> AsTyped<T1, T2>([NotNull] this IKeySubspace subspace, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static ITypedKeySubspace<T1, T2> AsTyped<T1, T2>(this IKeySubspace subspace, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			if (subspace is ITypedKeySubspace<T1, T2> typed && (context == null || context == typed.Context) && encoding == null)
@@ -112,8 +112,8 @@ namespace FoundationDB.Client
 		/// <param name="encoding">Encoding used by the keys of this subspace. If not specified, the <see cref="TuPack">Tuple Encoding</see> will be used to generate an encoder.</param>
 		/// <param name="context">If non-null, overrides the current subspace context.</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static ITypedKeySubspace<T1, T2, T3> AsTyped<T1, T2, T3>([NotNull] this IKeySubspace subspace, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static ITypedKeySubspace<T1, T2, T3> AsTyped<T1, T2, T3>(this IKeySubspace subspace, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			if (subspace is ITypedKeySubspace<T1, T2, T3> typed && (context == null || context == typed.Context) && encoding == null)
@@ -128,8 +128,8 @@ namespace FoundationDB.Client
 		/// <param name="encoding">Encoding used by the keys of this namespace. If not specified, the <see cref="TuPack">Tuple Encoding</see> will be used to generate an encoder.</param>
 		/// <param name="context">If non-null, overrides the current subspace context.</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static ITypedKeySubspace<T1, T2, T3, T4> AsTyped<T1, T2, T3, T4>([NotNull] this IKeySubspace subspace, [CanBeNull] IKeyEncoding encoding = null, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static ITypedKeySubspace<T1, T2, T3, T4> AsTyped<T1, T2, T3, T4>(this IKeySubspace subspace, IKeyEncoding? encoding = null, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			if (subspace is ITypedKeySubspace<T1, T2, T3, T4> typed && (context == null || context == typed.Context) && encoding == null)
@@ -147,8 +147,8 @@ namespace FoundationDB.Client
 		/// <param name="subspace">Instance of a generic subspace to extend</param>
 		/// <param name="encoder">Custom key encoder</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static IDynamicKeySubspace UsingEncoder([NotNull] this IKeySubspace subspace, [NotNull] IDynamicKeyEncoder encoder, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static IDynamicKeySubspace UsingEncoder(this IKeySubspace subspace, IDynamicKeyEncoder encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(encoder, nameof(encoder));
@@ -159,8 +159,8 @@ namespace FoundationDB.Client
 		/// <param name="subspace">Instance of a generic subspace to extend</param>
 		/// <param name="encoder">Custom key encoder</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static ITypedKeySubspace<T> UsingEncoder<T>([NotNull] this IKeySubspace subspace, [NotNull] IKeyEncoder<T> encoder, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static ITypedKeySubspace<T> UsingEncoder<T>(this IKeySubspace subspace, IKeyEncoder<T> encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(encoder, nameof(encoder));
@@ -171,8 +171,8 @@ namespace FoundationDB.Client
 		/// <param name="subspace">Instance of a generic subspace to extend</param>
 		/// <param name="encoder">Custom key encoder</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static ITypedKeySubspace<T1, T2> UsingEncoder<T1, T2>([NotNull] this IKeySubspace subspace, [NotNull] ICompositeKeyEncoder<T1, T2> encoder, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static ITypedKeySubspace<T1, T2> UsingEncoder<T1, T2>(this IKeySubspace subspace, ICompositeKeyEncoder<T1, T2> encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(encoder, nameof(encoder));
@@ -183,8 +183,8 @@ namespace FoundationDB.Client
 		/// <param name="subspace">Instance of a generic subspace to extend</param>
 		/// <param name="encoder">Custom key encoder</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static ITypedKeySubspace<T1, T2, T3> UsingEncoder<T1, T2, T3>([NotNull] this IKeySubspace subspace, [NotNull] ICompositeKeyEncoder<T1, T2, T3> encoder, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static ITypedKeySubspace<T1, T2, T3> UsingEncoder<T1, T2, T3>(this IKeySubspace subspace, ICompositeKeyEncoder<T1, T2, T3> encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(encoder, nameof(encoder));
@@ -195,8 +195,8 @@ namespace FoundationDB.Client
 		/// <param name="subspace">Instance of a generic subspace</param>
 		/// <param name="encoder">Encoder used to serialize the keys of this namespace.</param>
 		/// <returns>Subspace equivalent to <paramref name="subspace"/>, but augmented with a specific TypeSystem</returns>
-		[Pure, NotNull]
-		public static ITypedKeySubspace<T1, T2, T3, T4> UsingEncoder<T1, T2, T3, T4>([NotNull] this IKeySubspace subspace, [NotNull] ICompositeKeyEncoder<T1, T2, T3, T4> encoder, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static ITypedKeySubspace<T1, T2, T3, T4> UsingEncoder<T1, T2, T3, T4>(this IKeySubspace subspace, ICompositeKeyEncoder<T1, T2, T3, T4> encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(encoder, nameof(encoder));
@@ -209,7 +209,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Create a new copy of a subspace's prefix</summary>
 		[Pure]
-		internal static Slice StealPrefix([NotNull] IKeySubspace subspace)
+		internal static Slice StealPrefix(IKeySubspace subspace)
 		{
 			//note: we can workaround the 'security' in top directory partition by accessing their key prefix without triggering an exception!
 			return subspace is KeySubspace ks
@@ -218,8 +218,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a copy of a generic subspace, sharing the same binary prefix</summary>
-		[Pure, NotNull]
-		public static KeySubspace Copy([NotNull] this IKeySubspace subspace)
+		[Pure]
+		public static KeySubspace Copy(this IKeySubspace subspace)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 
@@ -235,8 +235,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a copy of a generic subspace, sharing the same binary prefix</summary>
-		[Pure, NotNull]
-		public static DynamicKeySubspace Copy([NotNull] this IKeySubspace subspace, IDynamicKeyEncoding encoding, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static DynamicKeySubspace Copy(this IKeySubspace subspace, IDynamicKeyEncoding encoding, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(encoding, nameof(encoding));
@@ -244,8 +244,8 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a copy of a generic subspace, sharing the same binary prefix</summary>
-		[Pure, NotNull]
-		public static DynamicKeySubspace Copy([NotNull] this IKeySubspace subspace, IDynamicKeyEncoder encoder, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static DynamicKeySubspace Copy(this IKeySubspace subspace, IDynamicKeyEncoder encoder, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			Contract.NotNull(encoder, nameof(encoder));
@@ -253,40 +253,40 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Create a copy of a dynamic subspace, sharing the same binary prefix and encoder</summary>
-		[Pure, NotNull]
-		public static DynamicKeySubspace Copy([NotNull] this IDynamicKeySubspace subspace, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static DynamicKeySubspace Copy(this IDynamicKeySubspace subspace, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			return new DynamicKeySubspace(StealPrefix(subspace), subspace.KeyEncoder, context ?? subspace.Context);
 		}
 
 		/// <summary>Create a copy of a typed subspace, sharing the same binary prefix and encoder</summary>
-		[Pure, NotNull]
-		public static TypedKeySubspace<T1> Copy<T1>([NotNull] this ITypedKeySubspace<T1> subspace, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static TypedKeySubspace<T1> Copy<T1>(this ITypedKeySubspace<T1> subspace, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			return new TypedKeySubspace<T1>(StealPrefix(subspace), subspace.KeyEncoder, context ?? subspace.Context);
 		}
 
 		/// <summary>Create a copy of a typed subspace, sharing the same binary prefix and encoder</summary>
-		[Pure, NotNull]
-		public static TypedKeySubspace<T1, T2> Copy<T1, T2>([NotNull] this ITypedKeySubspace<T1, T2> subspace, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static TypedKeySubspace<T1, T2> Copy<T1, T2>(this ITypedKeySubspace<T1, T2> subspace, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			return new TypedKeySubspace<T1, T2>(StealPrefix(subspace), subspace.KeyEncoder, context ?? subspace.Context);
 		}
 
 		/// <summary>Create a copy of a typed subspace, sharing the same binary prefix and encoder</summary>
-		[Pure, NotNull]
-		public static TypedKeySubspace<T1, T2, T3> Copy<T1, T2, T3>([NotNull] this ITypedKeySubspace<T1, T2, T3> subspace, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static TypedKeySubspace<T1, T2, T3> Copy<T1, T2, T3>(this ITypedKeySubspace<T1, T2, T3> subspace, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			return new TypedKeySubspace<T1, T2, T3>(StealPrefix(subspace), subspace.KeyEncoder, context ?? subspace.Context);
 		}
 
 		/// <summary>Create a copy of a typed subspace, sharing the same binary prefix and encoder</summary>
-		[Pure, NotNull]
-		public static TypedKeySubspace<T1, T2, T3, T4> Copy<T1, T2, T3, T4>([NotNull] this ITypedKeySubspace<T1, T2, T3, T4> subspace, [CanBeNull] ISubspaceContext context = null)
+		[Pure]
+		public static TypedKeySubspace<T1, T2, T3, T4> Copy<T1, T2, T3, T4>(this ITypedKeySubspace<T1, T2, T3, T4> subspace, ISubspaceContext? context = null)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 			return new TypedKeySubspace<T1, T2, T3, T4>(StealPrefix(subspace), subspace.KeyEncoder, context ?? subspace.Context);
@@ -322,7 +322,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Clear the entire content of a subspace</summary>
-		public static void ClearRange(this IFdbTransaction trans, [NotNull] IKeySubspace subspace)
+		public static void ClearRange(this IFdbTransaction trans, IKeySubspace subspace)
 		{
 			Contract.Requires(trans != null && subspace != null);
 
@@ -331,7 +331,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Clear the entire content of a subspace</summary>
-		public static Task ClearRangeAsync(this IFdbRetryable db, [NotNull] IKeySubspace subspace, CancellationToken ct)
+		public static Task ClearRangeAsync(this IFdbRetryable db, IKeySubspace subspace, CancellationToken ct)
 		{
 			Contract.NotNull(db, nameof(db));
 			Contract.NotNull(subspace, nameof(subspace));
@@ -340,9 +340,9 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Returns all the keys inside of a subspace</summary>
-		[Pure, NotNull]
+		[Pure]
 		[Obsolete("This method will be removed soon. Replace with 'trans.GetRange(subspace.ToRange(), ...)'")]
-		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRangeStartsWith(this IFdbReadOnlyTransaction trans, [NotNull] IKeySubspace subspace, FdbRangeOptions? options = null)
+		public static FdbRangeQuery<KeyValuePair<Slice, Slice>> GetRangeStartsWith(this IFdbReadOnlyTransaction trans, IKeySubspace subspace, FdbRangeOptions? options = null)
 		{
 			//REVIEW: should we remove this method?
 			Contract.Requires(trans != null && subspace != null);

--- a/FoundationDB.Client/Subspaces/SubspaceContext.cs
+++ b/FoundationDB.Client/Subspaces/SubspaceContext.cs
@@ -39,7 +39,6 @@ namespace FoundationDB.Client
 		/// <remarks>Should throw an exception if the context is in an invalid state</remarks>
 		void EnsureIsValid();
 
-		[NotNull]
 		string Name { get; }
 	}
 
@@ -47,7 +46,6 @@ namespace FoundationDB.Client
 	{
 		private SubspaceContext() { }
 
-		[NotNull]
 		public static readonly ISubspaceContext Default = new SubspaceContext();
 
 		public void EnsureIsValid()

--- a/FoundationDB.Client/Subspaces/SubspaceLocation.cs
+++ b/FoundationDB.Client/Subspaces/SubspaceLocation.cs
@@ -58,7 +58,7 @@ namespace FoundationDB.Client
 		/// <remarks>The default is to use the <see cref="TuPack"/> encoding, but it can be any other custom encoding.</remarks>
 		IKeyEncoding Encoding { get; }
 
-		ValueTask<IKeySubspace> Resolve(IFdbReadOnlyTransaction tr, [CanBeNull] FdbDirectoryLayer directory = null);
+		ValueTask<IKeySubspace> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null);
 	}
 
 	/// <summary>Represents the path to a typed subspace in the database</summary>
@@ -74,7 +74,7 @@ namespace FoundationDB.Client
 		/// The instance resolved for this transaction SHOULD NOT be used in the context of a different transaction, because its location in the Directory Layer may have been changed concurrently!
 		/// Re-using cached subspace instances MAY lead to DATA CORRUPTION if not used carefully! The best practice is to re-<see cref="Resolve"/>() the subspace again in each new transaction opened.
 		/// </remarks>
-		new ValueTask<TSubspace> Resolve(IFdbReadOnlyTransaction tr, [CanBeNull] FdbDirectoryLayer directory = null);
+		new ValueTask<TSubspace> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null);
 	}
 
 	/// <summary>Default implementation of a subspace location</summary>
@@ -114,12 +114,12 @@ namespace FoundationDB.Client
 
 		protected bool IsTopLevel => this.Path.Count == 0;
 
-		async ValueTask<IKeySubspace> ISubspaceLocation.Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory)
+		async ValueTask<IKeySubspace> ISubspaceLocation.Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory)
 		{
 			return await Resolve(tr, directory);
 		}
 
-		public abstract ValueTask<TSubspace> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory = null);
+		public abstract ValueTask<TSubspace> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null);
 
 		public override bool Equals(object obj) => obj is ISubspaceLocation path && Equals(path);
 
@@ -149,7 +149,7 @@ namespace FoundationDB.Client
 			object.ReferenceEquals(other, this)
 			|| (other is BinaryKeySubspaceLocation bin && bin.Path == this.Path && bin.Prefix == other.Prefix);
 
-		public override ValueTask<IBinaryKeySubspace> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory = null)
+		public override ValueTask<IBinaryKeySubspace> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null)
 		{
 			if (this.IsTopLevel)
 			{ // not contained in a directory subspace
@@ -158,7 +158,7 @@ namespace FoundationDB.Client
 			return ResolveWithDirectory(tr, directory);
 		}
 
-		private async ValueTask<IBinaryKeySubspace> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory)
+		private async ValueTask<IBinaryKeySubspace?> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory)
 		{
 			// located inside a directory subspace!
 			var folder = await (directory ?? tr.Context.Database.DirectoryLayer).TryOpenCachedAsync(tr, this.Path);
@@ -207,7 +207,7 @@ namespace FoundationDB.Client
 			object.ReferenceEquals(other, this)
 			|| (other is DynamicKeySubspaceLocation dyn && dyn.Encoding == this.Encoding && dyn.Path == this.Path && dyn.Prefix == other.Prefix);
 
-		public override ValueTask<IDynamicKeySubspace> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory = null)
+		public override ValueTask<IDynamicKeySubspace> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null)
 		{
 			Contract.NotNull(tr, nameof(tr));
 
@@ -219,7 +219,7 @@ namespace FoundationDB.Client
 			return ResolveWithDirectory(tr, directory);
 		}
 
-		private async ValueTask<IDynamicKeySubspace> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory)
+		private async ValueTask<IDynamicKeySubspace> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory)
 		{
 			// located inside a directory subspace!
 			var folder = await (directory ?? tr.Context.Database.DirectoryLayer).TryOpenCachedAsync(tr, this.Path);
@@ -276,7 +276,7 @@ namespace FoundationDB.Client
 			|| (other is TypedKeySubspaceLocation<T1> typed && typed.Encoding == this.Encoding && typed.Path == this.Path && typed.Prefix == other.Prefix);
 		
 		/// <inheritdoc/>
-		public override ValueTask<ITypedKeySubspace<T1>> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory = null)
+		public override ValueTask<ITypedKeySubspace<T1>> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null)
 		{
 			Contract.NotNull(tr, nameof(tr));
 
@@ -289,7 +289,7 @@ namespace FoundationDB.Client
 			return ResolveWithDirectory(tr, directory);
 		}
 
-		private async ValueTask<ITypedKeySubspace<T1>> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory)
+		private async ValueTask<ITypedKeySubspace<T1>> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory)
 		{
 			Contract.Requires(this.Path.Count != 0);
 
@@ -328,7 +328,7 @@ namespace FoundationDB.Client
 			|| (other is TypedKeySubspaceLocation<T1, T2> typed && typed.Encoding == this.Encoding && typed.Path == this.Path && typed.Prefix == other.Prefix);
 
 		/// <inheritdoc/>
-		public override ValueTask<ITypedKeySubspace<T1, T2>> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory = null)
+		public override ValueTask<ITypedKeySubspace<T1, T2>> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null)
 		{
 			Contract.NotNull(tr, nameof(tr));
 
@@ -341,7 +341,7 @@ namespace FoundationDB.Client
 			return ResolveWithDirectory(tr, directory);
 		}
 
-		private async ValueTask<ITypedKeySubspace<T1, T2>> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory)
+		private async ValueTask<ITypedKeySubspace<T1, T2>> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory)
 		{
 			Contract.Requires(this.Path.Count != 0);
 
@@ -382,7 +382,7 @@ namespace FoundationDB.Client
 			object.ReferenceEquals(other, this)
 			|| (other is TypedKeySubspaceLocation<T1, T2, T3> typed && typed.Encoding == this.Encoding && typed.Path == this.Path && typed.Prefix == other.Prefix);
 
-		public override ValueTask<ITypedKeySubspace<T1, T2, T3>> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory = null)
+		public override ValueTask<ITypedKeySubspace<T1, T2, T3>> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null)
 		{
 			if (this.IsTopLevel)
 			{ // not contained in a directory subspace
@@ -393,7 +393,7 @@ namespace FoundationDB.Client
 			return ResolveWithDirectory(tr, directory);
 		}
 
-		private async ValueTask<ITypedKeySubspace<T1, T2, T3>> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory)
+		private async ValueTask<ITypedKeySubspace<T1, T2, T3>> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory)
 		{
 			Contract.Requires(tr != null && this.Path.Count != 0);
 
@@ -437,7 +437,7 @@ namespace FoundationDB.Client
 			object.ReferenceEquals(other, this)
 			|| (other is TypedKeySubspaceLocation<T1, T2, T3, T4> typed && typed.Encoding == this.Encoding && typed.Path == this.Path && typed.Prefix == other.Prefix);
 
-		public override ValueTask<ITypedKeySubspace<T1, T2, T3, T4>> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory = null)
+		public override ValueTask<ITypedKeySubspace<T1, T2, T3, T4>> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null)
 		{
 			if (this.IsTopLevel)
 			{ // not contained in a directory subspace
@@ -448,7 +448,7 @@ namespace FoundationDB.Client
 			return ResolveWithDirectory(tr, directory);
 		}
 
-		private async ValueTask<ITypedKeySubspace<T1, T2, T3, T4>> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer directory = null)
+		private async ValueTask<ITypedKeySubspace<T1, T2, T3, T4>> ResolveWithDirectory(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory)
 		{
 			Contract.Requires(tr != null && this.Path.Count != 0);
 
@@ -487,7 +487,7 @@ namespace FoundationDB.Client
 		/// <param name="encoding">If specified, change the encoding use by the current path. If <c>null</c>, inherit the current encoding</param>
 		/// <returns>A <see cref="DynamicKeySubspaceLocation"/> that points to a <see cref="IDynamicKeySubspace">dynamic key subspace</see></returns>
 		[Pure]
-		public static DynamicKeySubspaceLocation AsDynamic(this ISubspaceLocation self, IKeyEncoding encoding = null)
+		public static DynamicKeySubspaceLocation AsDynamic(this ISubspaceLocation self, IKeyEncoding? encoding = null)
 		{
 			if (self == null) throw new ArgumentNullException(nameof(self));
 
@@ -496,7 +496,7 @@ namespace FoundationDB.Client
 				if (encoding == null || encoding == ksp.Encoding) return ksp;
 			}
 
-			return new DynamicKeySubspaceLocation(self.Path, self.Prefix, (encoding ?? self.Encoding)?.GetDynamicKeyEncoder());
+			return new DynamicKeySubspaceLocation(self.Path, self.Prefix, (encoding ?? self.Encoding).GetDynamicKeyEncoder());
 		}
 
 		/// <summary>Return a dynamic version of the current path</summary>
@@ -521,7 +521,7 @@ namespace FoundationDB.Client
 		/// <typeparam name="T1">Type of the key</typeparam>
 		/// <param name="self">Existing subspace path</param>
 		/// <param name="encoding">If specified, change the encoding use by the current path. If <c>null</c>, inherit the current encoding</param>
-		public static TypedKeySubspaceLocation<T1> AsTyped<T1>(this ISubspaceLocation self, IKeyEncoding encoding = null)
+		public static TypedKeySubspaceLocation<T1> AsTyped<T1>(this ISubspaceLocation self, IKeyEncoding? encoding = null)
 		{
 			if (self == null) throw new ArgumentNullException(nameof(self));
 
@@ -555,7 +555,7 @@ namespace FoundationDB.Client
 		/// <typeparam name="T2">Type of the second part of the key</typeparam>
 		/// <param name="self">Existing subspace path</param>
 		/// <param name="encoding">If specified, change the encoding use by the current path. If <c>null</c>, inherit the current encoding</param>
-		public static TypedKeySubspaceLocation<T1, T2> AsTyped<T1, T2>(this ISubspaceLocation self, IKeyEncoding encoding = null)
+		public static TypedKeySubspaceLocation<T1, T2> AsTyped<T1, T2>(this ISubspaceLocation self, IKeyEncoding? encoding = null)
 		{
 			if (self == null) throw new ArgumentNullException(nameof(self));
 
@@ -591,7 +591,7 @@ namespace FoundationDB.Client
 		/// <typeparam name="T3">Type of the third part of the key</typeparam>
 		/// <param name="self">Existing subspace path</param>
 		/// <param name="encoding">If specified, change the encoding use by the current path. If <c>null</c>, inherit the current encoding</param>
-		public static TypedKeySubspaceLocation<T1, T2, T3> AsTyped<T1, T2, T3>(this ISubspaceLocation self, IKeyEncoding encoding = null)
+		public static TypedKeySubspaceLocation<T1, T2, T3> AsTyped<T1, T2, T3>(this ISubspaceLocation self, IKeyEncoding? encoding = null)
 		{
 			if (self == null) throw new ArgumentNullException(nameof(self));
 
@@ -678,7 +678,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Create a location that uses a fixed prefix given by a tuple</summary>
 		[Pure]
-		public static DynamicKeySubspaceLocation FromKey(IVarTuple items, IDynamicKeyEncoding encoding = null)
+		public static DynamicKeySubspaceLocation FromKey(IVarTuple items, IDynamicKeyEncoding? encoding = null)
 		{
 			var encoder = (encoding ?? TuPack.Encoding).GetDynamicKeyEncoder();
 			return new DynamicKeySubspaceLocation(encoder.Pack(items), encoder);
@@ -686,7 +686,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Create a location that uses a fixed prefix given by a tuple</summary>
 		[Pure]
-		public static DynamicKeySubspaceLocation FromKey(IVarTuple items, [CanBeNull] IDynamicKeyEncoder encoder)
+		public static DynamicKeySubspaceLocation FromKey(IVarTuple items, IDynamicKeyEncoder? encoder)
 		{
 			encoder ??= TuPack.Encoding.GetDynamicKeyEncoder();
 			return new DynamicKeySubspaceLocation(encoder.Pack(items), encoder);
@@ -694,14 +694,14 @@ namespace FoundationDB.Client
 
 		/// <summary>Create a location that uses a fixed binary prefix</summary>
 		[Pure]
-		public static DynamicKeySubspaceLocation FromKey(ReadOnlySpan<byte> key, IDynamicKeyEncoding encoding = null)
+		public static DynamicKeySubspaceLocation FromKey(ReadOnlySpan<byte> key, IDynamicKeyEncoding? encoding = null)
 		{
 			return new DynamicKeySubspaceLocation(Slice.Copy(key), (encoding ?? TuPack.Encoding).GetDynamicKeyEncoder());
 		}
 
 		/// <summary>Create a location that uses a fixed binary prefix</summary>
 		[Pure]
-		public static DynamicKeySubspaceLocation FromKey(Slice key, IDynamicKeyEncoding encoding = null)
+		public static DynamicKeySubspaceLocation FromKey(Slice key, IDynamicKeyEncoding? encoding = null)
 		{
 			if (key.IsNull) throw new ArgumentException("Key cannot be nil.", nameof(key));
 			return new DynamicKeySubspaceLocation(key, (encoding ?? TuPack.Encoding).GetDynamicKeyEncoder());
@@ -709,7 +709,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Create a location that uses a fixed binary prefix</summary>
 		[Pure]
-		public static DynamicKeySubspaceLocation FromKey(Slice key, [CanBeNull] IDynamicKeyEncoder encoder)
+		public static DynamicKeySubspaceLocation FromKey(Slice key, IDynamicKeyEncoder? encoder)
 		{
 			if (key.IsNull) throw new ArgumentException("Key cannot be nil.", nameof(key));
 			return new DynamicKeySubspaceLocation(key, encoder ?? TuPack.Encoding.GetDynamicKeyEncoder());

--- a/FoundationDB.Client/Subspaces/TypedKeySubspace`1.cs
+++ b/FoundationDB.Client/Subspaces/TypedKeySubspace`1.cs
@@ -44,7 +44,6 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Encoding used to generate and parse the keys of this subspace</summary>
-		[NotNull]
 		IKeyEncoder<T1> KeyEncoder { get; }
 
 		/// <summary>Encode a pair of values into a key in this subspace</summary>
@@ -83,7 +82,7 @@ namespace FoundationDB.Client
 	{
 		public IKeyEncoder<T1> KeyEncoder { get; }
 
-		internal TypedKeySubspace(Slice prefix, [NotNull] IKeyEncoder<T1> encoder, [NotNull] ISubspaceContext context)
+		internal TypedKeySubspace(Slice prefix, IKeyEncoder<T1> encoder, ISubspaceContext context)
 			: base(prefix, context)
 		{
 			Contract.Requires(encoder != null);
@@ -182,7 +181,7 @@ namespace FoundationDB.Client
 		}
 
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice Pack<T1, TTuple>(this ITypedKeySubspace<T1> self, [NotNull] TTuple tuple)
+		public static Slice Pack<T1, TTuple>(this ITypedKeySubspace<T1> self, TTuple tuple)
 			where TTuple : IVarTuple
 		{
 			return self.Encode(tuple.OfSize(1).Get<T1>(0));
@@ -193,14 +192,14 @@ namespace FoundationDB.Client
 		#region Encode()
 
 		/// <summary>Encode an array of items into an array of keys</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Slice[] Encode<T1>(this ITypedKeySubspace<T1> self, params T1[] items)
 		{
 			return self.KeyEncoder.EncodeKeys(self.GetPrefix(), items);
 		}
 
 		/// <summary>Encode an array of items into an array of keys</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<Slice> Encode<T1>(this ITypedKeySubspace<T1> self, IEnumerable<T1> items)
 		{
 			return self.KeyEncoder.EncodeKeys(self.GetPrefix(), items);

--- a/FoundationDB.Client/Subspaces/TypedKeySubspace`2.cs
+++ b/FoundationDB.Client/Subspaces/TypedKeySubspace`2.cs
@@ -45,7 +45,6 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Encoding used to generate and parse the keys of this subspace</summary>
-		[NotNull] 
 		ICompositeKeyEncoder<T1, T2> KeyEncoder { get; }
 
 		/// <summary>Encode a pair of values into a key in this subspace</summary>
@@ -98,7 +97,7 @@ namespace FoundationDB.Client
 	{
 		public ICompositeKeyEncoder<T1, T2> KeyEncoder { get; }
 
-		internal TypedKeySubspace(Slice prefix, [NotNull] ICompositeKeyEncoder<T1, T2> encoder, [NotNull] ISubspaceContext context)
+		internal TypedKeySubspace(Slice prefix, ICompositeKeyEncoder<T1, T2> encoder, ISubspaceContext context)
 			: base(prefix, context)
 		{
 			Contract.Requires(encoder != null);
@@ -254,7 +253,7 @@ namespace FoundationDB.Client
 		/// <param name="tuple">Tuple that must be of size 2</param>
 		/// <returns>Encoded key in this subspace</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Slice Pack<T1, T2, TTuple>(this ITypedKeySubspace<T1, T2> self, [NotNull] TTuple tuple)
+		public static Slice Pack<T1, T2, TTuple>(this ITypedKeySubspace<T1, T2> self, TTuple tuple)
 			where TTuple : IVarTuple
 		{
 			tuple.OfSize(2);
@@ -262,14 +261,14 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode an array of items into an array of keys</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Slice[] Pack<T1, T2>(this ITypedKeySubspace<T1, T2> self, params (T1, T2)[] items)
 		{
 			return self.KeyEncoder.EncodeKeys(self.GetPrefix(), items);
 		}
 
 		/// <summary>Encode an array of items into an array of keys</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<Slice> Pack<T1, T2>(this ITypedKeySubspace<T1, T2> self, IEnumerable<(T1, T2)> items)
 		{
 			return self.KeyEncoder.EncodeKeys(self.GetPrefix(), items);

--- a/FoundationDB.Client/Subspaces/TypedKeySubspace`3.cs
+++ b/FoundationDB.Client/Subspaces/TypedKeySubspace`3.cs
@@ -45,7 +45,6 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Encoding used to generate and parse the keys of this subspace</summary>
-		[NotNull] 
 		ICompositeKeyEncoder<T1, T2, T3> KeyEncoder { get; }
 
 		Slice this[T1 item1, T2 item2, T3 item3] { [Pure]  get; }
@@ -85,7 +84,7 @@ namespace FoundationDB.Client
 	{
 		public ICompositeKeyEncoder<T1, T2, T3> KeyEncoder { get; }
 
-		internal TypedKeySubspace(Slice prefix, [NotNull] ICompositeKeyEncoder<T1, T2, T3> encoder, [NotNull] ISubspaceContext context)
+		internal TypedKeySubspace(Slice prefix, ICompositeKeyEncoder<T1, T2, T3> encoder, ISubspaceContext context)
 			: base(prefix, context)
 		{
 			Contract.Requires(encoder != null);
@@ -244,14 +243,14 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode an array of items into an array of keys</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Slice[] Pack<T1, T2, T3>(this ITypedKeySubspace<T1, T2, T3> self, params (T1, T2, T3)[] items)
 		{
 			return self.KeyEncoder.EncodeKeys(self.GetPrefix(), items);
 		}
 
 		/// <summary>Encode an array of items into an array of keys</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<Slice> Pack<T1, T2, T3>(this ITypedKeySubspace<T1, T2, T3> self, IEnumerable<(T1, T2, T3)> items)
 		{
 			return self.KeyEncoder.EncodeKeys(self.GetPrefix(), items);

--- a/FoundationDB.Client/Subspaces/TypedKeySubspace`4.cs
+++ b/FoundationDB.Client/Subspaces/TypedKeySubspace`4.cs
@@ -45,7 +45,6 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Encoding used to generate and parse the keys of this subspace</summary>
-		[NotNull]
 		ICompositeKeyEncoder<T1, T2, T3, T4> KeyEncoder { get; }
 
 		Slice this[T1 item1, T2 item2, T3 item3, T4 item4] { get; }
@@ -93,7 +92,7 @@ namespace FoundationDB.Client
 	{
 		public ICompositeKeyEncoder<T1, T2, T3, T4> KeyEncoder { get; }
 
-		internal TypedKeySubspace(Slice prefix, [NotNull] ICompositeKeyEncoder<T1, T2, T3, T4> encoder, [NotNull] ISubspaceContext context)
+		internal TypedKeySubspace(Slice prefix, ICompositeKeyEncoder<T1, T2, T3, T4> encoder, ISubspaceContext context)
 			: base(prefix, context)
 		{
 			this.KeyEncoder = encoder;
@@ -274,14 +273,14 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Encode an array of items into an array of keys</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Slice[] Pack<T1, T2, T3, T4>(this ITypedKeySubspace<T1, T2, T3, T4> self, params (T1, T2, T3, T4)[] items)
 		{
 			return self.KeyEncoder.EncodeKeys(self.GetPrefix(), items);
 		}
 
 		/// <summary>Encode an array of items into an array of keys</summary>
-		[Pure, NotNull, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<Slice> Pack<T1, T2, T3, T4>(this ITypedKeySubspace<T1, T2, T3, T4> self, IEnumerable<(T1, T2, T3, T4)> items)
 		{
 			return self.KeyEncoder.EncodeKeys(self.GetPrefix(), items);

--- a/FoundationDB.Client/Utils/Batched.cs
+++ b/FoundationDB.Client/Utils/Batched.cs
@@ -32,15 +32,13 @@ namespace FoundationDB
 	using System.Collections.Generic;
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Memory;
-	using JetBrains.Annotations;
 
 	internal static class Batched<TValue, TState>
 	{
 
 		public delegate void Handler(ref SliceWriter writer, TValue item, TState state);
 
-		[NotNull]
-		public static Slice[] Convert(SliceWriter writer, [NotNull, ItemNotNull] IEnumerable<TValue> values, Handler handler, TState state)
+		public static Slice[] Convert(SliceWriter writer, IEnumerable<TValue> values, Handler handler, TState state)
 		{
 			Contract.Requires(values != null && handler != null);
 

--- a/FoundationDB.DependencyInjection/FdbDatabaseProviderBuilderExtensions.cs
+++ b/FoundationDB.DependencyInjection/FdbDatabaseProviderBuilderExtensions.cs
@@ -38,8 +38,7 @@ namespace FoundationDB.DependencyInjection
 	public static class FdbDatabaseProviderBuilderExtensions
 	{
 
-		[NotNull]
-		public static IFdbDatabaseProviderBuilder WithApiVersion([NotNull] this IFdbDatabaseProviderBuilder builder, int apiVersion)
+		public static IFdbDatabaseProviderBuilder WithApiVersion(this IFdbDatabaseProviderBuilder builder, int apiVersion)
 		{
 			Contract.GreaterThan(apiVersion, 0, nameof(apiVersion));
 			builder.Services.Configure<FdbDatabaseProviderOptions>(c =>
@@ -49,8 +48,7 @@ namespace FoundationDB.DependencyInjection
 			return builder;
 		}
 
-		[NotNull]
-		public static IFdbDatabaseProviderBuilder WithConnectionString([NotNull] this IFdbDatabaseProviderBuilder builder, [NotNull] FdbConnectionOptions options)
+		public static IFdbDatabaseProviderBuilder WithConnectionString(this IFdbDatabaseProviderBuilder builder, FdbConnectionOptions options)
 		{
 			Contract.NotNull(options, nameof(options));
 			builder.Services.Configure<FdbDatabaseProviderOptions>(c =>
@@ -60,8 +58,7 @@ namespace FoundationDB.DependencyInjection
 			return builder;
 		}
 
-		[NotNull]
-		public static IFdbDatabaseProviderBuilder WithClusterFile([NotNull] this IFdbDatabaseProviderBuilder builder, [CanBeNull] string clusterFile)
+		public static IFdbDatabaseProviderBuilder WithClusterFile(this IFdbDatabaseProviderBuilder builder, string? clusterFile)
 		{
 			builder.Services.Configure<FdbDatabaseProviderOptions>(c =>
 			{

--- a/FoundationDB.DependencyInjection/FdbDatabaseServiceCollectionExtensions.cs
+++ b/FoundationDB.DependencyInjection/FdbDatabaseServiceCollectionExtensions.cs
@@ -38,8 +38,7 @@ namespace FoundationDB.DependencyInjection
 	public static class FdbDatabaseServiceCollectionExtensions
 	{
 
-		[NotNull]
-		public static IFdbDatabaseProviderBuilder AddFoundationDb([NotNull] this IServiceCollection services, int apiVersion)
+		public static IFdbDatabaseProviderBuilder AddFoundationDb(this IServiceCollection services, int apiVersion)
 		{
 			Contract.NotNull(services, nameof(services));
 			Contract.GreaterThan(apiVersion, 0, nameof(apiVersion));
@@ -49,8 +48,7 @@ namespace FoundationDB.DependencyInjection
 			return new FdbDefaultDatabaseProviderBuilder(services);
 		}
 
-		[NotNull]
-		public static IServiceCollection AddFoundationDb([NotNull] this IServiceCollection services, int apiVersion, Action<FdbDatabaseProviderOptions> configure)
+		public static IServiceCollection AddFoundationDb(this IServiceCollection services, int apiVersion, Action<FdbDatabaseProviderOptions> configure)
 		{
 			Contract.NotNull(services, nameof(services));
 			Contract.GreaterThan(apiVersion, 0, nameof(apiVersion));

--- a/FoundationDB.DependencyInjection/IFdbDatabaseProviderBuilder.cs
+++ b/FoundationDB.DependencyInjection/IFdbDatabaseProviderBuilder.cs
@@ -29,14 +29,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace FoundationDB.DependencyInjection
 {
 	using System;
-	using JetBrains.Annotations;
 	using Microsoft.Extensions.DependencyInjection;
 
 	public interface IFdbDatabaseProviderBuilder
 	{
 
-		[NotNull]
 		IServiceCollection Services { get; }
 
 	}
+
 }

--- a/FoundationDB.DependencyInjection/Implementation/FdbDatabaseProvider.cs
+++ b/FoundationDB.DependencyInjection/Implementation/FdbDatabaseProvider.cs
@@ -39,31 +39,28 @@ namespace FoundationDB.DependencyInjection
 	public sealed class FdbDatabaseProvider : IFdbDatabaseProvider
 	{
 
-		private IFdbDatabase Db { get; set; }
+		private IFdbDatabase? Db { get; set; }
 
 		public bool IsAvailable { get; private set; }
 
-		[NotNull]
 		public FdbDatabaseProviderOptions Options { get; }
 
-		private TaskCompletionSource<IFdbDatabase> InitTask;
+		private TaskCompletionSource<IFdbDatabase>? InitTask;
 
-		[NotNull]
 		private Task<IFdbDatabase> DbTask;
 
-		[NotNull]
 		private CancellationTokenSource LifeTime { get; } = new CancellationTokenSource();
 
-		private Exception Error { get; set;}
+		private Exception? Error { get; set;}
 
-		[Pure, NotNull]
-		public static IFdbDatabaseProvider Create([NotNull] FdbDatabaseProviderOptions options)
+		[Pure]
+		public static IFdbDatabaseProvider Create(FdbDatabaseProviderOptions options)
 		{
 			Contract.NotNull(options, nameof(options));
 			return new FdbDatabaseProvider(Microsoft.Extensions.Options.Options.Create(options));
 		}
 
-		public FdbDatabaseProvider([NotNull] IOptions<FdbDatabaseProviderOptions> optionsAccessor)
+		public FdbDatabaseProvider(IOptions<FdbDatabaseProviderOptions> optionsAccessor)
 		{
 			Contract.NotNull(optionsAccessor, nameof(optionsAccessor));
 			this.Options = optionsAccessor.Value;
@@ -113,7 +110,7 @@ namespace FoundationDB.DependencyInjection
 			SetDatabase(null, null);
 		}
 
-		public void SetDatabase(IFdbDatabase db, Exception e)
+		public void SetDatabase(IFdbDatabase? db, Exception? e)
 		{
 			this.Db = db;
 			this.Error = e;
@@ -156,7 +153,7 @@ namespace FoundationDB.DependencyInjection
 			Interlocked.Exchange(ref this.InitTask, null)?.TrySetCanceled();
 		}
 
-		IFdbDatabaseScopeProvider IFdbDatabaseScopeProvider.Parent => null;
+		IFdbDatabaseScopeProvider? IFdbDatabaseScopeProvider.Parent => null;
 
 		public CancellationToken Cancellation => this.LifeTime.Token;
 

--- a/FoundationDB.Layers.Common/Collections/FdbMap`2.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbMap`2.cs
@@ -35,20 +35,18 @@ namespace FoundationDB.Layers.Collections
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
-	using Doxense.Linq;
 	using Doxense.Serialization.Encoders;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	[DebuggerDisplay("Location={Location}")]
 	public class FdbMap<TKey, TValue>
 	{
 
-		public FdbMap([NotNull] ISubspaceLocation location, [NotNull] IValueEncoder<TValue> valueEncoder)
+		public FdbMap(ISubspaceLocation location, IValueEncoder<TValue> valueEncoder)
 			: this(location.AsTyped<TKey>(), valueEncoder)
 		{ }
 
-		public FdbMap([NotNull] TypedKeySubspaceLocation<TKey> location, [NotNull] IValueEncoder<TValue> valueEncoder)
+		public FdbMap(TypedKeySubspaceLocation<TKey> location, IValueEncoder<TValue> valueEncoder)
 		{
 			this.Location = location ?? throw new ArgumentNullException(nameof(location));
 			this.ValueEncoder = valueEncoder ?? throw new ArgumentNullException(nameof(valueEncoder));
@@ -57,11 +55,9 @@ namespace FoundationDB.Layers.Collections
 		#region Public Properties...
 
 		/// <summary>Subspace used to encoded the keys for the items</summary>
-		[NotNull]
 		public TypedKeySubspaceLocation<TKey> Location { get; }
 
 		/// <summary>Class that can serialize/deserialize values into/from slices</summary>
-		[NotNull]
 		public IValueEncoder<TValue> ValueEncoder { get; }
 
 		#endregion
@@ -88,7 +84,7 @@ namespace FoundationDB.Layers.Collections
 			/// <returns>Value of the entry if it exists; otherwise, throws an exception</returns>
 			/// <exception cref="System.ArgumentNullException">If either <paramref name="trans"/> or <paramref name="id"/> is null.</exception>
 			/// <exception cref="System.Collections.Generic.KeyNotFoundException">If the map does not contain an entry with this key.</exception>
-			public async Task<TValue> GetAsync([NotNull] IFdbReadOnlyTransaction trans, TKey id)
+			public async Task<TValue> GetAsync(IFdbReadOnlyTransaction trans, TKey id)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 				if (id == null) throw new ArgumentNullException(nameof(id));
@@ -103,7 +99,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="trans">Transaction used for the operation</param>
 			/// <param name="id">Key of the entry to read from the map</param>
 			/// <returns>Optional with the value of the entry it it exists, or an empty result if it is not present in the map.</returns>
-			public async Task<(TValue Value, bool HasValue)> TryGetAsync([NotNull] IFdbReadOnlyTransaction trans, TKey id)
+			public async Task<(TValue Value, bool HasValue)> TryGetAsync(IFdbReadOnlyTransaction trans, TKey id)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 				if (id == null) throw new ArgumentNullException(nameof(id));
@@ -119,7 +115,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="id">Key of the entry to add or update</param>
 			/// <param name="value">New value of the entry</param>
 			/// <remarks>If the entry did not exist, it will be created. If not, its value will be replace with <paramref name="value"/>.</remarks>
-			public void Set([NotNull] IFdbTransaction trans, TKey id, TValue value)
+			public void Set(IFdbTransaction trans, TKey id, TValue value)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 				if (id == null) throw new ArgumentNullException(nameof(id));
@@ -131,7 +127,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="trans">Transaction used for the operation</param>
 			/// <param name="id">Key of the entry to remove</param>
 			/// <remarks>If the entry did not exist, the operation will not do anything.</remarks>
-			public void Remove([NotNull] IFdbTransaction trans, TKey id)
+			public void Remove(IFdbTransaction trans, TKey id)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 				if (id == null) throw new ArgumentNullException(nameof(id));
@@ -144,8 +140,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="options"></param>
 			/// <returns>Async sequence of pairs of keys and values, ordered by keys ascending.</returns>
 			/// <remarks>CAUTION: This can be dangerous if the map contains a lot of entries! You should always use .Take() to limit the number of results returned.</remarks>
-			[NotNull]
-			public IAsyncEnumerable<KeyValuePair<TKey, TValue>> All([NotNull] IFdbReadOnlyTransaction trans, FdbRangeOptions? options = null)
+			public IAsyncEnumerable<KeyValuePair<TKey, TValue>> All(IFdbReadOnlyTransaction trans, FdbRangeOptions? options = null)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -158,7 +153,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="trans">Transaction used for the operation</param>
 			/// <param name="ids">List of the keys to read</param>
 			/// <returns>Array of results, in the same order as specified in <paramref name="ids"/>.</returns>
-			public async Task<TValue[]> GetValuesAsync([NotNull] IFdbReadOnlyTransaction trans, [NotNull] IEnumerable<TKey> ids)
+			public async Task<TValue[]> GetValuesAsync(IFdbReadOnlyTransaction trans, IEnumerable<TKey> ids)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 				if (ids == null) throw new ArgumentNullException(nameof(ids));
@@ -183,7 +178,7 @@ namespace FoundationDB.Layers.Collections
 			/// <summary>Clear all the entries in the map</summary>
 			/// <param name="trans">Transaction used for the operation</param>
 			/// <remarks>This will delete EVERYTHING in the map!</remarks>
-			public void Clear([NotNull] IFdbTransaction trans)
+			public void Clear(IFdbTransaction trans)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -201,7 +196,7 @@ namespace FoundationDB.Layers.Collections
 			/// <p>Other transactions may see a partial view of the map while the sequence is being imported. If this is a problem, you may need to import the map into a temporary subspace, and then 'publish' the final result using an indirection layer (like the Directory Layer)</p>
 			/// <p>If the import operation fails midway, all items that have already been successfully imported will be kept in the database.</p>
 			/// </remarks>
-			public Task ImportAsync([NotNull] IFdbDatabase db, [NotNull] IEnumerable<KeyValuePair<TKey, TValue>> items, CancellationToken ct)
+			public Task ImportAsync(IFdbDatabase db, IEnumerable<KeyValuePair<TKey, TValue>> items, CancellationToken ct)
 			{
 				if (db == null) throw new ArgumentNullException(nameof(db));
 				if (items == null) throw new ArgumentNullException(nameof(items));
@@ -224,7 +219,7 @@ namespace FoundationDB.Layers.Collections
 			/// <p>Other transactions may see a partial view of the map while the sequence is being imported. If this is a problem, you may need to import the map into a temporary subspace, and then 'publish' the final result using an indirection layer (like the Directory Layer)</p>
 			/// <p>If the import operation fails midway, all items that have already been successfully imported will be kept in the database.</p>
 			/// </remarks>
-			public Task ImportAsync([NotNull] IFdbDatabase db, [NotNull] IEnumerable<TValue> items, [NotNull] Func<TValue, TKey> keySelector, CancellationToken ct)
+			public Task ImportAsync(IFdbDatabase db, IEnumerable<TValue> items, Func<TValue, TKey> keySelector, CancellationToken ct)
 			{
 				if (db == null) throw new ArgumentNullException(nameof(db));
 				if (items == null) throw new ArgumentNullException(nameof(items));
@@ -249,7 +244,7 @@ namespace FoundationDB.Layers.Collections
 			/// <p>Other transactions may see a partial view of the map while the sequence is being imported. If this is a problem, you may need to import the map into a temporary subspace, and then 'publish' the final result using an indirection layer (like the Directory Layer)</p>
 			/// <p>If the import operation fails midway, all items that have already been successfully imported will be kept in the database.</p>
 			/// </remarks>
-			public Task ImportAsync<TElement>([NotNull] IFdbDatabase db, [NotNull] IEnumerable<TElement> items, [NotNull] Func<TElement, TKey> keySelector, [NotNull] Func<TElement, TValue> valueSelector, CancellationToken ct)
+			public Task ImportAsync<TElement>(IFdbDatabase db, IEnumerable<TElement> items, Func<TElement, TKey> keySelector, Func<TElement, TValue> valueSelector, CancellationToken ct)
 			{
 				if (db == null) throw new ArgumentNullException(nameof(db));
 				if (items == null) throw new ArgumentNullException(nameof(items));
@@ -285,7 +280,7 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="ct">Token used to cancel the operation.</param>
 		/// <returns>Task that completes once all the entries have been processed.</returns>
 		/// <remarks>This method does not guarantee that the export will be a complete and coherent snapshot of the map. Any change made to the map while the export is running may be partially exported.</remarks>
-		public Task ExportAsync([NotNull] IFdbDatabase db, [NotNull] Action<KeyValuePair<TKey, TValue>> handler, CancellationToken ct)
+		public Task ExportAsync(IFdbDatabase db, Action<KeyValuePair<TKey, TValue>> handler, CancellationToken ct)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 			if (handler == null) throw new ArgumentNullException(nameof(handler));
@@ -312,7 +307,7 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="ct">Token used to cancel the operation.</param>
 		/// <returns>Task that completes once all the entries have been processed.</returns>
 		/// <remarks>This method does not guarantee that the export will be a complete and coherent snapshot of the map. Any change made to the map while the export is running may be partially exported.</remarks>
-		public Task ExportAsync([NotNull] IFdbDatabase db, [NotNull] Func<KeyValuePair<TKey, TValue>, CancellationToken, Task> handler, CancellationToken ct)
+		public Task ExportAsync(IFdbDatabase db, Func<KeyValuePair<TKey, TValue>, CancellationToken, Task> handler, CancellationToken ct)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 			if (handler == null) throw new ArgumentNullException(nameof(handler));
@@ -338,7 +333,7 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="ct">Token used to cancel the operation.</param>
 		/// <returns>Task that completes once all the entries have been processed.</returns>
 		/// <remarks>This method does not guarantee that the export will be a complete and coherent snapshot of the map, except that all the items in a single batch are from the same snapshot. Any change made to the map while the export is running may be partially exported.</remarks>
-		public Task ExportAsync([NotNull] IFdbDatabase db, [NotNull] Action<KeyValuePair<TKey, TValue>[]> handler, CancellationToken ct)
+		public Task ExportAsync(IFdbDatabase db, Action<KeyValuePair<TKey, TValue>[]> handler, CancellationToken ct)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 			if (handler == null) throw new ArgumentNullException(nameof(handler));
@@ -364,7 +359,7 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="ct">Token used to cancel the operation.</param>
 		/// <returns>Task that completes once all the entries have been processed.</returns>
 		/// <remarks>This method does not guarantee that the export will be a complete and coherent snapshot of the map, except that all the items in a single batch are from the same snapshot. Any change made to the map while the export is running may be partially exported.</remarks>
-		public Task ExportAsync([NotNull] IFdbDatabase db, [NotNull] Func<KeyValuePair<TKey, TValue>[], CancellationToken, Task> handler, CancellationToken ct)
+		public Task ExportAsync(IFdbDatabase db, Func<KeyValuePair<TKey, TValue>[], CancellationToken, Task> handler, CancellationToken ct)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 			if (handler == null) throw new ArgumentNullException(nameof(handler));
@@ -384,7 +379,7 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="ct">Token used to cancel the operation.</param>
 		/// <returns>Task that completes once all the entries have been processed and return the result of the last call to <paramref name="handler"/> if there was at least one batch, or the result of <paramref name="init"/> if the map was empty.</returns>
 		/// <remarks>This method does not guarantee that the export will be a complete and coherent snapshot of the map, except that all the items in a single batch are from the same snapshot. Any change made to the map while the export is running may be partially exported.</remarks>
-		public async Task<TResult> AggregateAsync<TResult>([NotNull] IFdbDatabase db, Func<TResult> init, [NotNull] Func<TResult, KeyValuePair<TKey, TValue>[], TResult> handler, CancellationToken ct)
+		public async Task<TResult> AggregateAsync<TResult>(IFdbDatabase db, Func<TResult> init, Func<TResult, KeyValuePair<TKey, TValue>[], TResult> handler, CancellationToken ct)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 			if (handler == null) throw new ArgumentNullException(nameof(handler));
@@ -417,7 +412,7 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="ct">Token used to cancel the operation.</param>
 		/// <returns>Task that completes once all the entries have been processed and return the result of calling <paramref name="finish"/> with the state return by the last call to <paramref name="handler"/> if there was at least one batch, or the result of <paramref name="init"/> if the map was empty.</returns>
 		/// <remarks>This method does not guarantee that the export will be a complete and coherent snapshot of the map, except that all the items in a single batch are from the same snapshot. Any change made to the map while the export is running may be partially exported.</remarks>
-		public async Task<TResult> AggregateAsync<TState, TResult>([NotNull] IFdbDatabase db, Func<TState> init, [NotNull] Func<TState, KeyValuePair<TKey, TValue>[], TState> handler, Func<TState, TResult> finish, CancellationToken ct)
+		public async Task<TResult> AggregateAsync<TState, TResult>(IFdbDatabase db, Func<TState> init, Func<TState, KeyValuePair<TKey, TValue>[], TState> handler, Func<TState, TResult> finish, CancellationToken ct)
 		{
 			if (db == null) throw new ArgumentNullException(nameof(db));
 			if (handler == null) throw new ArgumentNullException(nameof(handler));
@@ -458,7 +453,6 @@ namespace FoundationDB.Layers.Collections
 			);
 		}
 
-		[NotNull]
 		private static KeyValuePair<TKey, TValue>[] DecodeItems(ITypedKeySubspace<TKey> subspace, IValueEncoder<TValue> valueEncoder, KeyValuePair<Slice, Slice>[] batch)
 		{
 			Contract.Requires(batch != null);

--- a/FoundationDB.Layers.Common/Collections/FdbMultimap`2.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbMultimap`2.cs
@@ -67,7 +67,6 @@ namespace FoundationDB.Layers.Collections
 		#region Public Properties...
 
 		/// <summary>Subspace used to encoded the keys for the items</summary>
-		[NotNull]
 		public TypedKeySubspaceLocation<TKey, TValue> Location { get; }
 
 		/// <summary>If true, allow negative or zero values to stay in the map.</summary>
@@ -96,7 +95,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="value">Value for the <paramref name="key"/> to increment</param>
 			/// <remarks>If the (index, value) pair does not exist, its value is considered to be 0</remarks>
 			/// <exception cref="System.ArgumentNullException">If <paramref name="trans"/> is null.</exception>
-			public Task AddAsync([NotNull] IFdbTransaction trans, TKey key, TValue value)
+			public Task AddAsync(IFdbTransaction trans, TKey key, TValue value)
 			{
 				//note: this method does not need to be async, but subtract is, so it's better if both methods have the same shape.
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
@@ -110,7 +109,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="key">Key of the entry</param>
 			/// <param name="value">Value for the <paramref name="key"/> to decrement</param>
 			/// <remarks>If the updated count reaches zero or less, and AllowNegativeValues is not set, the key will be cleared from the map.</remarks>
-			public async Task SubtractAsync([NotNull] IFdbTransaction trans, TKey key, TValue value)
+			public async Task SubtractAsync(IFdbTransaction trans, TKey key, TValue value)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -138,7 +137,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Checks if a (key, value) pair exists</summary>
-			public async Task<bool> ContainsAsync([NotNull] IFdbReadOnlyTransaction trans, TKey key, TValue value)
+			public async Task<bool> ContainsAsync(IFdbReadOnlyTransaction trans, TKey key, TValue value)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -152,7 +151,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="value"></param>
 			/// <returns>Value for this value, or null if the index does not contains that particular value</returns>
 			/// <remarks>The count can be zero or negative if AllowNegativeValues is enable.</remarks>
-			public async Task<long?> GetCountAsync([NotNull] IFdbReadOnlyTransaction trans, TKey key, TValue value)
+			public async Task<long?> GetCountAsync(IFdbReadOnlyTransaction trans, TKey key, TValue value)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -166,8 +165,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="trans"></param>
 			/// <param name="key"></param>
 			/// <returns></returns>
-			[NotNull]
-			public IAsyncEnumerable<TValue> Get([NotNull] IFdbReadOnlyTransaction trans, TKey key)
+			public IAsyncEnumerable<TValue> Get(IFdbReadOnlyTransaction trans, TKey key)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -191,7 +189,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="trans"></param>
 			/// <param name="key"></param>
 			/// <returns>List of values for this index, or an empty list if the index does not exist</returns>
-			public Task<List<TValue>> GetAsync([NotNull] IFdbReadOnlyTransaction trans, TKey key)
+			public Task<List<TValue>> GetAsync(IFdbReadOnlyTransaction trans, TKey key)
 			{
 				return Get(trans, key).ToListAsync();
 			}
@@ -200,8 +198,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="trans"></param>
 			/// <param name="key"></param>
 			/// <returns></returns>
-			[NotNull]
-			public IAsyncEnumerable<(TValue Value, long Count)> GetCounts([NotNull] IFdbReadOnlyTransaction trans, TKey key)
+			public IAsyncEnumerable<(TValue Value, long Count)> GetCounts(IFdbReadOnlyTransaction trans, TKey key)
 			{
 				var range = KeyRange.StartsWith(this.Subspace.EncodePartial(key));
 
@@ -219,7 +216,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="key"></param>
 			/// <param name="comparer"></param>
 			/// <returns></returns>
-			public Task<Dictionary<TValue, long>> GetCountsAsync([NotNull] IFdbReadOnlyTransaction trans, TKey key, IEqualityComparer<TValue> comparer = null)
+			public Task<Dictionary<TValue, long>> GetCountsAsync(IFdbReadOnlyTransaction trans, TKey key, IEqualityComparer<TValue>? comparer = null)
 			{
 				return GetCounts(trans, key).ToDictionaryAsync(x => x.Value, x => x.Count, comparer);
 			}
@@ -228,7 +225,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="trans"></param>
 			/// <param name="key"></param>
 			/// <returns></returns>
-			public void Remove([NotNull] IFdbTransaction trans, TKey key)
+			public void Remove(IFdbTransaction trans, TKey key)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -240,7 +237,7 @@ namespace FoundationDB.Layers.Collections
 			/// <param name="key"></param>
 			/// <param name="value"></param>
 			/// <returns></returns>
-			public void Remove([NotNull] IFdbTransaction trans, TKey key, TValue value)
+			public void Remove(IFdbTransaction trans, TKey key, TValue value)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 

--- a/FoundationDB.Layers.Common/Collections/FdbQueue`1.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbQueue`1.cs
@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace FoundationDB.Layers.Collections
 {
 	using System;
-	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Threading;
 	using System.Threading.Tasks;
@@ -39,7 +38,6 @@ namespace FoundationDB.Layers.Collections
 #if DEBUG
 	using FoundationDB.Filters.Logging;
 #endif
-	using JetBrains.Annotations;
 
 	/// <summary>Provides a high-contention Queue class</summary>
 	[DebuggerDisplay("Location={Location}")]
@@ -49,29 +47,27 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="location">Subspace where the queue will be stored</param>
 		/// <param name="encoder">Encoder for the values stored in this queue</param>
 		/// <remarks>Uses the default Tuple serializer</remarks>
-		public FdbQueue([NotNull] ISubspaceLocation location, IValueEncoder<T> encoder = null)
+		public FdbQueue(ISubspaceLocation location, IValueEncoder<T>? encoder = null)
 			: this(location.AsTyped<VersionStamp>(), encoder)
 		{ }
 
 		/// <summary>Create a new queue using either High Contention mode or Simple mode</summary>
 		/// <param name="location">Subspace where the queue will be stored</param>
 		/// <param name="encoder">Encoder for the values stored in this queue</param>
-		public FdbQueue([NotNull] TypedKeySubspaceLocation<VersionStamp> location, IValueEncoder<T> encoder = null)
+		public FdbQueue(TypedKeySubspaceLocation<VersionStamp> location, IValueEncoder<T>? encoder = null)
 		{
 			this.Location = location ?? throw new ArgumentNullException(nameof(location));
 			this.Encoder = encoder ?? TuPack.Encoding.GetValueEncoder<T>();
 		}
 
 		/// <summary>Subspace used as a prefix for all items in this table</summary>
-		[NotNull]
 		public TypedKeySubspaceLocation<VersionStamp> Location { get; }
 
 		/// <summary>Serializer for the elements of the queue</summary>
-		[NotNull]
 		public IValueEncoder<T> Encoder { get; }
 
 		/// <summary>Remove all items from the queue.</summary>
-		public async Task ClearAsync([NotNull] IFdbTransaction tr)
+		public async Task ClearAsync(IFdbTransaction tr)
 		{
 			if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -80,7 +76,7 @@ namespace FoundationDB.Layers.Collections
 		}
 
 		/// <summary>Push a single item onto the queue.</summary>
-		public async Task PushAsync([NotNull] IFdbTransaction tr, T value)
+		public async Task PushAsync(IFdbTransaction tr, T value)
 		{
 			if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -96,7 +92,7 @@ namespace FoundationDB.Layers.Collections
 		private static readonly FdbRangeOptions SingleOptions = new FdbRangeOptions() { Limit = 1, Mode = FdbStreamingMode.Exact };
 
 		/// <summary>Pop the next item from the queue. Cannot be composed with other functions in a single transaction.</summary>
-		public async Task<(T Value, bool HasValue)> PopAsync([NotNull] IFdbTransaction tr)
+		public async Task<(T Value, bool HasValue)> PopAsync(IFdbTransaction tr)
 		{
 			if (tr == null) throw new ArgumentNullException(nameof(tr));
 #if DEBUG
@@ -121,7 +117,7 @@ namespace FoundationDB.Layers.Collections
 		}
 
 		/// <summary>Test whether the queue is empty.</summary>
-		public async Task<bool> EmptyAsync([NotNull] IFdbReadOnlyTransaction tr)
+		public async Task<bool> EmptyAsync(IFdbReadOnlyTransaction tr)
 		{
 			var subspace = await this.Location.Resolve(tr);
 
@@ -130,7 +126,7 @@ namespace FoundationDB.Layers.Collections
 		}
 
 		/// <summary>Get the value of the next item in the queue without popping it.</summary>
-		public async Task<(T Value, bool HasValue)> PeekAsync([NotNull] IFdbReadOnlyTransaction tr)
+		public async Task<(T Value, bool HasValue)> PeekAsync(IFdbReadOnlyTransaction tr)
 		{
 			var subspace = await this.Location.Resolve(tr);
 

--- a/FoundationDB.Layers.Common/Collections/FdbRankedSet.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbRankedSet.cs
@@ -34,7 +34,6 @@ namespace FoundationDB.Layers.Collections
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Linq;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>
 	/// Provides a high-contention Queue class
@@ -46,13 +45,13 @@ namespace FoundationDB.Layers.Collections
 		private const int MAX_LEVELS = 6;
 		private const int LEVEL_FAN_POW = 4; // 2^X per level
 
-		public FdbRankedSet([NotNull] ISubspaceLocation location)
+		public FdbRankedSet(ISubspaceLocation location)
 			: this(location?.AsDynamic())
 		{ }
 
 		/// <summary>Initializes a new ranked set at a given location</summary>
 		/// <param name="location">Subspace where the set will be stored</param>
-		public FdbRankedSet([NotNull] DynamicKeySubspaceLocation location)
+		public FdbRankedSet(DynamicKeySubspaceLocation location)
 		{
 			this.Location = location ?? throw new ArgumentNullException(nameof(location));
 		}
@@ -64,7 +63,7 @@ namespace FoundationDB.Layers.Collections
 		private readonly Random Rng = new Random();
 
 		/// <summary>Make sure that the set is initialized</summary>
-		public async Task OpenAsync([NotNull] IFdbTransaction trans)
+		public async Task OpenAsync(IFdbTransaction trans)
 		{
 			//TODO: BUGBUG: this should be cached!
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
@@ -87,7 +86,7 @@ namespace FoundationDB.Layers.Collections
 			/// <summary>Returns the number of items in the set.</summary>
 			/// <param name="trans"></param>
 			/// <returns></returns>
-			public Task<long> SizeAsync([NotNull] IFdbReadOnlyTransaction trans)
+			public Task<long> SizeAsync(IFdbReadOnlyTransaction trans)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -97,7 +96,7 @@ namespace FoundationDB.Layers.Collections
 					.SumAsync();
 			}
 
-			public async Task InsertAsync([NotNull] IFdbTransaction trans, Slice key)
+			public async Task InsertAsync(IFdbTransaction trans, Slice key)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -135,7 +134,7 @@ namespace FoundationDB.Layers.Collections
 				}
 			}
 
-			public async Task<bool> ContainsAsync([NotNull] IFdbReadOnlyTransaction trans, Slice key)
+			public async Task<bool> ContainsAsync(IFdbReadOnlyTransaction trans, Slice key)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 				if (key.IsNull) throw new ArgumentException("Empty key not allowed in set", nameof(key));
@@ -143,7 +142,7 @@ namespace FoundationDB.Layers.Collections
 				return (await trans.GetAsync(this.Subspace.Encode(0, key)).ConfigureAwait(false)).HasValue;
 			}
 
-			public async Task EraseAsync([NotNull] IFdbTransaction trans, Slice key)
+			public async Task EraseAsync(IFdbTransaction trans, Slice key)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -169,7 +168,7 @@ namespace FoundationDB.Layers.Collections
 				}
 			}
 
-			public async Task<long?> Rank([NotNull] IFdbReadOnlyTransaction trans, Slice key)
+			public async Task<long?> Rank(IFdbReadOnlyTransaction trans, Slice key)
 			{
 				if (trans == null) throw new ArgumentNullException(nameof(trans));
 				if (key.IsNull) throw new ArgumentException("Empty key not allowed in set", nameof(key));
@@ -204,7 +203,7 @@ namespace FoundationDB.Layers.Collections
 				return r;
 			}
 
-			public async Task<Slice> GetNthAsync([NotNull] IFdbReadOnlyTransaction trans, long rank)
+			public async Task<Slice> GetNthAsync(IFdbReadOnlyTransaction trans, long rank)
 			{
 				if (rank < 0) return Slice.Nil;
 
@@ -238,7 +237,7 @@ namespace FoundationDB.Layers.Collections
 			//TODO: get_range
 
 			/// <summary>Clears the entire set.</summary>
-			public Task ClearAllAsync([NotNull] IFdbTransaction trans)
+			public Task ClearAllAsync(IFdbTransaction trans)
 			{
 				trans.ClearRange(this.Subspace.ToRange());
 				return SetupLevelsAsync(trans);

--- a/FoundationDB.Layers.Common/Collections/FdbVector`1.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbVector`1.cs
@@ -66,7 +66,7 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="location">Subspace where the vector will be stored</param>
 		/// <param name="defaultValue">Default value for sparse entries</param>
 		/// <param name="encoder">Encoder used for the values of this vector</param>
-		public FdbVector([NotNull] ISubspaceLocation location, T defaultValue = default, IValueEncoder<T> encoder = null)
+		public FdbVector(ISubspaceLocation location, T defaultValue = default, IValueEncoder<T>? encoder = null)
 			: this(location.AsDynamic(), defaultValue, encoder)
 		{ }
 
@@ -74,7 +74,7 @@ namespace FoundationDB.Layers.Collections
 		/// <param name="location">Subspace where the vector will be stored</param>
 		/// <param name="defaultValue">Default value for sparse entries</param>
 		/// <param name="encoder">Encoder used for the values of this vector</param>
-		public FdbVector([NotNull] DynamicKeySubspaceLocation location, T defaultValue, IValueEncoder<T> encoder = null)
+		public FdbVector(DynamicKeySubspaceLocation location, T defaultValue, IValueEncoder<T>? encoder = null)
 		{
 			Contract.NotNull(location, nameof(location));
 
@@ -85,13 +85,11 @@ namespace FoundationDB.Layers.Collections
 
 
 		/// <summary>Subspace used as a prefix for all items in this vector</summary>
-		[NotNull]
 		public DynamicKeySubspaceLocation Location { get; }
 
 		/// <summary>Default value for sparse entries</summary>
 		public T DefaultValue { get; }
 
-		[NotNull]
 		public IValueEncoder<T> Encoder { get; }
 
 		public sealed class State
@@ -106,12 +104,12 @@ namespace FoundationDB.Layers.Collections
 			internal State(IDynamicKeySubspace subspace, T defaultValue, IValueEncoder<T> encoder)
 			{
 				this.Subspace = subspace;
-				this.DefaultValue = default;
+				this.DefaultValue = defaultValue;
 				this.Encoder = encoder;
 			}
 
 			/// <summary>Get the number of items in the Vector. This number includes the sparsely represented items.</summary>
-			public Task<long> SizeAsync([NotNull] IFdbReadOnlyTransaction tr)
+			public Task<long> SizeAsync(IFdbReadOnlyTransaction tr)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -119,7 +117,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Push a single item onto the end of the Vector.</summary>
-			public async Task PushAsync([NotNull] IFdbTransaction tr, T value)
+			public async Task PushAsync(IFdbTransaction tr, T value)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -129,7 +127,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Get the value of the last item in the Vector.</summary>
-			public Task<T> BackAsync([NotNull] IFdbReadOnlyTransaction tr)
+			public Task<T> BackAsync(IFdbReadOnlyTransaction tr)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -140,13 +138,13 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Get the value of the first item in the Vector.</summary>
-			public Task<T> FrontAsync([NotNull] IFdbReadOnlyTransaction tr)
+			public Task<T> FrontAsync(IFdbReadOnlyTransaction tr)
 			{
 				return GetAsync(tr, 0);
 			}
 
 			/// <summary>Get and pops the last item off the Vector.</summary>
-			public async Task<(T Value, bool HasValue)> PopAsync([NotNull] IFdbTransaction tr)
+			public async Task<(T Value, bool HasValue)> PopAsync(IFdbTransaction tr)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -181,7 +179,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Swap the items at positions i1 and i2.</summary>
-			public async Task SwapAsync([NotNull] IFdbTransaction tr, long index1, long index2)
+			public async Task SwapAsync(IFdbTransaction tr, long index1, long index2)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -218,7 +216,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Get the item at the specified index.</summary>
-			public async Task<T> GetAsync([NotNull] IFdbReadOnlyTransaction tr, long index)
+			public async Task<T> GetAsync(IFdbReadOnlyTransaction tr, long index)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 				if (index < 0) throw new IndexOutOfRangeException($"Index {index} must be positive");
@@ -247,7 +245,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>[NOT YET IMPLEMENTED] Get a range of items in the Vector, returned as an async sequence.</summary>
-			public IAsyncEnumerable<T> GetRangeAsync([NotNull] IFdbReadOnlyTransaction tr, long startIndex, long endIndex, long step)
+			public IAsyncEnumerable<T> GetRangeAsync(IFdbReadOnlyTransaction tr, long startIndex, long endIndex, long step)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -257,7 +255,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Set the value at a particular index in the Vector.</summary>
-			public void Set([NotNull] IFdbTransaction tr, long index, T value)
+			public void Set(IFdbTransaction tr, long index, T value)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -265,7 +263,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Test whether the Vector is empty.</summary>
-			public async Task<bool> EmptyAsync([NotNull] IFdbReadOnlyTransaction tr)
+			public async Task<bool> EmptyAsync(IFdbReadOnlyTransaction tr)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -273,7 +271,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Grow or shrink the size of the Vector.</summary>
-			public async Task ResizeAsync([NotNull] IFdbTransaction tr, long length)
+			public async Task ResizeAsync(IFdbTransaction tr, long length)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 
@@ -296,7 +294,7 @@ namespace FoundationDB.Layers.Collections
 			}
 
 			/// <summary>Remove all items from the Vector.</summary>
-			public void Clear([NotNull] IFdbTransaction tr)
+			public void Clear(IFdbTransaction tr)
 			{
 				if (tr == null) throw new ArgumentNullException(nameof(tr));
 

--- a/FoundationDB.Layers.Common/Counters/FdbCounterMap.cs
+++ b/FoundationDB.Layers.Common/Counters/FdbCounterMap.cs
@@ -32,7 +32,6 @@ namespace FoundationDB.Layers.Counters
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Providers a dictionary of 64-bit counters that can be updated atomically</summary>
 	/// <typeparam name="TKey">Type of the key in the counter map</typeparam>
@@ -40,12 +39,12 @@ namespace FoundationDB.Layers.Counters
 	{
 
 		/// <summary>Create a new counter map.</summary>
-		public FdbCounterMap([NotNull] IKeySubspace subspace)
+		public FdbCounterMap(IKeySubspace subspace)
 			: this(subspace.AsTyped<TKey>())
 		{ }
 
 		/// <summary>Create a new counter map, using a specific key encoder.</summary>
-		public FdbCounterMap([NotNull] ITypedKeySubspace<TKey> subspace)
+		public FdbCounterMap(ITypedKeySubspace<TKey> subspace)
 		{
 			Contract.NotNull(subspace, nameof(subspace));
 
@@ -54,10 +53,8 @@ namespace FoundationDB.Layers.Counters
 		}
 
 		/// <summary>Subspace used as a prefix for all items in this counter list</summary>
-		[NotNull]
 		public IKeySubspace Subspace { get; }
 
-		[NotNull]
 		internal ITypedKeySubspace<TKey> Location { get; }
 
 		/// <summary>Add a value to a counter in one atomic operation</summary>
@@ -65,7 +62,7 @@ namespace FoundationDB.Layers.Counters
 		/// <param name="counterKey">Key of the counter, relative to the list's subspace</param>
 		/// <param name="value">Value that will be added</param>
 		/// <remarks>This operation will not cause the current transaction to conflict. It may create conflicts for transactions that would read the value of the counter.</remarks>
-		public void Add([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey, long value)
+		public void Add(IFdbTransaction transaction, TKey counterKey, long value)
 		{
 			if (transaction == null) throw new ArgumentNullException(nameof(transaction));
 			if (counterKey == null) throw new ArgumentNullException(nameof(counterKey));
@@ -79,7 +76,7 @@ namespace FoundationDB.Layers.Counters
 		/// <param name="counterKey">Key of the counter, relative to the list's subspace</param>
 		/// <param name="value">Value that will be subtracted. If the value is zero</param>
 		/// <remarks>This operation will not cause the current transaction to conflict. It may create conflicts for transactions that would read the value of the counter.</remarks>
-		public void Subtract([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey, long value)
+		public void Subtract(IFdbTransaction transaction, TKey counterKey, long value)
 		{
 			Add(transaction, counterKey, -value);
 		}
@@ -88,7 +85,7 @@ namespace FoundationDB.Layers.Counters
 		/// <param name="transaction">Transaction to use for the operation</param>
 		/// <param name="counterKey">Key of the counter, relative to the list's subspace</param>
 		/// <remarks>This operation will not cause the current transaction to conflict. It may create conflicts for transactions that would read the value of the counter.</remarks>
-		public void Increment([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey)
+		public void Increment(IFdbTransaction transaction, TKey counterKey)
 		{
 			Add(transaction, counterKey, 1);
 		}
@@ -97,7 +94,7 @@ namespace FoundationDB.Layers.Counters
 		/// <param name="transaction">Transaction to use for the operation</param>
 		/// <param name="counterKey">Key of the counter, relative to the list's subspace</param>
 		/// <remarks>This operation will not cause the current transaction to conflict. It may create conflicts for transactions that would read the value of the counter.</remarks>
-		public void Decrement([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey)
+		public void Decrement(IFdbTransaction transaction, TKey counterKey)
 		{
 			Add(transaction, counterKey, -1);
 		}
@@ -106,7 +103,7 @@ namespace FoundationDB.Layers.Counters
 		/// <param name="transaction">Transaction to use for the operation</param>
 		/// <param name="counterKey">Key of the counter, relative to the list's subspace</param>
 		/// <returns></returns>
-		public async Task<long?> ReadAsync([NotNull] IFdbReadOnlyTransaction transaction, [NotNull] TKey counterKey)
+		public async Task<long?> ReadAsync(IFdbReadOnlyTransaction transaction, TKey counterKey)
 		{
 			if (transaction == null) throw new ArgumentNullException(nameof(transaction));
 			if (counterKey == null) throw new ArgumentNullException(nameof(counterKey));
@@ -122,7 +119,7 @@ namespace FoundationDB.Layers.Counters
 		/// <param name="value">Value that will be added to the counter</param>
 		/// <returns>New value of the counter. Returns <paramref name="value"/> if the counter did not exist previously.</returns>
 		/// <remarks>This method WILL conflict with other transactions!</remarks>
-		public async Task<long> AddThenReadAsync([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey, long value)
+		public async Task<long> AddThenReadAsync(IFdbTransaction transaction, TKey counterKey, long value)
 		{
 			if (transaction == null) throw new ArgumentNullException(nameof(transaction));
 			if (counterKey == null) throw new ArgumentNullException(nameof(counterKey));
@@ -136,17 +133,17 @@ namespace FoundationDB.Layers.Counters
 			return value;
 		}
 
-		public Task<long> SubtractThenReadAsync([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey, long value)
+		public Task<long> SubtractThenReadAsync(IFdbTransaction transaction, TKey counterKey, long value)
 		{
 			return AddThenReadAsync(transaction, counterKey, -value);
 		}
 
-		public Task<long> IncrementThenReadAsync([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey)
+		public Task<long> IncrementThenReadAsync(IFdbTransaction transaction, TKey counterKey)
 		{
 			return AddThenReadAsync(transaction, counterKey, 1);
 		}
 
-		public Task<long> DecrementThenReadAsync([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey)
+		public Task<long> DecrementThenReadAsync(IFdbTransaction transaction, TKey counterKey)
 		{
 			return AddThenReadAsync(transaction, counterKey, -1);
 		}
@@ -157,7 +154,7 @@ namespace FoundationDB.Layers.Counters
 		/// <param name="value">Value that will be added to the counter</param>
 		/// <returns>Previous value of the counter. Returns 0 if the counter did not exist previously.</returns>
 		/// <remarks>This method WILL conflict with other transactions!</remarks>
-		public async Task<long> ReadThenAddAsync([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey, long value)
+		public async Task<long> ReadThenAddAsync(IFdbTransaction transaction, TKey counterKey, long value)
 		{
 			if (transaction == null) throw new ArgumentNullException(nameof(transaction));
 			if (counterKey == null) throw new ArgumentNullException(nameof(counterKey));
@@ -171,17 +168,17 @@ namespace FoundationDB.Layers.Counters
 			return previous;
 		}
 
-		public Task<long> ReadThenSubtractAsync([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey, long value)
+		public Task<long> ReadThenSubtractAsync(IFdbTransaction transaction, TKey counterKey, long value)
 		{
 			return ReadThenAddAsync(transaction, counterKey, -value);
 		}
 
-		public Task<long> ReadThenIncrementAsync([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey)
+		public Task<long> ReadThenIncrementAsync(IFdbTransaction transaction, TKey counterKey)
 		{
 			return ReadThenAddAsync(transaction, counterKey, 1);
 		}
 
-		public Task<long> ReadThenDecrementAsync([NotNull] IFdbTransaction transaction, [NotNull] TKey counterKey)
+		public Task<long> ReadThenDecrementAsync(IFdbTransaction transaction, TKey counterKey)
 		{
 			return ReadThenAddAsync(transaction, counterKey, -1);
 		}

--- a/FoundationDB.Layers.Common/Counters/FdbHighContentionCounter.cs
+++ b/FoundationDB.Layers.Common/Counters/FdbHighContentionCounter.cs
@@ -28,13 +28,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace FoundationDB.Layers.Counters
 {
-	using FoundationDB.Client;
-	using JetBrains.Annotations;
 	using System;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Collections.Tuples;
 	using Doxense.Serialization.Encoders;
+	using FoundationDB.Client;
 
 	/// <summary>Represents an integer value which can be incremented without conflict.
 	/// Uses a sharded representation (which scales with contention) along with background coalescing...
@@ -55,25 +54,23 @@ namespace FoundationDB.Layers.Counters
 
 		/// <summary>Create a new High Contention counter.</summary>
 		/// <param name="location">Subspace to be used for storing the counter</param>
-		public FdbHighContentionCounter([NotNull] ISubspaceLocation location)
+		public FdbHighContentionCounter(ISubspaceLocation location)
 			: this(location.AsDynamic(), TuPack.Encoding.GetValueEncoder<long>())
 		{ }
 
 		/// <summary>Create a new High Contention counter, using a specific value encoder.</summary>
 		/// <param name="location">Location for storing the counters</param>
 		/// <param name="encoder">Encoder for the counter values</param>
-		public FdbHighContentionCounter([NotNull] DynamicKeySubspaceLocation location, [NotNull] IValueEncoder<long> encoder)
+		public FdbHighContentionCounter(DynamicKeySubspaceLocation location, IValueEncoder<long> encoder)
 		{
 			this.Location = location ?? throw new ArgumentNullException(nameof(location));
 			this.Encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
 		}
 
 		/// <summary>Subspace used as a prefix for all items in this table</summary>
-		[NotNull] 
 		public DynamicKeySubspaceLocation Location { get; }
 
 		/// <summary>Encoder for the integer values of the counter</summary>
-		[NotNull]
 		public IValueEncoder<long> Encoder {get; }
 
 		/// <summary>Generate a new random slice</summary>
@@ -153,7 +150,7 @@ namespace FoundationDB.Layers.Counters
 		/// <summary>Get the value of the counter.
 		/// Not recommended for use with read/write transactions when the counter is being frequently updated (conflicts will be very likely).
 		/// </summary>
-		public async Task<long> GetTransactional([NotNull] IFdbReadOnlyTransaction trans)
+		public async Task<long> GetTransactional(IFdbReadOnlyTransaction trans)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -168,13 +165,13 @@ namespace FoundationDB.Layers.Counters
 			return total;
 		}
 
-		public Task<long> GetSnapshot([NotNull] IFdbReadOnlyTransaction trans)
+		public Task<long> GetSnapshot(IFdbReadOnlyTransaction trans)
 		{
 			return GetTransactional(trans.Snapshot);
 		}
 
 		/// <summary>Add the value x to the counter.</summary>
-		public async ValueTask Add([NotNull] IFdbTransaction trans, long x)
+		public async ValueTask Add(IFdbTransaction trans, long x)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -194,7 +191,7 @@ namespace FoundationDB.Layers.Counters
 		}
 
 		/// <summary>Set the counter to value x.</summary>
-		public async ValueTask SetTotal([NotNull] IFdbTransaction trans, long x)
+		public async ValueTask SetTotal(IFdbTransaction trans, long x)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 

--- a/FoundationDB.Layers.Experimental/Documents/FdbHashSetCollection.cs
+++ b/FoundationDB.Layers.Experimental/Documents/FdbHashSetCollection.cs
@@ -34,7 +34,6 @@ namespace FoundationDB.Layers.Blobs
 	using Doxense.Collections.Tuples;
 	using Doxense.Diagnostics.Contracts;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	// THIS IS NOT AN OFFICIAL LAYER, JUST A PROTOTYPE TO TEST A FEW THINGS !
 
@@ -83,7 +82,7 @@ namespace FoundationDB.Layers.Blobs
 		/// <param name="id">Unique identifier of the hashset</param>
 		/// <param name="field">Name of the field to read</param>
 		/// <returns>Value of the corresponding field, or <see cref="Slice.Nil"/> if it the hashset does not exist, or doesn't have a field with this name</returns>
-		public Task<Slice> GetValueAsync([NotNull] IFdbReadOnlyTransaction trans, [NotNull] IVarTuple id, string field)
+		public Task<Slice> GetValueAsync(IFdbReadOnlyTransaction trans, IVarTuple id, string field)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 			if (id == null) throw new ArgumentNullException(nameof(id));
@@ -96,7 +95,7 @@ namespace FoundationDB.Layers.Blobs
 		/// <param name="trans">Transaction that will be used for this request</param>
 		/// <param name="id">Unique identifier of the hashset</param>
 		/// <returns>Dictionary containing, for all fields, their associated values</returns>
-		public async Task<IDictionary<string, Slice>> GetAsync([NotNull] IFdbReadOnlyTransaction trans, [NotNull] IVarTuple id)
+		public async Task<IDictionary<string, Slice>> GetAsync(IFdbReadOnlyTransaction trans, IVarTuple id)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 			if (id == null) throw new ArgumentNullException(nameof(id));
@@ -121,7 +120,7 @@ namespace FoundationDB.Layers.Blobs
 		/// <param name="id">Unique identifier of the hashset</param>
 		/// <param name="fields">List of the fields to read</param>
 		/// <returns>Dictionary containing the values of the selected fields, or <see cref="Slice.Empty"/> if that particular field does not exist.</returns>
-		public async Task<IDictionary<string, Slice>> GetAsync([NotNull] IFdbReadOnlyTransaction trans, [NotNull] IVarTuple id, [NotNull] params string[] fields)
+		public async Task<IDictionary<string, Slice>> GetAsync(IFdbReadOnlyTransaction trans, IVarTuple id, params string[] fields)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 			if (id == null) throw new ArgumentNullException(nameof(id));

--- a/FoundationDB.Layers.Experimental/FoundationDB.Layers.Experimental.csproj
+++ b/FoundationDB.Layers.Experimental/FoundationDB.Layers.Experimental.csproj
@@ -4,7 +4,8 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
     <RootNamespace>FoundationDB.Layers</RootNamespace>
     <AssemblyName>FoundationDB.Layers.Experimental</AssemblyName>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Common\foundationdb-net-client.snk</AssemblyOriginatorKeyFile>
     <PackageTags>foundationdb fdb nosql</PackageTags>

--- a/FoundationDB.Layers.Experimental/Indexes/Bitmaps/CompressedBitmap.cs
+++ b/FoundationDB.Layers.Experimental/Indexes/Bitmaps/CompressedBitmap.cs
@@ -28,8 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace FoundationDB.Layers.Experimental.Indexing
 {
-	using FoundationDB.Client;
-	using JetBrains.Annotations;
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
@@ -82,10 +80,9 @@ namespace FoundationDB.Layers.Experimental.Indexing
 			}
 		}
 
-		/// <summary>Gets a copy of the compressd bitmap's data</summary>
+		/// <summary>Gets a copy of the compressed bitmap's data</summary>
 		public MutableSlice ToSlice() { return m_data.Memoize(); }
 
-		[NotNull]
 		public CompressedBitmapBuilder ToBuilder()
 		{
 			return new CompressedBitmapBuilder(this);
@@ -225,7 +222,6 @@ namespace FoundationDB.Layers.Experimental.Indexing
 			ratio = (32.0 * words) /  m_bounds.Highest;
 		}
 
-		[NotNull]
 		public string Dump()
 		{
 			return WordAlignHybridEncoder.DumpCompressed(m_data).ToString();

--- a/FoundationDB.Layers.Experimental/Indexes/Bitmaps/CompressedBitmapBitView.cs
+++ b/FoundationDB.Layers.Experimental/Indexes/Bitmaps/CompressedBitmapBitView.cs
@@ -26,13 +26,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-
 namespace FoundationDB.Layers.Experimental.Indexing
 {
 	using System;
 	using System.Collections.Generic;
 	using Doxense.Diagnostics.Contracts;
-	using JetBrains.Annotations;
 
 	/// <summary>View that reads the indexes of all the set bits in a bitmap</summary>
 	public class CompressedBitmapBitView : IEnumerable<int>
@@ -45,11 +43,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 			m_bitmap = bitmap;
 		}
 
-		public CompressedBitmap Bitmap
-		{
-			[NotNull]
-			get { return m_bitmap; }
-		}
+		public CompressedBitmap Bitmap => m_bitmap;
 
 		public IEnumerator<int> GetEnumerator()
 		{

--- a/FoundationDB.Layers.Experimental/Indexes/Bitmaps/CompressedBitmapBuilder.cs
+++ b/FoundationDB.Layers.Experimental/Indexes/Bitmaps/CompressedBitmapBuilder.cs
@@ -89,7 +89,6 @@ namespace FoundationDB.Layers.Experimental.Indexing
 			m_highest = range.Highest;
 		}
 
-		[NotNull]
 		internal static CompressedWord[] DecodeWords(Slice data, int size, BitRange bounds)
 		{
 			Contract.Requires(size >= 0 && data.Count >= 4 && (data.Count & 3) == 0);
@@ -395,14 +394,13 @@ namespace FoundationDB.Layers.Experimental.Indexing
 			return Pack(m_words, m_size, m_highest);
 		}
 
-		[NotNull]
 		public CompressedBitmap ToBitmap()
 		{
 			if (m_size == 0) return CompressedBitmap.Empty;
 			return new CompressedBitmap(Pack(m_words, m_size, m_highest), new BitRange(m_lowest, m_highest));
 		}
 
-		internal static MutableSlice Pack([NotNull] CompressedWord[] words, int size, int highest)
+		internal static MutableSlice Pack(CompressedWord[] words, int size, int highest)
 		{
 			Contract.Requires(size >= 0 && size <= words.Length);
 
@@ -420,7 +418,6 @@ namespace FoundationDB.Layers.Experimental.Indexing
 			return writer.ToMutableSlice();
 		}
 
-		[NotNull]
 		public bool[] ToBooleanArray()
 		{
 			int n = m_highest + 1;

--- a/FoundationDB.Layers.Experimental/Indexes/Bitmaps/CompressedBitmapWriter.cs
+++ b/FoundationDB.Layers.Experimental/Indexes/Bitmaps/CompressedBitmapWriter.cs
@@ -287,7 +287,6 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		}
 
 		/// <summary>Flush the final words and return the compressed bitmap</summary>
-		[NotNull]
 		public CompressedBitmap GetBitmap()
 		{
 			return new CompressedBitmap(GetBuffer(), m_bounds);

--- a/FoundationDB.Layers.Experimental/Indexes/Bitmaps/WordAlignHybridCoding.cs
+++ b/FoundationDB.Layers.Experimental/Indexes/Bitmaps/WordAlignHybridCoding.cs
@@ -32,7 +32,6 @@ namespace FoundationDB.Layers.Experimental.Indexing
 	using System.Text;
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Memory;
-	using JetBrains.Annotations;
 
 	public static class WordAlignHybridEncoder
 	{
@@ -376,8 +375,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="size">Minimum logical size of the result (bits in the uncompressed bitmap)</param>
 		/// <returns>Compressed slice with the result of flipping all the bits in <paramref name="bitmap"/>, containing up to at least <paramref name="size"/> bits.</returns>
 		/// <remarks>If <paramref name="bitmap"/> is larger than <paramref name="size"/>, then the resulting bitmap will be larger.</remarks>
-		[NotNull]
-		public static CompressedBitmap Not([NotNull] this CompressedBitmap bitmap, int size)
+		public static CompressedBitmap Not(this CompressedBitmap bitmap, int size)
 		{
 			if (bitmap == null) throw new ArgumentNullException(nameof(bitmap));
 
@@ -414,8 +412,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="left">First compressed bitmap</param>
 		/// <param name="right">Second compressed bitmap</param>
 		/// <returns>Compressed slice with the result of boolean expression <paramref name="left"/> AND <paramref name="right"/></returns>
-		[NotNull]
-		public static CompressedBitmap And([NotNull] this CompressedBitmap left, [NotNull] CompressedBitmap right)
+		public static CompressedBitmap And(this CompressedBitmap left, CompressedBitmap right)
 		{
 			if (left == null) throw new ArgumentNullException(nameof(left));
 			if (right == null) throw new ArgumentNullException(nameof(right));
@@ -428,8 +425,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="left">First compressed bitmap</param>
 		/// <param name="right">Second compressed bitmap</param>
 		/// <returns>Compressed slice with the result of boolean expression <paramref name="left"/> AND <paramref name="right"/></returns>
-		[NotNull]
-		public static CompressedBitmap Or([NotNull] this CompressedBitmap left, [NotNull] CompressedBitmap right)
+		public static CompressedBitmap Or(this CompressedBitmap left, CompressedBitmap right)
 		{
 			if (left == null) throw new ArgumentNullException(nameof(left));
 			if (right == null) throw new ArgumentNullException(nameof(right));
@@ -443,8 +439,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="left">First compressed bitmap</param>
 		/// <param name="right">Second compressed bitmap</param>
 		/// <returns>Compressed slice with the result of boolean expression <paramref name="left"/> AND <paramref name="right"/></returns>
-		[NotNull]
-		public static CompressedBitmap Xor([NotNull] this CompressedBitmap left, [NotNull] CompressedBitmap right)
+		public static CompressedBitmap Xor(this CompressedBitmap left, CompressedBitmap right)
 		{
 			if (left == null) throw new ArgumentNullException(nameof(left));
 			if (right == null) throw new ArgumentNullException(nameof(right));
@@ -458,8 +453,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="left">First compressed bitmap</param>
 		/// <param name="right">Second compressed bitmap</param>
 		/// <returns>Compressed slice with the result of boolean expression <paramref name="left"/> AND NOT(<paramref name="right"/>)</returns>
-		[NotNull]
-		public static CompressedBitmap AndNot([NotNull] this CompressedBitmap left, [NotNull] CompressedBitmap right)
+		public static CompressedBitmap AndNot(this CompressedBitmap left, CompressedBitmap right)
 		{
 			if (left == null) throw new ArgumentNullException(nameof(left));
 			if (right == null) throw new ArgumentNullException(nameof(right));
@@ -472,8 +466,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="left">First compressed bitmap</param>
 		/// <param name="right">Second compressed bitmap</param>
 		/// <returns>Compressed slice with the result of boolean expression <paramref name="left"/> OR NOT(<paramref name="right"/>)</returns>
-		[NotNull]
-		public static CompressedBitmap OrNot([NotNull] this CompressedBitmap left, [NotNull] CompressedBitmap right)
+		public static CompressedBitmap OrNot(this CompressedBitmap left, CompressedBitmap right)
 		{
 			if (left == null) throw new ArgumentNullException(nameof(left));
 			if (right == null) throw new ArgumentNullException(nameof(right));
@@ -487,8 +480,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="left">First compressed bitmap</param>
 		/// <param name="right">Second compressed bitmap</param>
 		/// <returns>Compressed slice with the result of boolean expression <paramref name="left"/> XOR NOT(<paramref name="right"/>)</returns>
-		[NotNull]
-		public static CompressedBitmap XorNot([NotNull] this CompressedBitmap left, [NotNull] CompressedBitmap right)
+		public static CompressedBitmap XorNot(this CompressedBitmap left, CompressedBitmap right)
 		{
 			if (left == null) throw new ArgumentNullException(nameof(left));
 			if (right == null) throw new ArgumentNullException(nameof(right));
@@ -503,8 +495,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="right">Second compressed bitmap</param>
 		/// <param name="op">Type of operation to perform (And, Or, Xor, ...)</param>
 		/// <returns>Compressed slice with the result of boolean expression <paramref name="left"/> AND <paramref name="right"/></returns>
-		[NotNull]
-		internal static CompressedBitmap CompressedBinaryExpression([NotNull] CompressedBitmap left, [NotNull] CompressedBitmap right, LogicalOperation op)
+		internal static CompressedBitmap CompressedBinaryExpression(CompressedBitmap left, CompressedBitmap right, LogicalOperation op)
 		{
 			Contract.Requires(left != null && right != null && /*op != LogicalOperation.And &&*/ Enum.IsDefined(typeof(LogicalOperation), op));
 

--- a/FoundationDB.Layers.Experimental/Indexes/FdbCompressedBitmapIndex.cs
+++ b/FoundationDB.Layers.Experimental/Indexes/FdbCompressedBitmapIndex.cs
@@ -36,7 +36,6 @@ namespace FoundationDB.Layers.Experimental.Indexing
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Simple index that maps values of type <typeparamref name="TValue"/> into lists of numerical ids</summary>
 	/// <typeparam name="TValue">Type of the value being indexed</typeparam>
@@ -44,11 +43,11 @@ namespace FoundationDB.Layers.Experimental.Indexing
 	public class FdbCompressedBitmapIndex<TValue>
 	{
 
-		public FdbCompressedBitmapIndex([NotNull] string name, [NotNull] IKeySubspace subspace, IEqualityComparer<TValue> valueComparer = null, bool indexNullValues = false)
+		public FdbCompressedBitmapIndex(string name, IKeySubspace subspace, IEqualityComparer<TValue>? valueComparer = null, bool indexNullValues = false)
 			: this(name, subspace.AsTyped<TValue>(), valueComparer, indexNullValues)
 		{ }
 
-		public FdbCompressedBitmapIndex([NotNull] string name, [NotNull] ITypedKeySubspace<TValue> subspace, IEqualityComparer<TValue> valueComparer = null, bool indexNullValues = false)
+		public FdbCompressedBitmapIndex(string name, ITypedKeySubspace<TValue> subspace, IEqualityComparer<TValue>? valueComparer = null, bool indexNullValues = false)
 		{
 			Contract.NotNull(name, nameof(name));
 			Contract.NotNull(subspace, nameof(subspace));
@@ -59,13 +58,10 @@ namespace FoundationDB.Layers.Experimental.Indexing
 			this.IndexNullValues = indexNullValues;
 		}
 
-		[NotNull]
 		public string Name { get; }
 
-		[NotNull]
 		public ITypedKeySubspace<TValue> Subspace { get; }
 
-		[NotNull]
 		public IEqualityComparer<TValue> ValueComparer { get; }
 
 		/// <summary>If true, null values are inserted in the index. If false (default), they are ignored</summary>
@@ -77,7 +73,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="id">Id of the new entity (that was never indexed before)</param>
 		/// <param name="value">Value of this entity in the index</param>
 		/// <returns>True if a value was inserted into the index; or false if <paramref name="value"/> is null and <see cref="IndexNullValues"/> is false, or if this <paramref name="id"/> was already indexed at this <paramref name="value"/>.</returns>
-		public async Task<bool> AddAsync([NotNull] IFdbTransaction trans, long id, TValue value)
+		public async Task<bool> AddAsync(IFdbTransaction trans, long id, TValue value)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -104,7 +100,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="previousValue">New value of this entity in the index</param>
 		/// <returns>True if a change was performed in the index; otherwise false (if <paramref name="previousValue"/> and <paramref name="newValue"/>)</returns>
 		/// <remarks>If <paramref name="newValue"/> and <paramref name="previousValue"/> are identical, then nothing will be done. Otherwise, the old index value will be deleted and the new value will be added</remarks>
-		public async Task<bool> UpdateAsync([NotNull] IFdbTransaction trans, long id, TValue newValue, TValue previousValue)
+		public async Task<bool> UpdateAsync(IFdbTransaction trans, long id, TValue newValue, TValue previousValue)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -143,7 +139,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="trans">Transaction to use</param>
 		/// <param name="id">Id of the entity that has been deleted</param>
 		/// <param name="value">Previous value of the entity in the index</param>
-		public async Task<bool> RemoveAsync([NotNull] IFdbTransaction trans, long id, TValue value)
+		public async Task<bool> RemoveAsync(IFdbTransaction trans, long id, TValue value)
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 
@@ -164,7 +160,7 @@ namespace FoundationDB.Layers.Experimental.Indexing
 		/// <param name="value">Value to lookup</param>
 		/// <param name="reverse"></param>
 		/// <returns>List of document ids matching this value for this particular index (can be empty if no document matches)</returns>
-		public async Task<IEnumerable<long>> LookupAsync([NotNull] IFdbReadOnlyTransaction trans, TValue value, bool reverse = false)
+		public async Task<IEnumerable<long>?> LookupAsync(IFdbReadOnlyTransaction trans, TValue value, bool reverse = false)
 		{
 			var key = this.Subspace[value];
 			var data = await trans.GetAsync(key).ConfigureAwait(false);

--- a/FoundationDB.Linq.Providers/Expressions/FdbDebugStatementWriter.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbDebugStatementWriter.cs
@@ -31,10 +31,9 @@ namespace FoundationDB.Linq.Expressions
 	using JetBrains.Annotations;
 	using System;
 	using System.Globalization;
-	using System.Linq.Expressions;
 	using System.Text;
 
-	/// <summary>Very simple writer to dump query expressions into a statement usefull for logging/debugging</summary>
+	/// <summary>Very simple writer to dump query expressions into a statement useful for logging/debugging</summary>
 	public sealed class FdbDebugStatementWriter
 	{
 		/// <summary>Create a new statement writer with an empty buffer</summary>
@@ -45,7 +44,7 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Underlying buffer used by this writer</summary>
-		public StringBuilder Buffer { [NotNull] get; private set; }
+		public StringBuilder Buffer { get; }
 
 		/// <summary>Current indentation level</summary>
 		public int IndentLevel { get; private set; }
@@ -54,7 +53,6 @@ namespace FoundationDB.Linq.Expressions
 		public bool StartOfLine {get; private set;}
 
 		/// <summary>Enter a new indentation scope</summary>
-		[NotNull]
 		public FdbDebugStatementWriter Enter()
 		{
 			this.IndentLevel++;
@@ -63,7 +61,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Leave the current indentation scope</summary>
-		[NotNull]
 		public FdbDebugStatementWriter Leave()
 		{
 			this.IndentLevel--;
@@ -72,8 +69,7 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Writes a line of text</summary>
-		[NotNull]
-		public FdbDebugStatementWriter WriteLine([NotNull] string text)
+		public FdbDebugStatementWriter WriteLine(string text)
 		{
 			if (this.StartOfLine) Indent();
 			this.Buffer.AppendLine(text);
@@ -82,15 +78,13 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Starts a new line</summary>
-		[NotNull]
 		public FdbDebugStatementWriter WriteLine()
 		{
 			return WriteLine(String.Empty);
 		}
 
 		/// <summary>Appends text to the current line</summary>
-		[NotNull]
-		public FdbDebugStatementWriter Write([NotNull] string text)
+		public FdbDebugStatementWriter Write(string text)
 		{
 			if (this.StartOfLine) Indent();
 			this.Buffer.Append(text);
@@ -100,18 +94,16 @@ namespace FoundationDB.Linq.Expressions
 
 		/// <summary>Writes a formatted line of text</summary>
 		[StringFormatMethod("format")]
-		[NotNull]
-		public FdbDebugStatementWriter WriteLine([NotNull] string format, params object[] args)
+		public FdbDebugStatementWriter WriteLine(string format, params object?[] args)
 		{
-			return WriteLine(String.Format(CultureInfo.InvariantCulture, format, args));
+			return WriteLine(string.Format(CultureInfo.InvariantCulture, format, args));
 		}
 
 		/// <summary>Appends formatted text to the current line</summary>
 		[StringFormatMethod("format")]
-		[NotNull]
-		public FdbDebugStatementWriter Write([NotNull] string format, params object[] args)
+		public FdbDebugStatementWriter Write(string format, params object?[] args)
 		{
-			return Write(String.Format(CultureInfo.InvariantCulture, format, args));
+			return Write(string.Format(CultureInfo.InvariantCulture, format, args));
 		}
 
 		private void Indent()

--- a/FoundationDB.Linq.Providers/Expressions/FdbQueryAsyncEnumerableExpression.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQueryAsyncEnumerableExpression.cs
@@ -34,9 +34,7 @@ namespace FoundationDB.Linq.Expressions
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Diagnostics.Contracts;
-	using Doxense.Linq;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Expression that uses an async sequence as the source of elements</summary>
 	public sealed class FdbQueryAsyncEnumerableExpression<T> : FdbQuerySequenceExpression<T>
@@ -49,17 +47,10 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Returns <see cref="FdbQueryShape.Sequence"/></summary>
-		public override FdbQueryShape Shape
-		{
-			get { return FdbQueryShape.Sequence; }
-		}
+		public override FdbQueryShape Shape => FdbQueryShape.Sequence;
 
 		/// <summary>Source sequence of this expression</summary>
-		public IAsyncEnumerable<T> Source
-		{
-			[NotNull] get;
-			private set;
-		}
+		public IAsyncEnumerable<T> Source { get; }
 
 		/// <summary>Apply a custom visitor to this expression</summary>
 		public override Expression Accept(FdbQueryExpressionVisitor visitor)
@@ -80,7 +71,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Returns a new expression that creates an async sequence that will execute this query on a transaction</summary>
-		[NotNull]
 		public override Expression<Func<IFdbReadOnlyTransaction, IAsyncEnumerable<T>>> CompileSequence()
 		{
 			var prmTrans = Expression.Parameter(typeof(IFdbReadOnlyTransaction), "trans");

--- a/FoundationDB.Linq.Providers/Expressions/FdbQueryExpression.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQueryExpression.cs
@@ -59,7 +59,7 @@ namespace FoundationDB.Linq.Expressions
 		public abstract FdbQueryShape Shape { get; }
 
 		/// <summary>Apply a custom visitor on this expression</summary>
-		public abstract Expression Accept([NotNull] FdbQueryExpressionVisitor visitor);
+		public abstract Expression Accept(FdbQueryExpressionVisitor visitor);
 
 		public string GetDebugView()
 		{
@@ -69,7 +69,7 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Write a human-readable explanation of this expression</summary>
-		public abstract void WriteTo([NotNull] FdbQueryExpressionStringBuilder builder);
+		public abstract void WriteTo(FdbQueryExpressionStringBuilder builder);
 
 #if DEBUG
 		public override string ToString()
@@ -90,7 +90,6 @@ namespace FoundationDB.Linq.Expressions
 		{ }
 
 		/// <summary>Returns a new expression that will execute this query on a transaction and return a single result</summary>
-		[NotNull]
 		public abstract Expression<Func<IFdbReadOnlyTransaction, CancellationToken, Task<T>>> CompileSingle();
 
 	}

--- a/FoundationDB.Linq.Providers/Expressions/FdbQueryExpressions.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQueryExpressions.cs
@@ -34,7 +34,6 @@ namespace FoundationDB.Linq.Expressions
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Doxense.Collections.Tuples;
-	using Doxense.Linq;
 	using FoundationDB.Client;
 	using JetBrains.Annotations;
 
@@ -43,8 +42,7 @@ namespace FoundationDB.Linq.Expressions
 	{
 
 		/// <summary>Return a single result from the query</summary>
-		[NotNull]
-		public static FdbQuerySingleExpression<T, R> Single<T, R>([NotNull] FdbQuerySequenceExpression<T> source, string name, [NotNull] Expression<Func<IAsyncEnumerable<T>, CancellationToken, Task<R>>> lambda)
+		public static FdbQuerySingleExpression<T, R> Single<T, R>(FdbQuerySequenceExpression<T> source, string name, Expression<Func<IAsyncEnumerable<T>, CancellationToken, Task<R>>> lambda)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (lambda == null) throw new ArgumentNullException(nameof(lambda));
@@ -55,8 +53,7 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Return a sequence of results from the query</summary>
-		[NotNull]
-		public static FdbQueryAsyncEnumerableExpression<T> Sequence<T>([NotNull] IAsyncEnumerable<T> source)
+		public static FdbQueryAsyncEnumerableExpression<T> Sequence<T>(IAsyncEnumerable<T> source)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -64,21 +61,18 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Execute a Range read from the database, and return all the keys and values</summary>
-		[NotNull]
 		public static FdbQueryRangeExpression Range(KeySelectorPair range, FdbRangeOptions? options = null)
 		{
 			return new FdbQueryRangeExpression(range, options);
 		}
 
 		/// <summary>Execute a Range read from the database, and return all the keys and values</summary>
-		[NotNull]
 		public static FdbQueryRangeExpression Range(KeySelector start, KeySelector stop, FdbRangeOptions? options = null)
 		{
 			return Range(new KeySelectorPair(start, stop), options);
 		}
 
 		/// <summary>Execute a Range read from the database, and return all the keys and values</summary>
-		[NotNull]
 		public static FdbQueryRangeExpression RangeStartsWith(Slice prefix, FdbRangeOptions? options = null)
 		{
 			// starts_with('A') means ['A', B')
@@ -86,7 +80,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Execute a Range read from the database, and return all the keys and values</summary>
-		[NotNull]
 		[Obsolete]
 		public static FdbQueryRangeExpression RangeStartsWith(IVarTuple tuple, FdbRangeOptions? options = null)
 		{
@@ -94,7 +87,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Return the intersection between one of more sequences of results</summary>
-		[NotNull]
 		public static FdbQueryIntersectExpression<T> Intersect<T>(params FdbQuerySequenceExpression<T>[] expressions)
 		{
 			if (expressions == null) throw new ArgumentNullException(nameof(expressions));
@@ -107,7 +99,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Return the union between one of more sequences of results</summary>
-		[NotNull]
 		public static FdbQueryUnionExpression<T> Union<T>(params FdbQuerySequenceExpression<T>[] expressions)
 		{
 			if (expressions == null) throw new ArgumentNullException(nameof(expressions));
@@ -120,32 +111,29 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Transform each elements of a sequence into a new sequence</summary>
-		[NotNull]
-		public static FdbQueryTransformExpression<T, R> Transform<T, R>([NotNull] FdbQuerySequenceExpression<T> source, [NotNull] Expression<Func<T, R>> transform)
+		public static FdbQueryTransformExpression<T, R> Transform<T, R>(FdbQuerySequenceExpression<T> source, Expression<Func<T, R>> transform)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (transform == null) throw new ArgumentNullException(nameof(transform));
 
-			if (source.ElementType != typeof(T)) throw new ArgumentException(String.Format("Source sequence has type {0} that is not compatible with transform input type {1}", source.ElementType.Name, typeof(T).Name), nameof(source));
+			if (source.ElementType != typeof(T)) throw new ArgumentException($"Source sequence has type {source.ElementType.Name} that is not compatible with transform input type {typeof(T).Name}", nameof(source));
 
 			return new FdbQueryTransformExpression<T, R>(source, transform);
 		}
 
 		/// <summary>Filter out the elements of e sequence that do not match a predicate</summary>
-		[NotNull]
-		public static FdbQueryFilterExpression<T> Filter<T>([NotNull] FdbQuerySequenceExpression<T> source, [NotNull] Expression<Func<T, bool>> filter)
+		public static FdbQueryFilterExpression<T> Filter<T>(FdbQuerySequenceExpression<T> source, Expression<Func<T, bool>> filter)
 		{
 			if (source == null) throw new ArgumentNullException(nameof(source));
 			if (filter == null) throw new ArgumentNullException(nameof(filter));
 
-			if (source.ElementType != typeof(T)) throw new ArgumentException(String.Format("Source sequence has type {0} that is not compatible with filter input type {1}", source.ElementType.Name, typeof(T).Name), nameof(source));
+			if (source.ElementType != typeof(T)) throw new ArgumentException($"Source sequence has type {source.ElementType.Name} that is not compatible with filter input type {typeof(T).Name}", nameof(source));
 
 			return new FdbQueryFilterExpression<T>(source, filter);
 		}
 
-		/// <summary>Returns a human-readble explanation of a query that returns a single element</summary>
-		[NotNull]
-		public static string ExplainSingle<T>([NotNull] FdbQueryExpression<T> expression, CancellationToken ct)
+		/// <summary>Returns a human-readable explanation of a query that returns a single element</summary>
+		public static string ExplainSingle<T>(FdbQueryExpression<T> expression, CancellationToken ct)
 		{
 			if (expression == null) throw new ArgumentNullException(nameof(expression));
 			if (expression.Shape != FdbQueryShape.Single) throw new InvalidOperationException("Invalid shape (single expected)");
@@ -155,9 +143,8 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 
-		/// <summary>Returns a human-readble explanation of a query that returns a sequence of elements</summary>
-		[NotNull]
-		public static string ExplainSequence<T>([NotNull] FdbQuerySequenceExpression<T> expression)
+		/// <summary>Returns a human-readable explanation of a query that returns a sequence of elements</summary>
+		public static string ExplainSequence<T>(FdbQuerySequenceExpression<T> expression)
 		{
 			if (expression == null) throw new ArgumentNullException(nameof(expression));
 			if (expression.Shape != FdbQueryShape.Sequence) throw new InvalidOperationException("Invalid shape (sequence expected)");

--- a/FoundationDB.Linq.Providers/Expressions/FdbQueryFilterExpression.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQueryFilterExpression.cs
@@ -34,7 +34,6 @@ namespace FoundationDB.Linq.Expressions
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Linq;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Expression that represent a filter on a source sequence</summary>
 	/// <typeparam name="T">Type of elements in the source sequence</typeparam>
@@ -49,18 +48,10 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Source sequence that is being filtered</summary>
-		public FdbQuerySequenceExpression<T> Source
-		{
-			[NotNull] get;
-			private set;
-		}
+		public FdbQuerySequenceExpression<T> Source { get; }
 
-		/// <summary>Filter applied on each element of <see cref="Source"/> and that must return true for the element to be outputed</summary>
-		public Expression<Func<T, bool>> Filter
-		{
-			[NotNull] get;
-			private set;
-		}
+		/// <summary>Filter applied on each element of <see cref="Source"/> and that must return true for the element to be outputted</summary>
+		public Expression<Func<T, bool>> Filter { get; }
 
 		/// <summary>Apply a custom visitor to this expression</summary>
 		public override Expression Accept(FdbQueryExpressionVisitor visitor)
@@ -79,7 +70,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Returns a new expression that creates an async sequence that will execute this query on a transaction</summary>
-		[NotNull]
 		public override Expression<Func<IFdbReadOnlyTransaction, IAsyncEnumerable<T>>> CompileSequence()
 		{
 			var lambda = this.Filter.Compile();

--- a/FoundationDB.Linq.Providers/Expressions/FdbQueryIntersectExpression.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQueryIntersectExpression.cs
@@ -32,9 +32,7 @@ namespace FoundationDB.Linq.Expressions
 	using System.Collections.Generic;
 	using System.Linq.Expressions;
 	using Doxense.Diagnostics.Contracts;
-	using Doxense.Linq;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Mode of execution of a merge operation</summary>
 	public enum FdbQueryMergeType
@@ -53,7 +51,7 @@ namespace FoundationDB.Linq.Expressions
 	{
 
 		/// <summary>Create a new merge expression</summary>
-		protected FdbQueryMergeExpression(FdbQuerySequenceExpression<T>[] expressions, IComparer<T> keyComparer)
+		protected FdbQueryMergeExpression(FdbQuerySequenceExpression<T>[] expressions, IComparer<T>? keyComparer)
 		{
 			Contract.Requires(expressions != null);
 			this.Expressions = expressions;
@@ -63,25 +61,13 @@ namespace FoundationDB.Linq.Expressions
 		/// <summary>Type of the merge applied to the source sequences</summary>
 		public abstract FdbQueryMergeType MergeType { get; }
 
-		internal FdbQuerySequenceExpression<T>[] Expressions
-		{
-			[NotNull] get;
-			private set;
-		}
+		internal FdbQuerySequenceExpression<T>[] Expressions { get; }
 
 		/// <summary>Liste of the source sequences that are being merged</summary>
-		public IReadOnlyList<FdbQuerySequenceExpression<T>> Terms
-		{
-			[NotNull]
-			get { return this.Expressions; }
-		}
+		public IReadOnlyList<FdbQuerySequenceExpression<T>> Terms => this.Expressions;
 
 		/// <summary>Comparer used during merging</summary>
-		public IComparer<T> KeyComparer
-		{
-			[CanBeNull] get;
-			private set;
-		}
+		public IComparer<T>? KeyComparer { get; }
 
 		/// <summary>Apply a custom visitor to this expression</summary>
 		public override Expression Accept(FdbQueryExpressionVisitor visitor)
@@ -105,7 +91,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Returns a new expression that creates an async sequence that will execute this query on a transaction</summary>
-		[NotNull]
 		public override Expression<Func<IFdbReadOnlyTransaction, IAsyncEnumerable<T>>> CompileSequence()
 		{
 			// compile the key selector
@@ -142,7 +127,7 @@ namespace FoundationDB.Linq.Expressions
 				}
 				default:
 				{
-					throw new InvalidOperationException(String.Format("Unsupported index merge mode {0}", this.MergeType.ToString()));
+					throw new InvalidOperationException($"Unsupported index merge mode {this.MergeType.ToString()}");
 				}
 			}
 
@@ -160,16 +145,12 @@ namespace FoundationDB.Linq.Expressions
 	public sealed class FdbQueryIntersectExpression<T> : FdbQueryMergeExpression<T>
 	{
 
-		internal FdbQueryIntersectExpression(FdbQuerySequenceExpression<T>[] expressions, IComparer<T> keyComparer)
+		internal FdbQueryIntersectExpression(FdbQuerySequenceExpression<T>[] expressions, IComparer<T>? keyComparer)
 			: base(expressions, keyComparer)
 		{ }
 
 		/// <summary>Returns <see cref="FdbQueryMergeType.Intersect"/></summary>
-		public override FdbQueryMergeType MergeType
-		{
-			get { return FdbQueryMergeType.Intersect; }
-		}
-
+		public override FdbQueryMergeType MergeType => FdbQueryMergeType.Intersect;
 	}
 
 	/// <summary>Union between two or more sequence</summary>
@@ -177,16 +158,12 @@ namespace FoundationDB.Linq.Expressions
 	public sealed class FdbQueryUnionExpression<T> : FdbQueryMergeExpression<T>
 	{
 
-		internal FdbQueryUnionExpression(FdbQuerySequenceExpression<T>[] expressions, IComparer<T> keyComparer)
+		internal FdbQueryUnionExpression(FdbQuerySequenceExpression<T>[] expressions, IComparer<T>? keyComparer)
 			: base(expressions, keyComparer)
 		{ }
 
 		/// <summary>Returns <see cref="FdbQueryMergeType.Union"/></summary>
-		public override FdbQueryMergeType MergeType
-		{
-			get { return FdbQueryMergeType.Union; }
-		}
-
+		public override FdbQueryMergeType MergeType => FdbQueryMergeType.Union;
 	}
 
 }

--- a/FoundationDB.Linq.Providers/Expressions/FdbQueryRangeExpression.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQueryRangeExpression.cs
@@ -33,13 +33,12 @@ namespace FoundationDB.Linq.Expressions
 	using System.Globalization;
 	using System.Linq.Expressions;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Expression that represents a GetRange query using a pair of key selectors</summary>
 	public class FdbQueryRangeExpression : FdbQuerySequenceExpression<KeyValuePair<Slice, Slice>>
 	{
 
-		internal FdbQueryRangeExpression(KeySelectorPair range, FdbRangeOptions options)
+		internal FdbQueryRangeExpression(KeySelectorPair range, FdbRangeOptions? options)
 		{
 			this.Range = range;
 			this.Options = options;
@@ -49,7 +48,7 @@ namespace FoundationDB.Linq.Expressions
 		public KeySelectorPair Range { get; }
 
 		/// <summary>Returns the options for this range query</summary>
-		public FdbRangeOptions Options { get; }
+		public FdbRangeOptions? Options { get; }
 
 		/// <summary>Visit this expression</summary>
 		public override Expression Accept(FdbQueryExpressionVisitor visitor)
@@ -67,7 +66,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Returns a new expression that creates an async sequence that will execute this query on a transaction</summary>
-		[NotNull]
 		public override Expression<Func<IFdbReadOnlyTransaction, IAsyncEnumerable<KeyValuePair<Slice, Slice>>>> CompileSequence()
 		{
 			var prmTrans = Expression.Parameter(typeof(IFdbReadOnlyTransaction), "trans");
@@ -88,7 +86,7 @@ namespace FoundationDB.Linq.Expressions
 		/// <summary>Returns a short description of this range query</summary>
 		public override string ToString()
 		{
-			return String.Format(CultureInfo.InvariantCulture, "GetRange({0}, {1})", this.Range.Begin.ToString(), this.Range.End.ToString());
+			return string.Format(CultureInfo.InvariantCulture, "GetRange({0}, {1})", this.Range.Begin.ToString(), this.Range.End.ToString());
 		}
 
 

--- a/FoundationDB.Linq.Providers/Expressions/FdbQuerySequenceExpression.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQuerySequenceExpression.cs
@@ -25,16 +25,14 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
- 
+
 namespace FoundationDB.Linq.Expressions
 {
-	using JetBrains.Annotations;
 	using System;
 	using System.Collections.Generic;
 	using System.Linq.Expressions;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Doxense.Linq;
 	using FoundationDB.Client;
 
 	/// <summary>Base class of all queries that return a sequence of elements (Ranges, Index lookups, ...)</summary>
@@ -42,17 +40,10 @@ namespace FoundationDB.Linq.Expressions
 	public abstract class FdbQuerySequenceExpression<T> : FdbQueryExpression<IAsyncEnumerable<T>>
 	{
 		/// <summary>Type of elements returned by the sequence</summary>
-		public Type ElementType
-		{
-			[NotNull]
-			get { return typeof(T); }
-		}
+		public Type ElementType => typeof(T);
 
 		/// <summary>Always returns <see cref="FdbQueryShape.Sequence"/></summary>
-		public override FdbQueryShape Shape
-		{
-			get { return FdbQueryShape.Sequence; }
-		}
+		public override FdbQueryShape Shape => FdbQueryShape.Sequence;
 
 		/// <summary>Returns a new expression that creates an async sequence that will execute this query on a transaction</summary>
 		public abstract Expression<Func<IFdbReadOnlyTransaction, IAsyncEnumerable<T>>> CompileSequence();

--- a/FoundationDB.Linq.Providers/Expressions/FdbQuerySingleExpression.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQuerySingleExpression.cs
@@ -30,15 +30,13 @@ namespace FoundationDB.Linq.Expressions
 {
 	using System;
 	using System.Collections.Generic;
-	using System.Diagnostics.Contracts;
 	using System.Globalization;
 	using System.Linq.Expressions;
 	using System.Reflection;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Doxense.Linq;
+	using Doxense.Diagnostics.Contracts;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Base class of all queries that return a single element</summary>
 	/// <typeparam name="T">Type of the elements of the source sequence</typeparam>
@@ -58,13 +56,11 @@ namespace FoundationDB.Linq.Expressions
 		public override FdbQueryShape Shape => FdbQueryShape.Single;
 
 		/// <summary>Source sequence</summary>
-		[NotNull]
 		public FdbQuerySequenceExpression<T> Sequence { get; }
 
 		/// <summary>Name of this query</summary>
 		public string Name { get; }
 
-		[NotNull]
 		public Expression<Func<IAsyncEnumerable<T>, CancellationToken, Task<R>>> Handler { get; }
 
 		/// <summary>Apply a custom visitor to this expression</summary>

--- a/FoundationDB.Linq.Providers/Expressions/FdbQueryTransformExpression.cs
+++ b/FoundationDB.Linq.Providers/Expressions/FdbQueryTransformExpression.cs
@@ -34,7 +34,6 @@ namespace FoundationDB.Linq.Expressions
 	using Doxense.Diagnostics.Contracts;
 	using Doxense.Linq;
 	using FoundationDB.Client;
-	using JetBrains.Annotations;
 
 	/// <summary>Expression that represent a projection from one type into another</summary>
 	/// <typeparam name="T">Type of elements in the inner sequence</typeparam>
@@ -50,18 +49,10 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Source sequence that is being transformed</summary>
-		public FdbQuerySequenceExpression<T> Source
-		{
-			[NotNull] get;
-			private set;
-		}
+		public FdbQuerySequenceExpression<T> Source { get; }
 
 		/// <summary>Transformation applied to each element of <see cref="Source"/></summary>
-		public Expression<Func<T, R>> Transform
-		{
-			[NotNull] get;
-			private set;
-		}
+		public Expression<Func<T, R>> Transform { get; }
 
 		/// <summary>Apply a custom visitor to this expression</summary>
 		public override Expression Accept(FdbQueryExpressionVisitor visitor)
@@ -80,7 +71,6 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Returns a new expression that creates an async sequence that will execute this query on a transaction</summary>
-		[NotNull]
 		public override Expression<Func<IFdbReadOnlyTransaction, IAsyncEnumerable<R>>> CompileSequence()
 		{
 			var lambda = this.Transform.Compile();

--- a/FoundationDB.Linq.Providers/Interfaces.cs
+++ b/FoundationDB.Linq.Providers/Interfaces.cs
@@ -28,25 +28,24 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace FoundationDB.Linq
 {
-	using FoundationDB.Client;
-	using FoundationDB.Layers.Indexing;
-	using FoundationDB.Linq.Expressions;
-	using JetBrains.Annotations;
 	using System;
 	using System.Threading;
 	using System.Threading.Tasks;
+	using FoundationDB.Client;
+	using FoundationDB.Layers.Indexing;
+	using FoundationDB.Linq.Expressions;
 
-	/// <summary>Base inteface of all queryable objects</summary>
+	/// <summary>Base interface of all queryable objects</summary>
 	public interface IFdbAsyncQueryable
 	{
 		/// <summary>Type of the results of the query</summary>
-		Type Type { [NotNull] get; }
+		Type Type { get; }
 
 		/// <summary>Expression describing the intent of the query</summary>
-		FdbQueryExpression Expression { [NotNull] get; }
+		FdbQueryExpression Expression { get; }
 
 		/// <summary>Provider that created this query</summary>
-		IFdbAsyncQueryProvider Provider { [NotNull] get; }
+		IFdbAsyncQueryProvider Provider { get; }
 	}
 
 	/// <summary>Queryable that returns a single result of type T</summary>
@@ -60,26 +59,23 @@ namespace FoundationDB.Linq
 	public interface IFdbAsyncSequenceQueryable<out T> : IFdbAsyncQueryable
 	{
 		/// <summary>Type of elements of the sequence</summary>
-		Type ElementType { [NotNull] get; }
+		Type ElementType { get; }
 	}
 
 	/// <summary>Query provider</summary>
 	public interface IFdbAsyncQueryProvider 
 	{
 		/// <summary>Wraps a query expression into a new queryable</summary>
-		[NotNull]
-		IFdbAsyncQueryable CreateQuery([NotNull] FdbQueryExpression expression);
+		IFdbAsyncQueryable CreateQuery(FdbQueryExpression expression);
 
 		/// <summary>Wraps a typed query expression into a new queryable</summary>
-		[NotNull]
-		IFdbAsyncQueryable<R> CreateQuery<R>([NotNull] FdbQueryExpression<R> expression);
+		IFdbAsyncQueryable<R> CreateQuery<R>(FdbQueryExpression<R> expression);
 
 		/// <summary>Wraps a type sequence query expression into a new queryable</summary>
-		[NotNull]
-		IFdbAsyncSequenceQueryable<R> CreateSequenceQuery<R>([NotNull] FdbQuerySequenceExpression<R> expression);
+		IFdbAsyncSequenceQueryable<R> CreateSequenceQuery<R>(FdbQuerySequenceExpression<R> expression);
 
 		/// <summary>Execute a query expression into a typed result</summary>
-		Task<R> ExecuteAsync<R>([NotNull] FdbQueryExpression expression, CancellationToken ct = default(CancellationToken));
+		Task<R> ExecuteAsync<R>(FdbQueryExpression expression, CancellationToken ct = default(CancellationToken));
 	}
 
 	/// <summary>Queryable transaction</summary>
@@ -88,7 +84,6 @@ namespace FoundationDB.Linq
 		// Note: this interface is only used to hook extension methods specific to transaction queries
 
 		/// <summary>Transaction used by this query</summary>
-		[NotNull]
 		IFdbReadOnlyTransaction Transaction { get; }
 
 	}
@@ -99,7 +94,7 @@ namespace FoundationDB.Linq
 		// Note: this interface is only used to hook extension methods specific to index queries
 
 		/// <summary>Index used by this query</summary>
-		FdbIndex<TId, TValue> Index { [NotNull] get; }
+		FdbIndex<TId, TValue> Index { get; }
 
 	}
 

--- a/FoundationDB.Linq.Providers/Visitors/FdbQueryExpressionStringBuilder.cs
+++ b/FoundationDB.Linq.Providers/Visitors/FdbQueryExpressionStringBuilder.cs
@@ -51,10 +51,7 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Writer used by this builder</summary>
-		public FdbDebugStatementWriter Writer
-		{
-			[NotNull] get { return m_writer; }
-		}
+		public FdbDebugStatementWriter Writer => m_writer;
 
 		/// <summary>Returns the text expression that has been written so far</summary>
 		public override string ToString()
@@ -65,7 +62,7 @@ namespace FoundationDB.Linq.Expressions
 		/// <summary>Visit a node and appends it to the string builder</summary>
 		/// <param name="node"></param>
 		/// <returns></returns>
-		public override Expression Visit(FdbQueryExpression node)
+		public override Expression Visit(FdbQueryExpression? node)
 		{
 			if (node != null)
 			{

--- a/FoundationDB.Linq.Providers/Visitors/FdbQueryExpressionVisitor.cs
+++ b/FoundationDB.Linq.Providers/Visitors/FdbQueryExpressionVisitor.cs
@@ -38,8 +38,7 @@ namespace FoundationDB.Linq.Expressions
 		/// <summary>Visit an extension node</summary>
 		protected override Expression VisitExtension(Expression node)
 		{
-			var expr = node as FdbQueryExpression;
-			if (expr != null)
+			if (node is FdbQueryExpression expr)
 			{
 				return Visit(expr);
 			}
@@ -47,13 +46,9 @@ namespace FoundationDB.Linq.Expressions
 		}
 
 		/// <summary>Visit this expression</summary>
-		public virtual Expression Visit(FdbQueryExpression node)
+		public virtual Expression? Visit(FdbQueryExpression? node)
 		{
-			if (node != null)
-			{
-				return node.Accept(this);
-			}
-			return null;
+			return node?.Accept(this);
 		}
 
 		/// <summary>Visit an Async Sequence query expression</summary>

--- a/FoundationDB.Tests/FdbTest.cs
+++ b/FoundationDB.Tests/FdbTest.cs
@@ -300,21 +300,21 @@ namespace FoundationDB.Client.Tests
 
 		[DebuggerNonUserCode]
 		[StringFormatMethod("format")]
-		public static void Log([NotNull] string format, object arg0)
+		public static void Log(string format, object arg0)
 		{
 			WriteToLog(String.Format(CultureInfo.InvariantCulture, format, arg0));
 		}
 
 		[DebuggerNonUserCode]
 		[StringFormatMethod("format")]
-		public static void Log([NotNull] string format, object arg0, object arg1)
+		public static void Log(string format, object arg0, object arg1)
 		{
 			WriteToLog(String.Format(CultureInfo.InvariantCulture, format, arg0, arg1));
 		}
 
 		[DebuggerNonUserCode]
 		[StringFormatMethod("format")]
-		public static void Log([NotNull] string format, params object[] args)
+		public static void Log(string format, params object[] args)
 		{
 			WriteToLog(String.Format(CultureInfo.InvariantCulture, format, args));
 		}


### PR DESCRIPTION
Replace the JetBrains nullability annotation (NotNull, MaybeNull, ...) by the new c# 8.0 nullability syntax.

Unfortunately the new syntax in c# 8.0 is less expressive than JetBrain's, so there are a few regression here and there, but there's nothing we can do about it except wait for c# 9.0...

For net472 and netstandard2.0 platforms, added "fake" attributes (marked private) with the same names as the ones in `System.Diagnostics.CodeAnalysis` so that the code builds (but without nullability analysis).

For netstandard2.1, use the actual attributes.