### PR TITLE
Refactoring of Directory Paths

### DIFF
--- a/FdbShell/Commands/BasicCommands.cs
+++ b/FdbShell/Commands/BasicCommands.cs
@@ -53,9 +53,9 @@ namespace FdbShell
 					return;
 				}
 
-				if (parent.Layer.IsPresent)
+				if (!string.IsNullOrEmpty(parent.Layer))
 				{
-					log.WriteLine($"# Layer: {parent.Layer:P}");
+					log.WriteLine($"# Layer: {parent.Layer}");
 				}
 
 				var folders = await Fdb.Directory.BrowseAsync(tr, parent);
@@ -72,16 +72,16 @@ namespace FdbShell
 								if (!(subfolder is FdbDirectoryPartition))
 								{
 									long count = await Fdb.System.EstimateCountAsync(db, subfolder.ToRange(), ct);
-									Program.StdOut(log, $"  {FdbKey.Dump(subfolder.Copy().GetPrefix()),-12} {(subfolder.Layer.IsNullOrEmpty ? "-" : ("<" + subfolder.Layer.ToUnicode() + ">")),-12} {count,9:N0} {name}", ConsoleColor.White);
+									Program.StdOut(log, $"  {FdbKey.Dump(subfolder.Copy().GetPrefix()),-12} {(string.IsNullOrEmpty(subfolder.Layer) ? "-" : ("<" + subfolder.Layer + ">")),-12} {count,9:N0} {name}", ConsoleColor.White);
 								}
 								else
 								{
-									Program.StdOut(log, $"  {FdbKey.Dump(subfolder.Copy().GetPrefix()),-12} {(subfolder.Layer.IsNullOrEmpty ? "-" : ("<" + subfolder.Layer.ToUnicode() + ">")),-12} {"-",9} {name}", ConsoleColor.White);
+									Program.StdOut(log, $"  {FdbKey.Dump(subfolder.Copy().GetPrefix()),-12} {(string.IsNullOrEmpty(subfolder.Layer) ? "-" : ("<" + subfolder.Layer + ">")),-12} {"-",9} {name}", ConsoleColor.White);
 								}
 							}
 							else
 							{
-								Program.StdOut(log, $"  {FdbKey.Dump(subfolder.Copy().GetPrefix()),-12} {(subfolder.Layer.IsNullOrEmpty ? "-" : ("<" + subfolder.Layer.ToUnicode() + ">")),-12} {name}", ConsoleColor.White);
+								Program.StdOut(log, $"  {FdbKey.Dump(subfolder.Copy().GetPrefix()),-12} {(string.IsNullOrEmpty(subfolder.Layer) ? "-" : ("<" + subfolder.Layer + ">")),-12} {name}", ConsoleColor.White);
 							}
 						}
 						else
@@ -109,7 +109,9 @@ namespace FdbShell
 
 			string layer = extras.Count > 0 ? extras.Get<string>(0) : null;
 
-			log.WriteLine($"# Creating directory {location.Path} with layer '{layer}'");
+			throw new NotImplementedException();
+			var path = location.Path.WithLayer(layer);
+			log.WriteLine($"# Creating directory {path}");
 
 			(var prefix, var created) = await db.ReadWriteAsync(async tr =>
 			{
@@ -119,7 +121,7 @@ namespace FdbShell
 					return (folder.GetPrefix(), false);
 				}
 
-				folder = await location.TryCreateAsync(tr, layer: Slice.FromString(layer));
+				folder = await location.TryCreateAsync(tr);
 				return (Slice.Nil /*folder.GetPrefixUnsafe()*/, true);
 			}, ct);
 
@@ -225,8 +227,8 @@ namespace FdbShell
 			{
 				if (dir.Layer == FdbDirectoryPartition.LayerId)
 					log.WriteLine($"# Directory {location.Path} is a partition");
-				else if (dir.Layer.IsPresent)
-					log.WriteLine($"# Directory {location.Path} has layer {dir.Layer:P}");
+				else if (!string.IsNullOrEmpty(dir.Layer))
+					log.WriteLine($"# Directory {location.Path} has layer '{dir.Layer}'");
 				else
 					log.WriteLine($"# Directory {location.Path} does not have a layer defined");
 			}
@@ -243,7 +245,7 @@ namespace FdbShell
 				}
 				else
 				{
-					dir = await dir.ChangeLayerAsync(tr, Slice.FromString(layer));
+					dir = await dir.ChangeLayerAsync(tr, layer);
 					Program.Success(log, $"# Directory {location.Path} layer changed to {dir.Layer:P}");
 				}
 			}, ct);
@@ -700,7 +702,7 @@ namespace FdbShell
 			}
 			else
 			{
-				stream.WriteLine($"{sb}{(folder.Layer.ToString() == "partition" ? ("<" + folder.Name + ">") : folder.Name)}{(folder.Layer.IsNullOrEmpty ? string.Empty : (" [" + folder.Layer.ToString() + "]"))}");
+				stream.WriteLine($"{sb}{(folder.Layer.ToString() == "partition" ? ("<" + folder.Name + ">") : folder.Name)}{(string.IsNullOrEmpty(folder.Layer) ? string.Empty : (" [" + folder.Layer + "]"))}");
 				node = folder;
 			}
 

--- a/FdbShell/Commands/BasicCommands.cs
+++ b/FdbShell/Commands/BasicCommands.cs
@@ -120,7 +120,7 @@ namespace FdbShell
 				}
 
 				folder = await location.TryCreateAsync(tr, layer: Slice.FromString(layer));
-				return (folder.GetPrefix(), true);
+				return (Slice.Nil /*folder.GetPrefixUnsafe()*/, true);
 			}, ct);
 
 			if (!created)
@@ -738,7 +738,7 @@ namespace FdbShell
 			Program.StdOut(log, "Listing all directories...");
 			var map = new Dictionary<string, int>(StringComparer.Ordinal);
 
-			void Account(FdbDirectoryPath p, int c)
+			void Account(FdbPath p, int c)
 			{
 				for (int i = 1; i <= p.Count; i++)
 				{

--- a/FdbShell/Program.cs
+++ b/FdbShell/Program.cs
@@ -191,7 +191,7 @@ namespace FdbShell
 			#region Options Parsing...
 
 			string clusterFile = null;
-			var partition = FdbDirectoryPath.Empty;
+			var partition = FdbPath.Root;
 			bool showHelp = false;
 			int timeout = 30;
 			int maxRetries = 10;
@@ -207,7 +207,7 @@ namespace FdbShell
 				{ 
 					"p|partition=",
 					"The name of the database partition to open.",
-					v => partition = FdbDirectoryPath.Parse(v.Trim())
+					v => partition = FdbPath.Parse(v.Trim())
 				},
 				{
 					"t|timeout=",
@@ -687,12 +687,12 @@ namespace FdbShell
 								string prm = PopParam(ref extras);
 								if (string.IsNullOrEmpty(prm))
 								{
-									StdOut($"# Current partition is {String.Join("/", partition)}");
+									StdOut($"# Current partition is {partition}");
 									//TODO: browse existing partitions ?
 									break;
 								}
 
-								var newPartition = FdbDirectoryPath.Parse(prm.Trim());
+								var newPartition = FdbPath.Parse(prm.Trim());
 								IFdbDatabase newDb = null;
 								try
 								{
@@ -721,7 +721,7 @@ namespace FdbShell
 
 										Db = newDb;
 										partition = newPartition;
-										StdOut($"# Changed partition to /{string.Join("/", partition)}");
+										StdOut($"# Changed partition to {partition}");
 									}
 								}
 
@@ -870,7 +870,7 @@ namespace FdbShell
 
 		private static FdbDirectorySubspaceLocation ParsePath(string path)
 		{
-			return Db.Root[FdbDirectoryPath.Parse(path)];
+			return Db.Root[FdbPath.Parse(path)];
 			//path = path.Replace("\\", "/").Trim();
 			//return path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 		}
@@ -881,8 +881,8 @@ namespace FdbShell
 			var parent = await db.ReadAsync(tr => BasicCommands.TryOpenCurrentDirectoryAsync(tr, path), ct);
 			if (parent == null) return null;
 
-			var names = await db.ReadAsync(tr => parent.ListAsync(tr), ct);
-			return names.ToArray();
+			var paths = await db.ReadAsync(tr => parent.ListAsync(tr), ct);
+			return paths.Select(p => p.Name).ToArray();
 		}
 
 		#endregion

--- a/FdbShell/Program.cs
+++ b/FdbShell/Program.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2018, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Client/Fdb.cs
+++ b/FoundationDB.Client/Fdb.cs
@@ -544,8 +544,8 @@ namespace FoundationDB.Client
 
 			string? clusterFile = options.ClusterFile;
 			bool readOnly = options.ReadOnly;
-			var directory = new FdbDirectoryLayer(SubspaceLocation.Empty);
-			var root = new FdbDirectorySubspaceLocation(options.Root, FdbDirectoryPartition.LayerId);
+			var directory = new FdbDirectoryLayer(SubspaceLocation.Root);
+			var root = new FdbDirectorySubspaceLocation(options.Root ?? FdbPath.Root, FdbDirectoryPartition.LayerId);
 			bool hasPartition = root.Path.Count != 0;
 
 			if (Logging.On) Logging.Info(typeof(Fdb), nameof(OpenInternalAsync), $"Connecting to database using cluster file '{clusterFile ?? "<default>"}' and root '{root}' ...");

--- a/FoundationDB.Client/Fdb.cs
+++ b/FoundationDB.Client/Fdb.cs
@@ -545,7 +545,7 @@ namespace FoundationDB.Client
 			string? clusterFile = options.ClusterFile;
 			bool readOnly = options.ReadOnly;
 			var directory = new FdbDirectoryLayer(SubspaceLocation.Root);
-			var root = new FdbDirectorySubspaceLocation(options.Root ?? FdbPath.Root, FdbDirectoryPartition.LayerId);
+			var root = new FdbDirectorySubspaceLocation(options.Root ?? FdbPath.Root);
 			bool hasPartition = root.Path.Count != 0;
 
 			if (Logging.On) Logging.Info(typeof(Fdb), nameof(OpenInternalAsync), $"Connecting to database using cluster file '{clusterFile ?? "<default>"}' and root '{root}' ...");
@@ -565,7 +565,7 @@ namespace FoundationDB.Client
 
 				if (hasPartition)
 				{ // open the partition, and switch the root of the db
-					await Fdb.Directory.SwitchToNamedPartitionAsync(db, root, readOnly, ct);
+					await Fdb.Directory.SwitchToNamedPartitionAsync(db, root.Path, ct);
 				}
 
 				success = true;

--- a/FoundationDB.Client/FdbConnectionOptions.cs
+++ b/FoundationDB.Client/FdbConnectionOptions.cs
@@ -66,7 +66,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Default root location used by the database (empty prefix by default)</summary>
 		/// <remarks>If specified, all started transactions will be automatically rooted to this location.</remarks>
-		public FdbDirectoryPath Root { get; set; }
+		public FdbPath? Root { get; set; }
 
 		/// <summary>If set, specify the datacenter ID that was passed to fdbserver processes running in the same datacenter as this client, for better location-aware load balancing.</summary>
 		public string? DataCenterId { get; set; }
@@ -79,7 +79,7 @@ namespace FoundationDB.Client
 		{
 			var sb = new StringBuilder();
 			AddKeyValue(sb, "cluster_file", this.ClusterFile ?? "default");
-			if (!this.Root.IsEmpty) AddKeyValue(sb, "root", "/" + this.Root.ToString());
+			if (this.Root != null) AddKeyValue(sb, "root", this.Root.ToString());
 			//REVIEW: cannot serialize subspace into a string ! :(
 			if (this.ReadOnly) AddKeyword(sb, "readonly");
 			if (this.DefaultTimeout > TimeSpan.Zero) AddKeyValue(sb, "timeout", this.DefaultTimeout.TotalSeconds);

--- a/FoundationDB.Client/FdbKey.cs
+++ b/FoundationDB.Client/FdbKey.cs
@@ -299,16 +299,20 @@ namespace FoundationDB.Client
 										case 0xFF:
 										{
 											//***README*** if you break under here, see README in the last catch() block
-											tuple = TuPack.Unpack(key[0, -1]);
-											suffix = ".<FF>";
+											if (TuPack.TryUnpack(key[0, -1], out tuple))
+											{
+												suffix = ".<FF>";
+											}
 											break;
 										}
 										case 0x01:
 										{
 											var tmp = key[0, -1] + (byte)0;
 											//***README*** if you break under here, see README in the last catch() block
-											tuple = TuPack.Unpack(tmp);
-											suffix = " + 1";
+											if (TuPack.TryUnpack(tmp, out tuple))
+											{
+												suffix = " + 1";
+											}
 											break;
 										}
 									}
@@ -324,8 +328,10 @@ namespace FoundationDB.Client
 									if (key.Count > 2 && key[-1] == 0 && key[-2] != 0xFF)
 									{
 										//***README*** if you break under here, see README in the last catch() block
-										tuple = TuPack.Unpack(key[0, -1]);
-										suffix = ".<00>";
+										if (TuPack.TryUnpack(key[0, -1], out tuple))
+										{
+											suffix = ".<00>";
+										}
 									}
 									break;
 								}
@@ -339,8 +345,7 @@ namespace FoundationDB.Client
 
 						if (tuple == null && !skip)
 						{ // attempt a regular decoding
-							//***README*** if you break under here, see README in the last catch() block
-							tuple = TuPack.Unpack(key);
+							TuPack.TryUnpack(key, out tuple);
 						}
 
 						if (tuple != null) return tuple.ToString() + suffix;

--- a/FoundationDB.Client/Layers/Directories/Fdb.Directory.cs
+++ b/FoundationDB.Client/Layers/Directories/Fdb.Directory.cs
@@ -76,7 +76,7 @@ namespace FoundationDB.Client
 				// open all the subdirectories
 				var folders = await names
 					.ToAsyncEnumerable()
-					.SelectAsync((name, _) => parent.OpenAsync(tr, name))
+					.SelectAsync((name, _) => parent.OpenAsync(tr, FdbPath.MakeRelative(name)))
 					.ToListAsync();
 
 				// map the result

--- a/FoundationDB.Client/Layers/Directories/Fdb.Directory.cs
+++ b/FoundationDB.Client/Layers/Directories/Fdb.Directory.cs
@@ -46,17 +46,17 @@ namespace FoundationDB.Client
 		{
 
 			/// <summary>Opens a named partition, and change the root subspace of the database to the corresponding prefix</summary>
-			internal static async Task SwitchToNamedPartitionAsync(FdbDatabase db, FdbDirectorySubspaceLocation top, bool readOnly, CancellationToken ct)
+			internal static async Task SwitchToNamedPartitionAsync(FdbDatabase db, FdbPath root, CancellationToken ct)
 			{
-				Contract.Requires(db != null && top != null);
+				Contract.Requires(db != null);
 				ct.ThrowIfCancellationRequested();
 
 				if (Logging.On) Logging.Verbose(typeof(Fdb.Directory), "OpenNamedPartitionAsync", $"Opened root layer using cluster file '{db.ClusterFile}'");
 
-				if (top.Path.Count != 0)
+				if (root.Count != 0)
 				{
 					// create the root partition if does not already exist
-					var descriptor = await db.ReadWriteAsync(tr => db.DirectoryLayer.CreateOrOpenAsync(tr, top.Path, layer: FdbDirectoryPartition.LayerId), ct).ConfigureAwait(false);
+					var descriptor = await db.ReadWriteAsync(tr => db.DirectoryLayer.CreateOrOpenAsync(tr, root), ct).ConfigureAwait(false);
 					if (Logging.On) Logging.Info(typeof(Fdb.Directory), "OpenNamedPartitionAsync", $"Opened partition {descriptor.Path} at {descriptor.GetPrefixUnsafe()}");
 				}
 			}

--- a/FoundationDB.Client/Layers/Directories/Fdb.Directory.cs
+++ b/FoundationDB.Client/Layers/Directories/Fdb.Directory.cs
@@ -76,7 +76,7 @@ namespace FoundationDB.Client
 				// open all the subdirectories
 				var folders = await names
 					.ToAsyncEnumerable()
-					.SelectAsync((name, _) => parent.OpenAsync(tr, FdbPath.MakeRelative(name)))
+					.SelectAsync((name, _) => parent.OpenAsync(tr, FdbPath.Relative(name)))
 					.ToListAsync();
 
 				// map the result

--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
@@ -38,7 +38,6 @@ namespace FoundationDB.Client
 	using JetBrains.Annotations;
 	using Doxense.Collections.Tuples;
 	using Doxense.Diagnostics.Contracts;
-	using Doxense.Linq;
 	using Doxense.Memory;
 	using FoundationDB.Filters.Logging;
 	using FoundationDB.Layers.Allocators;
@@ -99,8 +98,8 @@ namespace FoundationDB.Client
 
 		FdbDirectorySubspaceLocation IFdbDirectory.Location => new FdbDirectorySubspaceLocation(this.Path);
 
-		/// <summary>Returns the layer id for this <code>FdbDirectoryLayer</code>, which is always Slice.Empty.</summary>
-		Slice IFdbDirectory.Layer => Slice.Empty;
+		/// <summary>Returns the layer id for this <code>FdbDirectoryLayer</code>, which is always <see cref="string.Empty"/>.</summary>
+		string IFdbDirectory.Layer => string.Empty;
 
 		/// <summary>Self reference</summary>
 		FdbDirectoryLayer IFdbDirectory.DirectoryLayer => this;
@@ -113,15 +112,15 @@ namespace FoundationDB.Client
 			return path.Count != 0 ? this.Path.Add(path) : this.Path;
 		}
 
-		void IFdbDirectory.CheckLayer(Slice layer)
+		void IFdbDirectory.CheckLayer(string? layer)
 		{
-			if (layer.Count != 0)
+			if (!string.IsNullOrEmpty(layer))
 			{
-				throw ThrowHelper.InvalidOperationException($"The directory layer {this.FullName} is not compatible with layer {layer:K}.");
+				throw ThrowHelper.InvalidOperationException($"The directory layer {this.FullName} is not compatible with layer {layer}.");
 			}
 		}
 
-		Task<FdbDirectorySubspace> IFdbDirectory.ChangeLayerAsync(IFdbTransaction trans, Slice newLayer)
+		Task<FdbDirectorySubspace> IFdbDirectory.ChangeLayerAsync(IFdbTransaction trans, string newLayer)
 		{
 			throw ThrowHelper.NotSupportedException("You cannot change the layer of a Directory Layer.");
 		}
@@ -156,15 +155,14 @@ namespace FoundationDB.Client
 		/// <summary>Opens the directory with the given path. If the directory does not exist, it is created (creating parent directories if necessary).</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to create or open</param>
-		/// <param name="layer">If layer is specified, it is checked against the layer of an existing directory or set as the layer of a new directory.</param>
-		public async Task<FdbDirectorySubspace> CreateOrOpenAsync(IFdbTransaction trans, FdbPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace> CreateOrOpenAsync(IFdbTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var location = VerifyPath(path);
 
 			var metadata = await Resolve(trans);
-			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, layer, Slice.Nil, allowCreate: true, allowOpen: true, throwOnError: true))!;
+			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, Slice.Nil, allowCreate: true, allowOpen: true, throwOnError: true))!;
 		}
 
 		/// <summary>Opens the directory with the given <paramref name="path"/>.
@@ -172,15 +170,14 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to open.</param>
-		/// <param name="layer">Optional layer id of the directory. If it is different than the layer specified when creating the directory, an exception will be thrown.</param>
-		public async Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var location = VerifyPath(path);
 
 			var metadata = await Resolve(trans);
-			return (await metadata.CreateOrOpenInternalAsync(trans, null, location, layer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: true))!;
+			return (await metadata.CreateOrOpenInternalAsync(trans, null, location, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: true))!;
 		}
 
 		/// <summary>Creates a directory with the given <paramref name="path"/> (creating parent directories if necessary).
@@ -188,37 +185,36 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to create</param>
-		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
-		public async Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var location = VerifyPath(path);
 
 			var metadata = await Resolve(trans);
-			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, layer, prefix: Slice.Nil, allowCreate: true, allowOpen: false, throwOnError: true))!;
+			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, prefix: Slice.Nil, allowCreate: true, allowOpen: false, throwOnError: true))!;
 		}
 
 		/// <summary>Attempts to open the directory with the given <paramref name="path"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to open.</param>
 		/// <param name="layer">Optional layer id of the directory. If it is different than the layer specified when creating the directory, an exception will be thrown.</param>
-		public async Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var location = VerifyPath(path);
 
 			var metadata = await Resolve(trans);
-			return (await metadata.CreateOrOpenInternalAsync(trans, null, location, layer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: false))!;
+			return (await metadata.CreateOrOpenInternalAsync(trans, null, location, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: false))!;
 		}
 
-		public async ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default)
+		public async ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var metadata = await Resolve(trans);
-			return await metadata.OpenCachedInternalAsync(trans, path, layer, throwOnError: false);
+			return await metadata.OpenCachedInternalAsync(trans, path, throwOnError: false);
 		}
 
 		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<FdbPath> paths)
@@ -226,29 +222,20 @@ namespace FoundationDB.Client
 			Contract.NotNull(trans, nameof(trans));
 
 			var metadata = await Resolve(trans);
-			return await metadata.OpenCachedInternalAsync(trans, paths.Select(p => (p, Slice.Nil)).ToArray(), throwOnError: false);
-		}
-
-		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<(FdbPath Path, Slice Layer)> paths)
-		{
-			Contract.NotNull(trans, nameof(trans));
-
-			var metadata = await Resolve(trans);
-			return await metadata.OpenCachedInternalAsync(trans, paths as (FdbPath, Slice)[] ?? paths.ToArray(), throwOnError: false);
+			return await metadata.OpenCachedInternalAsync(trans, (paths as FdbPath[]) ?? paths.ToArray(), throwOnError: false);
 		}
 
 		/// <summary>Attempts to create a directory with the given <paramref name="path"/> (creating parent directories if necessary).</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to create</param>
-		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
-		public async Task<FdbDirectorySubspace?> TryCreateAsync(IFdbTransaction trans, FdbPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace?> TryCreateAsync(IFdbTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var location = VerifyPath(path);
 
 			var metadata = await Resolve(trans);
-			return await metadata.CreateOrOpenInternalAsync(null, trans, location, layer, prefix: Slice.Nil, allowCreate: true, allowOpen: false, throwOnError: false);
+			return await metadata.CreateOrOpenInternalAsync(null, trans, location, prefix: Slice.Nil, allowCreate: true, allowOpen: false, throwOnError: false);
 		}
 
 		/// <summary>Registers an existing prefix as a directory with the given <paramref name="path"/> (creating parent directories if necessary). This method is only indented for advanced use cases.</summary>
@@ -256,14 +243,14 @@ namespace FoundationDB.Client
 		/// <param name="path">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
 		/// <param name="prefix">The directory will be created with the given physical prefix; otherwise a prefix is allocated automatically.</param>
-		public async Task<FdbDirectorySubspace> RegisterAsync(IFdbTransaction trans, FdbPath path, Slice layer, Slice prefix)
+		public async Task<FdbDirectorySubspace> RegisterAsync(IFdbTransaction trans, FdbPath path, Slice prefix)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var location = VerifyPath(path);
 
 			var metadata = await Resolve(trans);
-			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, layer, prefix: prefix, allowCreate: true, allowOpen: false, throwOnError: true))!;
+			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, prefix: prefix, allowCreate: true, allowOpen: false, throwOnError: true))!;
 		}
 
 		/// <summary>Attempts to register an existing prefix as a directory with the given <paramref name="path"/> (creating parent directories if necessary). This method is only indented for advanced use cases.</summary>
@@ -271,14 +258,14 @@ namespace FoundationDB.Client
 		/// <param name="path">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
 		/// <param name="prefix">The directory will be created with the given physical prefix; otherwise a prefix is allocated automatically.</param>
-		public async Task<FdbDirectorySubspace?> TryRegisterAsync(IFdbTransaction trans, FdbPath path, Slice layer, Slice prefix)
+		public async Task<FdbDirectorySubspace?> TryRegisterAsync(IFdbTransaction trans, FdbPath path, Slice prefix)
 		{
 			Contract.NotNull(trans, nameof(trans));
 
 			var location = VerifyPath(path);
 
 			var metadata = await Resolve(trans);
-			return await metadata.CreateOrOpenInternalAsync(null, trans, location, layer, prefix: prefix, allowCreate: true, allowOpen: false, throwOnError: false);
+			return await metadata.CreateOrOpenInternalAsync(null, trans, location, prefix: prefix, allowCreate: true, allowOpen: false, throwOnError: false);
 		}
 
 		#endregion
@@ -436,18 +423,20 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the directory to change</param>
 		/// <param name="newLayer">New layer id of the directory</param>
-		public async Task<FdbDirectorySubspace> ChangeLayerAsync(IFdbTransaction trans, FdbPath path, Slice newLayer)
+		public async Task<FdbDirectorySubspace> ChangeLayerAsync(IFdbTransaction trans, FdbPath path, string newLayer)
 		{
 			Contract.NotNull(trans, nameof(trans));
+			Contract.NotNull(newLayer, nameof(newLayer));
 			var location = VerifyPath(path);
 
 			var metadata = await Resolve(trans);
 
 			// Set the layer to the new value
 			await metadata.ChangeLayerInternalAsync(trans, location, newLayer).ConfigureAwait(false);
+			var newPath = path.WithLayer(newLayer);
 
 			// And re-open the directory subspace
-			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, newLayer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: true).ConfigureAwait(false))!;
+			return (await metadata.CreateOrOpenInternalAsync(null, trans, newPath, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: true).ConfigureAwait(false))!;
 		}
 
 		public override string ToString()
@@ -459,10 +448,11 @@ namespace FoundationDB.Client
 
 		#region Internal Helpers...
 
+		[DebuggerDisplay("Path={Path}, Prefix={Prefix}, Layer={Layer}")]
 		internal readonly struct Node
 		{
 
-			public Node(FdbPath path, Slice prefix, Slice layer, PartitionDescriptor partition, PartitionDescriptor parentPartition)
+			public Node(FdbPath path, Slice prefix, string? layer, PartitionDescriptor partition, PartitionDescriptor parentPartition, Slice prefixInParentPartition)
 			{
 				Contract.Requires(partition != null && parentPartition != null);
 				this.Prefix = prefix;
@@ -470,13 +460,15 @@ namespace FoundationDB.Client
 				this.Layer = layer;
 				this.Partition = partition;
 				this.ParentPartition = parentPartition;
+				this.PrefixInParentPartition = prefixInParentPartition;
 			}
 
 			public readonly Slice Prefix;
 			public readonly FdbPath Path;
-			public readonly Slice Layer;
+			public readonly string? Layer;
 			public readonly PartitionDescriptor Partition;
 			public readonly PartitionDescriptor ParentPartition;
+			public readonly Slice PrefixInParentPartition;
 
 			public bool Exists => !this.Prefix.IsNull;
 
@@ -547,10 +539,10 @@ namespace FoundationDB.Client
 				this.ReadVersion = readVersion;
 			}
 
-			private static void SetLayer(IFdbTransaction trans, PartitionDescriptor partition, Slice prefix, Slice layer)
+			private static void SetLayer(IFdbTransaction trans, PartitionDescriptor partition, Slice prefix, string layer)
 			{
-				if (layer.IsNull) layer = Slice.Empty;
-				trans.Set(partition.Nodes.Encode(prefix, LayerAttribute), layer);
+				Contract.Requires(layer != null);
+				trans.Set(partition.Nodes.Encode(prefix, LayerAttribute), Slice.FromStringUtf8(layer));
 			}
 
 			private void UpdatePartitionMetadataVersion(IFdbTransaction trans, PartitionDescriptor partition, bool init = false)
@@ -589,26 +581,28 @@ namespace FoundationDB.Client
 				var current = partition.Nodes.GetPrefix();
 
 				int i = 0;
-				var layer = Slice.Nil;
+				string layer = FdbDirectoryPartition.LayerId; // the root is by convention a "partition"
 				PartitionDescriptor parent = partition;
+				Slice prefixInParentPartition  = current;
 				while (i < path.Count)
 				{
 					if (AnnotateTransactions) tr.Annotate("Looking for child {0} under node {1}...", path[i], FdbKey.Dump(current));
 
 					// maybe use the node cache, if allowed
-					var key = partition.Nodes.Encode(current, SUBDIRS, path[i]);
+					var key = partition.Nodes.Encode(current, SUBDIRS, path[i].Name);
 					current = await tr.GetAsync(key).ConfigureAwait(false);
 
 					if (current.IsNull)
 					{
-						return new Node(path, Slice.Nil, Slice.Nil, partition, parent);
+						return new Node(path, Slice.Nil, null, partition, parent, Slice.Nil);
 					}
 
 					if (AnnotateTransactions) tr.Annotate("Reading Layer value for subfolder '{0}' found at {1}", path[i], FdbKey.Dump(current));
-					layer = await tr.GetAsync(partition.Nodes.Encode(current, LayerAttribute)).ConfigureAwait(false);
+					layer = (await tr.GetAsync(partition.Nodes.Encode(current, LayerAttribute)).ConfigureAwait(false)).ToStringUtf8() ?? string.Empty;
 
 					parent = partition;
 
+					prefixInParentPartition = current;
 					if (layer == FdbDirectoryPartition.LayerId)
 					{ // jump to that partition's node subspace
 						partition = partition.CreateChild(path.Substring(0, i + 1), current);
@@ -618,11 +612,11 @@ namespace FoundationDB.Client
 					++i;
 				}
 
-				return new Node(path, current, layer, partition, parent);
+				return new Node(path, current, layer, partition, parent, prefixInParentPartition);
 			}
 
 			/// <summary>Open a subspace using the local cache</summary>
-			internal async ValueTask<FdbDirectorySubspace?> OpenCachedInternalAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer, bool throwOnError)
+			internal async ValueTask<FdbDirectorySubspace?> OpenCachedInternalAsync(IFdbReadOnlyTransaction trans, FdbPath path, bool throwOnError)
 			{
 				Contract.Requires(trans != null);
 
@@ -639,10 +633,10 @@ namespace FoundationDB.Client
 					}
 				}
 
-				return await OpenCachedInternalSlow(ctx, trans, path, layer, throwOnError);
+				return await OpenCachedInternalSlow(ctx, trans, path, throwOnError);
 			}
 
-			private async Task<FdbDirectorySubspace?> OpenCachedInternalSlow(CacheContext context, IFdbReadOnlyTransaction readTrans, FdbPath path, Slice layer, bool throwOnError)
+			private async Task<FdbDirectorySubspace?> OpenCachedInternalSlow(CacheContext context, IFdbReadOnlyTransaction readTrans, FdbPath path, bool throwOnError)
 			{
 				var existingNode = await FindAsync(readTrans, this.Partition, path).ConfigureAwait(false);
 
@@ -651,11 +645,12 @@ namespace FoundationDB.Client
 				FdbDirectorySubspace? subspace;
 				if (existingNode.Exists)
 				{
-					if (layer.Count != 0 && layer != existingNode.Layer)
+					var layer = path.LayerId;
+					if (!string.IsNullOrEmpty(layer) && layer != existingNode.Layer)
 					{
-						throw new InvalidOperationException($"The directory {path} was created with incompatible layer {layer:P} instead of expected {existingNode.Layer:P}.");
+						throw new InvalidOperationException($"The directory {path} was created with incompatible layer '{layer}' instead of expected '{existingNode.Layer}'.");
 					}
-					subspace = ContentsOfNode(existingNode.Path, existingNode.Prefix, existingNode.Layer, existingNode.Partition, existingNode.ParentPartition, context);
+					subspace = ContentsOfNode(existingNode.Path, existingNode.Prefix, existingNode.Layer!, existingNode.Partition, existingNode.ParentPartition, context);
 				}
 				else
 				{
@@ -667,7 +662,7 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Open a subspace using the local cache</summary>
-			internal async ValueTask<FdbDirectorySubspace?[]> OpenCachedInternalAsync(IFdbReadOnlyTransaction trans, ReadOnlyMemory<(FdbPath Path, Slice Layer)> paths, bool throwOnError)
+			internal async ValueTask<FdbDirectorySubspace?[]> OpenCachedInternalAsync(IFdbReadOnlyTransaction trans, ReadOnlyMemory<FdbPath> paths, bool throwOnError)
 			{
 				Contract.Requires(trans != null);
 
@@ -680,7 +675,7 @@ namespace FoundationDB.Client
 					List<(Task<FdbDirectorySubspace?> Task, int Index)>? tasks = null;
 					for (int i = 0; i < paths.Length; i++)
 					{
-						(var path, var layer) = paths.Span[i];
+						var path = paths.Span[i];
 						EnsureAbsolutePath(in path);
 						if (ctx.TryGetSubspace(trans, this, path, out var subspace))
 						{
@@ -690,7 +685,7 @@ namespace FoundationDB.Client
 						else
 						{
 							tasks ??= new List<(Task<FdbDirectorySubspace?>, int)>();
-							tasks.Add((OpenCachedInternalSlow(ctx, trans, path, layer, throwOnError), i));
+							tasks.Add((OpenCachedInternalSlow(ctx, trans, path, throwOnError), i));
 						}
 					}
 
@@ -708,15 +703,15 @@ namespace FoundationDB.Client
 					var tasks = new List<Task<FdbDirectorySubspace?>>(paths.Length);
 					for (int i = 0; i < paths.Length; i++)
 					{
-						(var path, var layer) = paths.Span[i];
-						tasks.Add(CreateOrOpenInternalAsync(trans, null, path, layer, Slice.Nil, false, true, throwOnError));
+						var path = paths.Span[i];
+						tasks.Add(CreateOrOpenInternalAsync(trans, null, path, Slice.Nil, false, true, throwOnError));
 					}
 
 					return await Task.WhenAll(tasks);
 				}
 			}
 
-			internal async Task<FdbDirectorySubspace?> CreateOrOpenInternalAsync(IFdbReadOnlyTransaction? readTrans, IFdbTransaction? trans, FdbPath path, Slice layer, Slice prefix, bool allowCreate, bool allowOpen, bool throwOnError)
+			internal async Task<FdbDirectorySubspace?> CreateOrOpenInternalAsync(IFdbReadOnlyTransaction? readTrans, IFdbTransaction? trans, FdbPath path, Slice prefix, bool allowCreate, bool allowOpen, bool throwOnError)
 			{
 				Contract.Requires(readTrans != null || trans != null, "Need at least one transaction");
 				Contract.Requires(readTrans == null || trans == null || object.ReferenceEquals(readTrans, trans), "The write transaction should be the same as the read transaction.");
@@ -738,6 +733,8 @@ namespace FoundationDB.Client
 				if (prefix.HasValue && this.Layer.Path.Count > 0)
 					throw new InvalidOperationException("Cannot specify a prefix in a partition.");
 
+				string layer = path.LayerId;
+
 				var existingNode = await FindAsync(readTrans, this.Partition, path).ConfigureAwait(false);
 
 				if (existingNode.Exists)
@@ -748,11 +745,11 @@ namespace FoundationDB.Client
 						return null;
 					}
 
-					if (layer.Count != 0 && layer != existingNode.Layer)
+					if (!string.IsNullOrEmpty(layer) && layer != existingNode.Layer)
 					{
-						throw new InvalidOperationException($"The directory {path} was created with incompatible layer {existingNode.Layer:P} instead of expected {layer:P}.");
+						throw new InvalidOperationException($"The directory {path} was created with incompatible layer {existingNode.Layer} instead of expected '{layer}'.");
 					}
-					return ContentsOfNode(existingNode.Path, existingNode.Prefix, existingNode.Layer, existingNode.Partition, existingNode.ParentPartition, null);
+					return ContentsOfNode(existingNode.Path, existingNode.Prefix, existingNode.Layer!, existingNode.Partition, existingNode.ParentPartition, null);
 				}
 
 				if (!allowCreate)
@@ -771,7 +768,7 @@ namespace FoundationDB.Client
 				var partition  = this.Partition;
 				if (path.Count > 1)
 				{
-					var parentSubspace = await CreateOrOpenInternalAsync(readTrans, trans, path.GetParent(), Slice.Nil, Slice.Nil, true, true, true).ConfigureAwait(false);
+					var parentSubspace = await CreateOrOpenInternalAsync(readTrans, trans, path.GetParent(), Slice.Nil, true, true, true).ConfigureAwait(false);
 					Contract.Assert(parentSubspace != null);
 					//HACKHACK: idéalement, CreateOrOpenInternalAsync devrait retourner toutes les informations en une seule fois!
 					var parentNode = await FindAsync(readTrans, this.Partition, path.GetParent());
@@ -821,7 +818,7 @@ namespace FoundationDB.Client
 				SetLayer(trans, existingNode.Partition, prefix, layer);
 				UpdatePartitionMetadataVersion(trans, existingNode.Partition);
 
-				if (layer.Equals(FdbDirectoryPartition.LayerId))
+				if (layer == FdbDirectoryPartition.LayerId)
 				{
 					InitializePartition(trans, existingNode.Partition);
 				}
@@ -899,7 +896,7 @@ namespace FoundationDB.Client
 					trans.TouchMetadataVersionKey();
 				}
 
-				trans.Set(parentPartition.Nodes.Encode(parentPrefix, SUBDIRS, newPath.Name), oldNode.Prefix);
+				trans.Set(parentPartition.Nodes.Encode(parentPrefix, SUBDIRS, newPath.Name), oldNode.PrefixInParentPartition);
 				UpdatePartitionMetadataVersion(trans, parentPartition);
 
 				await RemoveFromParent(trans, oldPath).ConfigureAwait(false);
@@ -955,15 +952,15 @@ namespace FoundationDB.Client
 					return null;
 				}
 
-				return await SubdirNamesAndNodes(trans, node.Partition, node.Prefix)
-					.Select(kvp => path[kvp.Key])
-					.ToListAsync()
-					.ConfigureAwait(false);
+				return (await SubdirNamesAndNodes(trans, node.Partition, node.Prefix, includeLayers: true).ConfigureAwait(false))
+					.Select(kvp => node.Path[new FdbPathSegment(kvp.Name, kvp.LayerId)])
+					.ToList()
+					;
 			}
 
 			internal async Task<bool> ExistsInternalAsync(IFdbReadOnlyTransaction trans, FdbPath path)
 			{
-				Contract.NotNull(trans, nameof(trans));
+				Contract.Requires(trans != null);
 
 				EnsureAbsolutePath(in path);
 
@@ -976,9 +973,9 @@ namespace FoundationDB.Client
 				return true;
 			}
 
-			internal async Task ChangeLayerInternalAsync(IFdbTransaction trans, FdbPath path, Slice newLayer)
+			internal async Task ChangeLayerInternalAsync(IFdbTransaction trans, FdbPath path, string newLayer)
 			{
-				Contract.NotNull(trans, nameof(trans));
+				Contract.Requires(trans != null && newLayer != null);
 
 				EnsureAbsolutePath(in path);
 
@@ -1066,7 +1063,7 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Returns a new Directory Subspace given its node subspace, path and layer id</summary>
-			private FdbDirectorySubspace ContentsOfNode(FdbPath path, Slice prefix, Slice layer, PartitionDescriptor partition, PartitionDescriptor parentPartition, ISubspaceContext? context)
+			private FdbDirectorySubspace ContentsOfNode(FdbPath path, Slice prefix, string layer, PartitionDescriptor partition, PartitionDescriptor parentPartition, ISubspaceContext? context)
 			{
 				Contract.Requires(partition != null && parentPartition != null);
 
@@ -1083,17 +1080,27 @@ namespace FoundationDB.Client
 			}
 
 			/// <summary>Returns the list of names and nodes of all children of the specified node</summary>
-			private IAsyncEnumerable<KeyValuePair<string, Slice>> SubdirNamesAndNodes(IFdbReadOnlyTransaction tr, PartitionDescriptor partition, Slice prefix)
+			private async Task<List<(string Name, string? LayerId, Slice Prefix)>> SubdirNamesAndNodes(IFdbReadOnlyTransaction tr, PartitionDescriptor partition, Slice prefix, bool includeLayers)
 			{
 				Contract.Requires(tr != null && partition != null);
 
 				var sd = partition.Nodes.Partition.ByKey(prefix, SUBDIRS);
-				return tr
+
+				var items = await tr
 					.GetRange(sd.ToRange())
-					.Select(kvp => new KeyValuePair<string, Slice>(
-						sd.Decode<string>(kvp.Key) ?? string.Empty,
-						kvp.Value
-					));
+					.Select(kvp => (Name: sd.Decode<string>(kvp.Key) ?? string.Empty, Prefix: kvp.Value))
+					.ToListAsync();
+
+				// fetch the layers from the corresponding directories
+				var layers = includeLayers ? await tr.GetValuesAsync(items.Select(item => partition.Nodes.Encode(item.Prefix, FdbDirectoryLayer.LayerAttribute))) : null;
+
+				var res = new List<(string, string?, Slice)>(items.Count);
+				for (int i = 0; i < items.Count; i++)
+				{
+					res.Add((items[i].Name, layers != null ? (layers[i].ToStringUtf8() ?? string.Empty) : null, items[i].Prefix));
+				}
+
+				return res;
 			}
 
 			/// <summary>Remove an existing node from its parents</summary>
@@ -1119,7 +1126,8 @@ namespace FoundationDB.Client
 				Contract.Requires(tr != null && partition != null);
 
 				//note: we could use Task.WhenAll to remove the children, but there is a risk of task explosion if the subtree is very large...
-				await SubdirNamesAndNodes(tr, partition, prefix).ForEachAsync((kvp) => RemoveRecursive(tr, partition, kvp.Value)).ConfigureAwait(false);
+				var children = await SubdirNamesAndNodes(tr, partition, prefix, includeLayers: false);
+				await Task.WhenAll(children.Select(child => RemoveRecursive(tr, partition, child.Prefix))).ConfigureAwait(false);
 
 				// remove ALL the contents
 				if (AnnotateTransactions) tr.Annotate("Removing all content located under {0}", KeyRange.StartsWith(prefix));
@@ -1344,18 +1352,12 @@ namespace FoundationDB.Client
 
 		internal FdbPath VerifyPath(in FdbPath path, string? argName = null)
 		{
-			var location = path.IsAbsolute ? path : this.Path[path];
-
-			// The path should not contain any null strings
-			var segments = location.Segments.Span;
-			for (int i = 0; i < segments.Length; i++)
+			if (path.IsAbsolute)
 			{
-				if (segments[i] == null)
-				{
-					throw new ArgumentException("The path of a directory cannot contain null elements.", argName ?? "path");
-				}
+				if (!path.StartsWith(this.Path)) throw new ArgumentException("The specified path is outside the current Directory Layer", argName ?? nameof(path));
+				return path;
 			}
-			return location;
+			return this.Path[path];
 		}
 
 		private static void CheckVersion(Slice value, bool writeAccess)
@@ -1520,16 +1522,14 @@ namespace FoundationDB.Client
 		[DebuggerDisplay("Path={Path}, Prefix={Prefix}, Layer={Layer}, Partition={Partition.Path}|{Partition.Content.GetPrefix()}")]
 		internal sealed class DirectoryDescriptor
 		{
-			public DirectoryDescriptor(FdbDirectoryLayer directoryLayer, FdbPath path, Slice prefix, Slice layer, PartitionDescriptor partition)
+			public DirectoryDescriptor(FdbDirectoryLayer directoryLayer, FdbPath path, Slice prefix, string layer, PartitionDescriptor partition)
 			{
 				Contract.Requires(directoryLayer != null && partition != null && path.StartsWith(partition.Path));
-
-				if (layer.IsNull) layer = Slice.Empty;
 
 				this.DirectoryLayer = directoryLayer;
 				this.Path = path;
 				this.Prefix = prefix;
-				this.Layer = layer;
+				this.Layer = layer ?? string.Empty;
 				this.Partition = partition;
 
 				Contract.Ensures(this.DirectoryLayer != null);
@@ -1546,7 +1546,7 @@ namespace FoundationDB.Client
 			public FdbDirectoryLayer DirectoryLayer { get; }
 
 			/// <summary>Layer id of this directory</summary>
-			public Slice Layer { get; }
+			public string Layer { get; }
 
 			public override string ToString() => $"DirectoryDescriptor(Path={Path}, Prefix={Prefix:K}, Layer={Layer}, Partition=({Partition.Path}, {Partition.Content.GetPrefix():K}))";
 

--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
@@ -1358,14 +1358,6 @@ namespace FoundationDB.Client
 			return location;
 		}
 
-		/// <summary>Maps an absolute path to a relative path within this directory layer</summary>
-		internal FdbPath ToRelativePath(FdbPath path)
-		{
-			if (!path.StartsWith(this.Path)) throw new InvalidOperationException("The path cannot be outside of this partition.");
-			return path.Substring(this.Path.Count);
-		}
-
-
 		private static void CheckVersion(Slice value, bool writeAccess)
 		{
 			// the version is stored as 3 x 32-bit unsigned int, so (1, 0, 0) will be "<01><00><00><00> <00><00><00><00> <00><00><00><00>"

--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryPartition.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryPartition.cs
@@ -36,7 +36,7 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Returns a slice with the ASCII string "partition"</summary>
-		public static Slice LayerId => Slice.FromString("partition");
+		public const string LayerId = "partition";
 
 		internal FdbDirectoryPartition(FdbDirectoryLayer.DirectoryDescriptor descriptor, FdbDirectoryLayer.PartitionDescriptor parent, IDynamicKeyEncoder keyEncoder, ISubspaceContext? context)
 			: base(descriptor, keyEncoder, context)
@@ -54,11 +54,28 @@ namespace FoundationDB.Client
 		/// <summary>Descriptor of the partition directory in its parent partition</summary>
 		internal FdbDirectoryLayer.PartitionDescriptor Parent { get; }
 
-		protected override Slice GetKeyPrefix() => throw new InvalidOperationException($"Cannot create keys in the root of directory partition {this.Path}.");
+		internal bool IsTopLevel => this.Descriptor.Path.IsRoot;
 
-		protected override KeyRange GetKeyRange() => throw new InvalidOperationException($"Cannot create a key range in the root of directory partition {this.Path}.");
+		protected override Slice GetKeyPrefix()
+		{
+			// only "/" is allowed for legacy reasons
+			if (!this.IsTopLevel) throw ThrowHelper.InvalidOperationException($"Cannot create keys in the root of directory partition {this.Path}.");
+			return base.GetKeyPrefix();
+		}
 
-		public override bool Contains(ReadOnlySpan<byte> key) => throw new InvalidOperationException($"Cannot check whether a key belongs to the root of directory partition {this.Path}");
+		protected override KeyRange GetKeyRange()
+		{
+			// only "/" is allowed for legacy reasons
+			if (!this.IsTopLevel) throw ThrowHelper.InvalidOperationException($"Cannot create a key range in the root of directory partition {this.Path}.");
+			return base.GetKeyRange();
+		}
+
+		public override bool Contains(ReadOnlySpan<byte> key)
+		{
+			// only "/" is allowed for legacy reasons
+			if (!this.IsTopLevel) throw ThrowHelper.InvalidOperationException($"Cannot check whether a key belongs to the root of directory partition {this.Path}");
+			return base.Contains(key);
+		}
 
 		internal override FdbDirectoryLayer.PartitionDescriptor GetEffectivePartition()
 		{
@@ -77,7 +94,7 @@ namespace FoundationDB.Client
 
 		public override string ToString()
 		{
-			return $"DirectoryPartition(path={this.FullName}, prefix={FdbKey.Dump(GetPrefixUnsafe())})";
+			return $"DirectoryPartition(path={this.Descriptor.Path.ToString()}, prefix={FdbKey.Dump(GetPrefixUnsafe())})";
 		}
 
 	}

--- a/FoundationDB.Client/Layers/Directories/FdbDirectorySubspace.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectorySubspace.cs
@@ -53,7 +53,7 @@ namespace FoundationDB.Client
 		internal FdbDirectoryLayer.DirectoryDescriptor Descriptor { get; }
 
 		/// <summary>Absolute path of this directory, from the root directory</summary>
-		public FdbDirectoryPath Path => this.Descriptor.Path;
+		public FdbPath Path => this.Descriptor.Path;
 
 		/// <summary>Gets the location that points to this <code>Directory</code></summary>
 		public FdbDirectorySubspaceLocation Location => new FdbDirectorySubspaceLocation(this.Descriptor.Path, this.Layer);
@@ -87,7 +87,7 @@ namespace FoundationDB.Client
 		/// <summary>Convert a path relative to this directory, into a path relative to the root of the current partition</summary>
 		/// <param name="location">Path relative from this directory</param>
 		/// <returns>Path relative to the path of the current partition</returns>
-		protected virtual FdbDirectoryPath ToAbsolutePath(FdbDirectoryPath location)
+		protected virtual FdbPath ToAbsolutePath(FdbPath location)
 		{
 			return this.Descriptor.Path.Add(location);
 		}
@@ -153,7 +153,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Relative path of the sub-directory to create or open</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is checked against the layer of an existing sub-directory or set as the layer of a new sub-directory.</param>
-		public async Task<FdbDirectorySubspace> CreateOrOpenAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace> CreateOrOpenAsync(IFdbTransaction trans, FdbPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (path.IsEmpty) throw new ArgumentNullException(nameof(path));
@@ -170,7 +170,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Relative path of the sub-directory to open</param>
 		/// <param name="layer">If specified, the opened directory must have the same layer id.</param>
-		public async Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (path.IsEmpty) throw new ArgumentNullException(nameof(path));
@@ -188,7 +188,7 @@ namespace FoundationDB.Client
 		/// <param name="path">Relative path of the sub-directory to open</param>
 		/// <param name="layer">If specified, the opened directory must have the same layer id.</param>
 		/// <returns>Returns the directory if it exists, or null if it was not found</returns>
-		public async Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (path.IsEmpty) throw new ArgumentNullException(nameof(path));
@@ -199,7 +199,7 @@ namespace FoundationDB.Client
 			return await metadata.CreateOrOpenInternalAsync(trans, null, ToAbsolutePath(path), layer, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: false);
 		}
 
-		public async ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default)
+		public async ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (path.IsEmpty) throw new InvalidOperationException( "Cannot open empty path");
@@ -210,14 +210,14 @@ namespace FoundationDB.Client
 			return await metadata.OpenCachedInternalAsync(trans, ToAbsolutePath(path), layer, throwOnError: false);
 		}
 
-		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<(FdbDirectoryPath Path, Slice Layer)> paths)
+		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<(FdbPath Path, Slice Layer)> paths)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(paths, nameof(paths));
 
 			EnsureIsValid();
 
-			var items = new List<(FdbDirectoryPath, Slice)>();
+			var items = new List<(FdbPath, Slice)>();
 			foreach (var (path, layer) in paths)
 			{
 				if (path.IsEmpty) throw new InvalidOperationException("Cannot open empty path");
@@ -228,14 +228,14 @@ namespace FoundationDB.Client
 			return await metadata.OpenCachedInternalAsync(trans, items.ToArray(), throwOnError: false);
 		}
 
-		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<FdbDirectoryPath> paths)
+		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<FdbPath> paths)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			Contract.NotNull(paths, nameof(paths));
 
 			EnsureIsValid();
 
-			var items = new List<(FdbDirectoryPath, Slice)>();
+			var items = new List<(FdbPath, Slice)>();
 			foreach (var path in paths)
 			{
 				if (path.IsEmpty) throw new InvalidOperationException("Cannot open empty path");
@@ -252,7 +252,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Relative path of the sub-directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the sub-directory and will be checked by future calls to open.</param>
-		public async Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (path.IsEmpty) throw new ArgumentNullException(nameof(path));
@@ -268,7 +268,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Relative path of the sub-directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the sub-directory and will be checked by future calls to open.</param>
-		public async Task<FdbDirectorySubspace?> TryCreateAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer = default)
+		public async Task<FdbDirectorySubspace?> TryCreateAsync(IFdbTransaction trans, FdbPath path, Slice layer = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (path.IsEmpty) throw new ArgumentNullException(nameof(path));
@@ -283,7 +283,7 @@ namespace FoundationDB.Client
 		/// <param name="path">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
 		/// <param name="prefix">The directory will be created with the given physical prefix; otherwise a prefix is allocated automatically.</param>
-		public async Task<FdbDirectorySubspace> RegisterAsync(IFdbTransaction trans, FdbDirectoryPath path, Slice layer, Slice prefix)
+		public async Task<FdbDirectorySubspace> RegisterAsync(IFdbTransaction trans, FdbPath path, Slice layer, Slice prefix)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (path.IsEmpty) throw new ArgumentNullException(nameof(path));
@@ -299,7 +299,7 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="newAbsolutePath">Full path (from the root) where this directory will be moved</param>
-		public async Task<FdbDirectorySubspace> MoveToAsync(IFdbTransaction trans, FdbDirectoryPath newAbsolutePath)
+		public async Task<FdbDirectorySubspace> MoveToAsync(IFdbTransaction trans, FdbPath newAbsolutePath)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (newAbsolutePath.IsEmpty) throw new ArgumentNullException(nameof(newAbsolutePath));
@@ -309,7 +309,7 @@ namespace FoundationDB.Client
 			Contract.Assert(partition != null, "Effective partition cannot be null!");
 
 			// verify that it is still inside the same partition
-			var location = FdbDirectoryLayer.VerifyPath(newAbsolutePath, "newAbsolutePath");
+			var location = this.DirectoryLayer.VerifyPath(newAbsolutePath, "newAbsolutePath");
 			if (!location.StartsWith(partition.Path)) throw new InvalidOperationException($"Cannot move between partitions ['{location}' is outside '{partition.Path}']");
 
 			var metadata = await this.DirectoryLayer.Resolve(trans);
@@ -324,7 +324,7 @@ namespace FoundationDB.Client
 		/// <param name="oldPath">Relative path under this directory of the sub-directory to be moved</param>
 		/// <param name="newPath">Relative path under this directory where the sub-directory will be moved to</param>
 		/// <returns>Returns the directory at its new location if successful.</returns>
-		async Task<FdbDirectorySubspace> IFdbDirectory.MoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath)
+		async Task<FdbDirectorySubspace> IFdbDirectory.MoveAsync(IFdbTransaction trans, FdbPath oldPath, FdbPath newPath)
 		{
 			if (oldPath.IsEmpty) throw new ArgumentNullException(nameof(oldPath));
 			if (newPath.IsEmpty) throw new ArgumentNullException(nameof(newPath));
@@ -339,7 +339,7 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="newPath">Full path (from the root) where this directory will be moved</param>
-		public async Task<FdbDirectorySubspace?> TryMoveToAsync(IFdbTransaction trans, FdbDirectoryPath newPath)
+		public async Task<FdbDirectorySubspace?> TryMoveToAsync(IFdbTransaction trans, FdbPath newPath)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			if (newPath.IsEmpty) throw new ArgumentNullException(nameof(newPath));
@@ -347,7 +347,7 @@ namespace FoundationDB.Client
 
 			var descriptor = this.Descriptor;
 
-			var location = FdbDirectoryLayer.VerifyPath(newPath, "newPath");
+			var location = this.DirectoryLayer.VerifyPath(newPath, "newPath");
 			if (!location.StartsWith(descriptor.Partition.Path)) throw new InvalidOperationException("Cannot move between partitions.");
 
 			var metadata = await descriptor.DirectoryLayer.Resolve(trans);
@@ -362,7 +362,7 @@ namespace FoundationDB.Client
 		/// <param name="oldPath">Relative path under this directory of the sub-directory to be moved</param>
 		/// <param name="newPath">Relative path under this directory where the sub-directory will be moved to</param>
 		/// <returns>Returns the directory at its new location if successful. If the directory cannot be moved, then null is returned.</returns>
-		Task<FdbDirectorySubspace?> IFdbDirectory.TryMoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath)
+		Task<FdbDirectorySubspace?> IFdbDirectory.TryMoveAsync(IFdbTransaction trans, FdbPath oldPath, FdbPath newPath)
 		{
 			if (oldPath.IsEmpty) throw new ArgumentNullException(nameof(oldPath));
 			if (newPath.IsEmpty) throw new ArgumentNullException(nameof(newPath));
@@ -391,13 +391,13 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the sub-directory to remove (relative to this directory)</param>
-		public async Task RemoveAsync(IFdbTransaction trans, FdbDirectoryPath path)
+		public async Task RemoveAsync(IFdbTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			EnsureIsValid();
 
 			// If path is empty, we are removing ourselves!
-			var location = FdbDirectoryLayer.VerifyPath(path, "path");
+			var location = this.DirectoryLayer.VerifyPath(path, nameof(path));
 			if (location.Count == 0)
 			{
 				await RemoveAsync(trans);
@@ -429,13 +429,13 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Path of the sub-directory to remove (relative to this directory)</param>
-		public async Task<bool> TryRemoveAsync(IFdbTransaction trans, FdbDirectoryPath path)
+		public async Task<bool> TryRemoveAsync(IFdbTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			EnsureIsValid();
 
 			// If path is empty, we are removing ourselves!
-			var location = FdbDirectoryLayer.VerifyPath(path, "path");
+			var location = this.DirectoryLayer.VerifyPath(path, nameof(path));
 			if (location.Count == 0)
 			{
 				return await TryRemoveAsync(trans);
@@ -460,13 +460,13 @@ namespace FoundationDB.Client
 
 		/// <summary>Checks if a sub-directory exists</summary>
 		/// <returns>Returns true if the directory exists, otherwise false.</returns>
-		public async Task<bool> ExistsAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path)
+		public async Task<bool> ExistsAsync(IFdbReadOnlyTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			EnsureIsValid();
 
 			// If path is empty, we are checking ourselves!
-			var location = FdbDirectoryLayer.VerifyPath(path, "path");
+			var location = this.DirectoryLayer.VerifyPath(path, nameof(path));
 			if (location.Count == 0)
 			{
 				return await ExistsAsync(trans);
@@ -477,7 +477,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Returns the list of all the subdirectories of a sub-directory.</summary>
-		public async Task<List<string>> ListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path = default)
+		public async Task<List<FdbPath>> ListAsync(IFdbReadOnlyTransaction trans, FdbPath path = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			EnsureIsValid();
@@ -487,7 +487,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Returns the list of all the subdirectories of the current directory, it it exists.</summary>
-		public async Task<List<string>?> TryListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path = default)
+		public async Task<List<FdbPath>?> TryListAsync(IFdbReadOnlyTransaction trans, FdbPath path = default)
 		{
 			Contract.NotNull(trans, nameof(trans));
 			EnsureIsValid();

--- a/FoundationDB.Client/Layers/Directories/FdbDirectorySubspace.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectorySubspace.cs
@@ -89,6 +89,15 @@ namespace FoundationDB.Client
 		/// <returns>Path relative to the path of the current partition</returns>
 		protected virtual FdbPath ToAbsolutePath(FdbPath location)
 		{
+			if (location.IsAbsolute)
+			{ // we only accept an absolute path if it is technically contained in the current directory
+				if (!location.StartsWith(this.Descriptor.Path))
+				{
+					throw new InvalidOperationException("Cannot use absolute path that is not contained within the current directory path.");
+				}
+				return location;
+			}
+
 			return this.Descriptor.Path.Add(location);
 		}
 

--- a/FoundationDB.Client/Layers/Directories/FdbDirectorySubspaceLocation.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectorySubspaceLocation.cs
@@ -108,18 +108,21 @@ namespace FoundationDB.Client
 		/// <summary>Append a segment to the current path</summary>
 		public FdbDirectorySubspaceLocation this[FdbPathSegment segment] => new FdbDirectorySubspaceLocation(this.Path.Add(segment));
 
+		/// <summary>Append one or more segments to the current path</summary>
+		public FdbDirectorySubspaceLocation this[ReadOnlySpan<FdbPathSegment> segments] => new FdbDirectorySubspaceLocation(this.Path.Add(segments));
+
 		/// <summary>Append a segment to the current path</summary>
-		/// <param name="segment">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
-		public FdbDirectorySubspaceLocation this[string segment] => new FdbDirectorySubspaceLocation(this.Path.Add(FdbPathSegment.Parse(segment)));
+		/// <param name="name">Name of the segment</param>
+		/// <remarks>The new segment will not have a layer id.</remarks>
+		public FdbDirectorySubspaceLocation this[string name] => new FdbDirectorySubspaceLocation(this.Path.Add(FdbPathSegment.Create(name)));
 
 		/// <summary>Append a segment - composed of a name and layer id - to the current path</summary>
-		public FdbDirectorySubspaceLocation this[string name, string layer] => new FdbDirectorySubspaceLocation(this.Path.Add(new FdbPathSegment(name, layer)));
+		/// <param name="name">Name of the segment</param>
+		/// <param name="layerId">Layer Id of the segment</param>
+		public FdbDirectorySubspaceLocation this[string name, string layerId] => new FdbDirectorySubspaceLocation(this.Path.Add(new FdbPathSegment(name, layerId)));
 
 		/// <summary>Append a relative path to the current path</summary>
 		public FdbDirectorySubspaceLocation this[FdbPath relativePath] => new FdbDirectorySubspaceLocation(this.Path.Add(relativePath));
-
-		/// <summary>Append one or more segments to the current path</summary>
-		public FdbDirectorySubspaceLocation this[ReadOnlySpan<FdbPathSegment> segments] => new FdbDirectorySubspaceLocation(this.Path.Add(segments));
 
 		/// <summary>Append an encoded key to the prefix of the current location</summary>
 		/// <typeparam name="T1">Type of the key</typeparam>

--- a/FoundationDB.Client/Layers/Directories/FdbPath.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbPath.cs
@@ -533,7 +533,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of a single segment</summary>
 		[Pure]
-		public static FdbPath MakeAbsolute(string segment)
+		public static FdbPath Absolute(string segment)
 		{
 			Contract.NotNull(segment, nameof(segment));
 			return new FdbPath(new [] { FdbPathSegment.Parse(segment) }, absolute: true);
@@ -541,7 +541,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of a single segment</summary>
 		[Pure]
-		public static FdbPath MakeAbsolute(FdbPathSegment segment)
+		public static FdbPath Absolute(FdbPathSegment segment)
 		{
 			if (segment.IsEmpty) throw new ArgumentException("Segment cannot be empty.", nameof(segment));
 			return new FdbPath(new [] { segment }, absolute: true);
@@ -549,7 +549,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		[Pure]
-		public static FdbPath MakeAbsolute(params string[] segments)
+		public static FdbPath Absolute(params string[] segments)
 		{
 			Contract.NotNull(segments, nameof(segments));
 			if (segments.Length == 0) return FdbPath.Empty;
@@ -558,7 +558,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		[Pure]
-		public static FdbPath MakeAbsolute(params FdbPathSegment[] segments)
+		public static FdbPath Absolute(params FdbPathSegment[] segments)
 		{
 			Contract.NotNull(segments, nameof(segments));
 			if (segments.Length == 0) return FdbPath.Empty;
@@ -567,7 +567,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		[Pure]
-		public static FdbPath MakeAbsolute(ReadOnlySpan<FdbPathSegment> segments)
+		public static FdbPath Absolute(ReadOnlySpan<FdbPathSegment> segments)
 		{
 			// we have to copy the buffer!
 			return new FdbPath(segments.ToArray(), absolute: true);
@@ -575,13 +575,13 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		[Pure]
-		public static FdbPath MakeAbsolute(ReadOnlyMemory<FdbPathSegment> segments)
+		public static FdbPath Absolute(ReadOnlyMemory<FdbPathSegment> segments)
 		{
 			return new FdbPath(segments, absolute: true);
 		}
 
 		[Pure]
-		public static FdbPath MakeAbsolute(IEnumerable<FdbPathSegment> segments)
+		public static FdbPath Absolute(IEnumerable<FdbPathSegment> segments)
 		{
 			Contract.NotNull(segments, nameof(segments));
 			return new FdbPath(segments.ToArray(), absolute: true);

--- a/FoundationDB.Client/Layers/Directories/FdbPath.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbPath.cs
@@ -105,7 +105,7 @@ namespace FoundationDB.Client
 #endif
 
 		/// <summary>Return the name of the last segment of this path</summary>
-		/// <example><see cref="MakeRelative(string[])"/>Combine("Foo", "Bar", "Baz").Name => "Baz"</example>
+		/// <example><see cref="Relative(string[])"/>Combine("Foo", "Bar", "Baz").Name => "Baz"</example>
 		/// <remarks>The name of the <see cref="Empty"/> or <see cref="Root"/> paths is, by convention, the empty string.</remarks>
 		public string Name
 		{
@@ -118,7 +118,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return the Layer Id of the last segment of this path</summary>
-		/// <example><see cref="MakeRelative(string[])"/>Combine("Foo", "Bar", "Baz").Name => "Baz"</example>
+		/// <example><see cref="Relative(string[])"/>Combine("Foo", "Bar", "Baz").Name => "Baz"</example>
 		/// <remarks>Be convention, the layer id of the <see cref="Empty"/> path is the <c>empty</c> string, and the layer id of the <see cref="Root"/> path is <c>"partition"</c></remarks>
 		public string LayerId
 		{
@@ -474,7 +474,7 @@ namespace FoundationDB.Client
 		/// <summary>Return a relative path composed of a single segment</summary>
 		/// <param name="segment">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
 		[Pure]
-		public static FdbPath MakeRelative(string segment)
+		public static FdbPath Relative(string segment)
 		{
 			Contract.NotNull(segment, nameof(segment));
 			return new FdbPath(new [] { FdbPathSegment.Parse(segment) }, absolute: false);
@@ -482,7 +482,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of a single segment</summary>
 		[Pure]
-		public static FdbPath MakeRelative(FdbPathSegment segment)
+		public static FdbPath Relative(FdbPathSegment segment)
 		{
 			if (segment.IsEmpty) throw new ArgumentException("Segment cannot be empty", nameof(segment));
 			return new FdbPath(new [] { segment }, absolute: false);
@@ -491,7 +491,7 @@ namespace FoundationDB.Client
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		/// <param name="segments">Array of encoded path segments, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
 		[Pure]
-		public static FdbPath MakeRelative(params string[] segments)
+		public static FdbPath Relative(params string[] segments)
 		{
 			Contract.NotNull(segments, nameof(segments));
 			if (segments.Length == 0) return FdbPath.Empty;
@@ -500,7 +500,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		[Pure]
-		public static FdbPath MakeRelative(params FdbPathSegment[] segments)
+		public static FdbPath Relative(params FdbPathSegment[] segments)
 		{
 			Contract.NotNull(segments, nameof(segments));
 			if (segments.Length == 0) return FdbPath.Empty;
@@ -509,7 +509,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		[Pure]
-		public static FdbPath MakeRelative(ReadOnlySpan<FdbPathSegment> segments)
+		public static FdbPath Relative(ReadOnlySpan<FdbPathSegment> segments)
 		{
 			// we have to copy the buffer!
 			return new FdbPath(segments.ToArray(), absolute: false);
@@ -517,7 +517,7 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		[Pure]
-		public static FdbPath MakeRelative(ReadOnlyMemory<FdbPathSegment> segments)
+		public static FdbPath Relative(ReadOnlyMemory<FdbPathSegment> segments)
 		{
 			return new FdbPath(segments, absolute: false);
 		}
@@ -525,7 +525,7 @@ namespace FoundationDB.Client
 		/// <summary>Return a relative path composed of the specified segments</summary>
 		/// <param name="segments">Sequence of path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
 		[Pure]
-		public static FdbPath MakeRelative(IEnumerable<FdbPathSegment> segments)
+		public static FdbPath Relative(IEnumerable<FdbPathSegment> segments)
 		{
 			Contract.NotNull(segments, nameof(segments));
 			return new FdbPath(segments.ToArray(), absolute: false);

--- a/FoundationDB.Client/Layers/Directories/FdbPath.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbPath.cs
@@ -172,11 +172,14 @@ namespace FoundationDB.Client
 				: throw new InvalidOperationException("The root path does not have a parent path.");
 
 		/// <summary>Append a new segment to the curent path</summary>
-		/// <param name="segment">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
-		public FdbPath this[string segment] => Add(FdbPathSegment.Parse(segment));
+		/// <param name="name">Name of the segment</param>
+		/// <remarks>The new segment will not have a layer id.</remarks>
+		public FdbPath this[string name] => Add(FdbPathSegment.Create(name));
 
 		/// <summary>Append a new segment - composed of a name and layer id - to the curent path</summary>
-		public FdbPath this[string name, string layer] => Add(FdbPathSegment.Create(name, layer));
+		/// <param name="name">Name of the segment</param>
+		/// <param name="layerId">Layer Id of the segment</param>
+		public FdbPath this[string name, string layerId] => Add(FdbPathSegment.Create(name, layerId));
 
 		/// <summary>Append a new segment to the curent path</summary>
 		public FdbPath this[FdbPathSegment segment] => Add(segment);
@@ -223,21 +226,23 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Append a new segment to the curent path</summary>
-		/// <param name="segment">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
+		/// <param name="name">Name of the segment</param>
+		/// <remarks>This segment will not have any layer id defined.</remarks>
 		[Pure]
-		public FdbPath Add(string segment)
-			=> new FdbPath(AppendSegment(this.Segments.Span, FdbPathSegment.Parse(segment)), this.IsAbsolute);
+		public FdbPath Add(string name)
+			=> new FdbPath(AppendSegment(this.Segments.Span, FdbPathSegment.Create(name)), this.IsAbsolute);
+
+		/// <summary>Append a new segment to the curent path</summary>
+		/// <param name="name">Name of the segment</param>
+		/// <param name="layerId">Layer Id of the segment</param>
+		[Pure]
+		public FdbPath Add(string name, string layerId)
+			=> new FdbPath(AppendSegment(this.Segments.Span, FdbPathSegment.Create(name, layerId)), this.IsAbsolute);
 
 		/// <summary>Append a new segment to the curent path</summary>
 		[Pure]
 		public FdbPath Add(FdbPathSegment segment)
 			=> new FdbPath(AppendSegment(this.Segments.Span, segment), this.IsAbsolute);
-
-		/// <summary>Append a new segment to the curent path</summary>
-		/// <param name="segment">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
-		[Pure]
-		public FdbPath Add(ReadOnlySpan<char> segment)
-			=> new FdbPath(AppendSegment(this.Segments.Span, FdbPathSegment.Parse(segment)), this.IsAbsolute);
 
 		/// <summary>Add new segments to the current path</summary>
 		[Pure]
@@ -410,28 +415,9 @@ namespace FoundationDB.Client
 		/// <param name="path">Parent path</param>
 		/// <param name="segment">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
 		[Pure]
-		public static FdbPath Combine(FdbPath path, string segment)
-		{
-			return path.Add(FdbPathSegment.Parse(segment));
-		}
-
-		/// <summary>Add a segment to a parent path</summary>
-		/// <param name="path">Parent path</param>
-		/// <param name="segment">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
-		[Pure]
 		public static FdbPath Combine(FdbPath path, FdbPathSegment segment)
 		{
 			return path.Add(segment);
-		}
-
-		/// <summary>Add a pair of segments to a root path</summary>
-		/// <param name="path">Parent path</param>
-		/// <param name="segment1">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
-		/// <param name="segment2">Encoded path segment, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
-		[Pure]
-		public static FdbPath Combine(FdbPath path, string segment1, string segment2)
-		{
-			return path.Add(FdbPathSegment.Parse(segment1), FdbPathSegment.Parse(segment2));
 		}
 
 		/// <summary>Add a pair of segments to a root path</summary>
@@ -439,17 +425,6 @@ namespace FoundationDB.Client
 		public static FdbPath Combine(FdbPath path, FdbPathSegment segment1, FdbPathSegment segment2)
 		{
 			return path.Add(segment1, segment2);
-		}
-
-		/// <summary>Add one or more segments to a parent path</summary>
-		/// <param name="path">Parent path</param>
-		/// <param name="segments">Array of encoded path segments, composed of just a name (<c>"Foo"</c>), with an optional layer id (<c>"Foo[SomeLayer]"</c>)</param>
-		[Pure]
-		public static FdbPath Combine(FdbPath path, params string[] segments)
-		{
-			Contract.NotNull(segments, nameof(segments));
-			if (segments.Length == 0) return path;
-			return path.Add(FdbPathSegment.Parse(segments.AsSpan()));
 		}
 
 		/// <summary>Add one or more segments to a parent path</summary>
@@ -739,7 +714,7 @@ namespace FoundationDB.Client
 			=> head.Add(tail);
 
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static FdbPath operator +(FdbPath path, string segment)
+		public static FdbPath operator +(FdbPath path, FdbPathSegment segment)
 			=> path.Add(segment);
 
 		#endregion

--- a/FoundationDB.Client/Layers/Directories/FdbPathSegment.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbPathSegment.cs
@@ -30,7 +30,6 @@ namespace FoundationDB.Client
 {
 	using System;
 	using System.Runtime.CompilerServices;
-	using System.Runtime.InteropServices;
 	using System.Text;
 
 	/// <summary>Represent a segment in a <see cref="FdbPath">path</see> to a <see cref="IFdbDirectory">Directory</see>.</summary>
@@ -235,6 +234,14 @@ namespace FoundationDB.Client
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public bool Equals(FdbPathSegment other)
 			=> string.Equals(this.Name, other.Name) && string.Equals(this.LayerId ?? string.Empty, other.LayerId ?? string.Empty);
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool operator ==(FdbPathSegment left, FdbPathSegment right)
+			=> left.Equals(right);
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool operator !=(FdbPathSegment left, FdbPathSegment right)
+			=> !left.Equals(right);
 
 		#endregion
 

--- a/FoundationDB.Client/Layers/Directories/FdbPathSegment.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbPathSegment.cs
@@ -1,0 +1,242 @@
+﻿#region BSD License
+/* Copyright (c) 2013-2020, Doxense SAS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of Doxense nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#endregion
+
+namespace FoundationDB.Client
+{
+	using System;
+	using System.Runtime.CompilerServices;
+	using System.Runtime.InteropServices;
+	using System.Text;
+
+	/// <summary>Represent a segment in a <see cref="FdbPath">path</see> to a <see cref="IFdbDirectory">Directory</see>.</summary>
+	/// <remark>A path segment is composed of a <see cref="Name"/> and optional <see cref="LayerId"/> field.</remark>
+	public readonly struct FdbPathSegment : IEquatable<FdbPathSegment>
+	{
+
+		// Rules for encoding a segment into a string: '/', '\', '[' and ']' are escaped by prefixing them by another '\'
+		// - (Name: "Hello", LayerId: "") => "Hello"
+		// - (Name: "Hello", LayerId: "Foo") => "Hello[Foo]"
+		// - (Name: "Hello/World", "") => "Hello\/World"
+		// - (Name: "Hello[World]", "") => "Hello\[World\]"
+		// - (Name: "Hello[World]", "Foo") => "Hello\[World\][Foo]"
+		// - (Name: "Hello, "Foo/Bar") => "Hello[Foo\/Bar]"
+		// - (Name: "Hello, "Foo[Bar]") => "Hello[Foo\[Bar\]]"
+
+		/// <summary>Name of the segment</summary>
+		/// <remarks>This is the equivalent of the name of the "folder"</remarks>
+		public readonly string Name;
+
+		/// <summary>Id of the layer used by the corresponding directory; or <c>null</c> if it is not specified</summary>
+		/// <remarks>If present: when opening a directory, its layer id will compared to this value; when creating a directory, this value will be used as its layer id.</remarks>
+		public readonly string LayerId;
+
+		public FdbPathSegment(string name, string? layerId = null)
+		{
+			this.Name = name;
+			this.LayerId = layerId ?? string.Empty;
+		}
+
+		public bool IsEmpty => string.IsNullOrEmpty(this.Name);
+
+		private static readonly char[] EscapedLiterals = "\\/[]".ToCharArray();
+
+		private static string Escape(string value)
+		{
+			if (value.AsSpan().IndexOfAny(EscapedLiterals) >= 0)
+			{
+				return value.Replace("\\", "\\\\").Replace("/", "\\/").Replace("[", "\\[").Replace("]", "\\]");
+			}
+			return value;
+		}
+
+		/// <summary>Return a path segment composed of only a name, but without any layer id specified</summary>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static FdbPathSegment Create(string name)
+			=> new FdbPathSegment(name, string.Empty);
+
+		/// <summary>Return a path segment composed both a name, and a layer id</summary>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static FdbPathSegment Create(string name, string layerId)
+			=> new FdbPathSegment(name, layerId);
+
+		/// <summary>Return a path segment composed a name, and the "partition" layer id</summary>
+		public static FdbPathSegment Partition(string name) => new FdbPathSegment(name, FdbDirectoryPartition.LayerId);
+
+		public static string Encode(string name)
+			=> Escape(name);
+
+		public static string Encode(string name, string? layerId)
+			=> string.IsNullOrEmpty(layerId)
+				? Escape(name)
+				: Escape(name) + "[" + Escape(layerId) + "]";
+
+		internal static StringBuilder AppendTo(StringBuilder sb, string name)
+			=> sb.Append(Escape(name));
+
+		internal static StringBuilder AppendTo(StringBuilder sb, string name, string? layerId)
+		{
+			sb.Append(Escape(name));
+			if (!string.IsNullOrEmpty(layerId))
+			{
+				sb.Append('[').Append(Escape(layerId)).Append(']');
+			}
+			return sb;
+		}
+
+		public static FdbPathSegment[] Parse(ReadOnlySpan<string> segments)
+		{
+			var tmp = new FdbPathSegment[segments.Length];
+			for (int i = 0; i < segments.Length; i++)
+			{
+				tmp[i] = Parse(segments[i]);
+			}
+			return tmp;
+		}
+
+		/// <summary>Parse a string representation of a path segment (name with optional layer id)</summary>
+		/// <param name="value">Encoded path segment</param>
+		/// <returns>Decoded path segment (may include an optional layer id)</returns>
+		/// <example>Parse("Foo") == FdbPathSegment.Create("Foo"); Parse("Foo[SomeLayer]") == FdbPathSegment.Create("Foo", "SomeLayer")</example>
+		public static FdbPathSegment Parse(string value)
+		{
+			return Parse(value.AsSpan());
+		}
+
+		/// <summary>Parse a string representation of a path segment (name with optional layer id)</summary>
+		/// <param name="value">Encoded path segment</param>
+		/// <returns>Decoded path segment (may include an optional layer id)</returns>
+		/// <example>Parse("Foo") == FdbPathSegment.Create("Foo"); Parse("Foo[SomeLayer]") == FdbPathSegment.Create("Foo", "SomeLayer")</example>
+		public static FdbPathSegment Parse(ReadOnlySpan<char> value)
+		{
+			var sb = new StringBuilder(value.Length);
+			bool escaped = false;
+			bool inLayer = false;
+
+			string? name = null;
+			string? layerId = null;
+
+			foreach (var c in value)
+			{
+				switch (c)
+				{
+					case '\\':
+					{
+						if (escaped)
+						{
+							sb.Append('\\');
+							escaped = false;
+						}
+						else
+						{
+							escaped = true;
+						}
+						break;
+					}
+					case '[':
+					{
+						if (escaped)
+						{
+							sb.Append('[');
+							escaped = false;
+							break;
+						}
+						if (inLayer) throw new FormatException("Invalid path segment: unescaped '[' inside layer keyword");
+						name = sb.ToString();
+						sb.Clear();
+						inLayer = true;
+						break;
+					}
+					case ']':
+					{
+						if (escaped || !inLayer)
+						{
+							sb.Append(']');
+							escaped = false;
+							break;
+						}
+						//note: the layer string can be empty '[]'
+						layerId = sb.ToString();
+						sb.Clear();
+						inLayer = false;
+						break;
+					}
+					default:
+					{
+						sb.Append(c);
+						escaped = false;
+						break;
+					}
+				}
+			}
+
+			if (name == null && sb.Length != 0)
+			{
+				name = sb.ToString();
+			}
+
+			if (string.IsNullOrEmpty(name)) throw new FormatException("Invalid path segment: name cannot be empty");
+
+			return new FdbPathSegment(name, layerId);
+		}
+
+		/// <summary>Return an encoded string representation of this path segment</summary>
+		/// <returns>Encoded string, with optional layer id</returns>
+		/// <example>FdbPathSegment.Create("Foo").ToString() == "Foo"; FdbPathSegment.Create("Foo", "SomeLayer") == "Foo[SomeLayer]"</example>
+		/// <remarks>The string retured can be parsed back into the original segment via <see cref="Parse(string)"/>.</remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public override string ToString()
+		{
+			return Encode(this.Name, this.LayerId);
+		}
+
+		/// <summary>Extract the pair of name and layer id from this segment</summary>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public void Deconstruct(out string name, out string? layerId)
+		{
+			name = this.Name;
+			layerId = this.LayerId ?? string.Empty;
+		}
+
+		#region Equality...
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public override bool Equals(object obj)
+			=> obj is FdbPathSegment other && Equals(other);
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public override int GetHashCode()
+			=> HashCodes.Combine(this.Name?.GetHashCode() ?? -1, (this.LayerId ?? string.Empty).GetHashCode());
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool Equals(FdbPathSegment other)
+			=> string.Equals(this.Name, other.Name) && string.Equals(this.LayerId ?? string.Empty, other.LayerId ?? string.Empty);
+
+		#endregion
+
+	}
+}

--- a/FoundationDB.Client/Layers/Directories/IFdbDirectory.cs
+++ b/FoundationDB.Client/Layers/Directories/IFdbDirectory.cs
@@ -50,7 +50,7 @@ namespace FoundationDB.Client
 		FdbDirectorySubspaceLocation Location { get; }
 
 		/// <summary>Gets the path represented by this <code>Directory</code>.</summary>
-		FdbDirectoryPath Path { get; }
+		FdbPath Path { get; }
 
 		/// <summary>Gets the layer id slice that was stored when this <code>Directory</code> was created.</summary>
 		Slice Layer { get; }
@@ -62,7 +62,7 @@ namespace FoundationDB.Client
 		/// If the sub-directory does not exist, it is created (creating intermediate subdirectories if necessary).
 		/// If layer is specified, it is checked against the layer of an existing sub-directory or set as the layer of a new sub-directory.
 		/// </summary>
-		Task<FdbDirectorySubspace> CreateOrOpenAsync(IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
+		Task<FdbDirectorySubspace> CreateOrOpenAsync(IFdbTransaction trans, FdbPath subPath, Slice layer = default);
 
 		/// <summary>Opens a sub-directory with the given <paramref name="path"/>.
 		/// An exception is thrown if the sub-directory does not exist, or if a layer is specified and a different layer was specified when the sub-directory was created.
@@ -70,7 +70,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Relative path of the sub-directory to open</param>
 		/// <param name="layer">Expected layer id for the sub-directory (optional)</param>
-		Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
+		Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default);
 
 		/// <summary>Opens a sub-directory with the given <paramref name="path"/>.
 		/// An exception is thrown if the sub-directory if a layer is specified and a different layer was specified when the sub-directory was created.
@@ -79,32 +79,32 @@ namespace FoundationDB.Client
 		/// <param name="path">Relative path of the sub-directory to open</param>
 		/// <param name="layer">Expected layer id for the sub-directory (optional)</param>
 		/// <returns>Returns the directory if it exists, or null if it was not found</returns>
-		Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
+		Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default);
 
 		/// <summary>Opens a sub-directory with the given <paramref name="path"/>, using the partition's cache context.</summary>
 		/// <returns>Returns the directory if it exists, or null if it was not found</returns>
 		/// <remarks>The instance returned MUST NOT be stored or kept outside the context of the transaction!
-		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, FdbDirectoryPath, Slice)"/> on every new transaction to obtained either the previously cached instance, or a new instance.
+		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, FdbPath, Slice)"/> on every new transaction to obtained either the previously cached instance, or a new instance.
 		/// Attempting to used a cached instance outside the transaction that produced it may throw exceptions!
 		/// </remarks>
-		ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath path, Slice layer = default);
+		ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbPath path, Slice layer = default);
 
 		/// <summary>Opens multiple sub-directories with the given <paramref name="paths"/>, using the partition's cache context.</summary>
 		/// <returns>Returns the list directories, in the same order. If a directory does not exist, the corresponding slot will contain <c>null</c></returns>
 		/// <remarks>The instances returned MUST NOT be stored or kept outside the context of the transaction!
-		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, IEnumerable{FdbDirectoryPath})"/> on every new transaction to obtained either the previously cached instances, or a new instances.
+		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, IEnumerable{FdbPath})"/> on every new transaction to obtained either the previously cached instances, or a new instances.
 		/// Attempting to used a cached instances outside the transaction that produced them may throw exceptions!
 		/// </remarks>
-		ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<FdbDirectoryPath> paths);
+		ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<FdbPath> paths);
 		//REVIEW: only keep the version that accept layers, and use an extension method instead?
 
 		/// <summary>Opens multiple sub-directories with the given <paramref name="paths"/>, using the partition's cache context.</summary>
 		/// <returns>Returns the list directories, in the same order. If a directory does not exist, the corresponding slot will contain <c>null</c></returns>
 		/// <remarks>The instances returned MUST NOT be stored or kept outside the context of the transaction!
-		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, IEnumerable{ValueTuple{FdbDirectoryPath, Slice}})"/> on every new transaction to obtained either the previously cached instances, or a new instances.
+		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, IEnumerable{ValueTuple{FdbPath, Slice}})"/> on every new transaction to obtained either the previously cached instances, or a new instances.
 		/// Attempting to used a cached instances outside the transaction that produced them may throw exceptions!
 		/// </remarks>
-		ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<(FdbDirectoryPath Path, Slice Layer)> paths);
+		ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<(FdbPath Path, Slice Layer)> paths);
 
 		/// <summary>Creates a sub-directory with the given <paramref name="subPath"/> (creating intermediate subdirectories if necessary).
 		/// An exception is thrown if the given sub-directory already exists.
@@ -112,7 +112,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Relative path of the sub-directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the sub-directory and will be checked by future calls to open.</param>
-		Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
+		Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbPath subPath, Slice layer = default);
 
 		/// <summary>Creates a sub-directory with the given <paramref name="subPath"/> (creating intermediate subdirectories if necessary).
 		/// An exception is thrown if the given sub-directory already exists.
@@ -120,14 +120,14 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Relative path of the sub-directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the sub-directory and will be checked by future calls to open.</param>
-		Task<FdbDirectorySubspace?> TryCreateAsync(IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer = default);
+		Task<FdbDirectorySubspace?> TryCreateAsync(IFdbTransaction trans, FdbPath subPath, Slice layer = default);
 
 		/// <summary>Registers an existing prefix as a directory with the given <paramref name="subPath"/> (creating parent directories if necessary). This method is only indented for advanced use cases.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to create</param>
 		/// <param name="layer">If <paramref name="layer"/> is specified, it is recorded with the directory and will be checked by future calls to open.</param>
 		/// <param name="prefix">The directory will be created with the given physical prefix; otherwise a prefix is allocated automatically.</param>
-		Task<FdbDirectorySubspace> RegisterAsync(IFdbTransaction trans, FdbDirectoryPath subPath, Slice layer, Slice prefix);
+		Task<FdbDirectorySubspace> RegisterAsync(IFdbTransaction trans, FdbPath subPath, Slice layer, Slice prefix);
 
 		/// <summary>Moves the specified sub-directory to <paramref name="newPath"/>.
 		/// There is no effect on the physical prefix of the given directory, or on clients that already have the directory open.
@@ -137,7 +137,7 @@ namespace FoundationDB.Client
 		/// <param name="oldPath">Relative path under this directory of the sub-directory to be moved</param>
 		/// <param name="newPath">Relative path under this directory where the sub-directory will be moved to</param>
 		/// <returns>Returns the directory at its new location if successful.</returns>
-		Task<FdbDirectorySubspace> MoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath);
+		Task<FdbDirectorySubspace> MoveAsync(IFdbTransaction trans, FdbPath oldPath, FdbPath newPath);
 
 		/// <summary>Attempts to move the specified sub-directory to <paramref name="newPath"/>.
 		/// There is no effect on the physical prefix of the given directory, or on clients that already have the directory open.
@@ -147,7 +147,7 @@ namespace FoundationDB.Client
 		/// <param name="oldPath">Relative path under this directory of the sub-directory to be moved</param>
 		/// <param name="newPath">Relative path under this directory where the sub-directory will be moved to</param>
 		/// <returns>Returns the directory at its new location if successful. If the directory doesn't exist, then null is returned.</returns>
-		Task<FdbDirectorySubspace?> TryMoveAsync(IFdbTransaction trans, FdbDirectoryPath oldPath, FdbDirectoryPath newPath);
+		Task<FdbDirectorySubspace?> TryMoveAsync(IFdbTransaction trans, FdbPath oldPath, FdbPath newPath);
 		//TODO: merge MoveAsync and TryMoveAsync into a single method!
 
 		/// <summary>Moves the current directory to <paramref name="newAbsolutePath"/>.
@@ -157,7 +157,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="newAbsolutePath">Full path (from the root) where this directory will be moved</param>
 		/// <returns>Returns the directory at its new location if successful.</returns>
-		Task<FdbDirectorySubspace> MoveToAsync(IFdbTransaction trans, FdbDirectoryPath newAbsolutePath);
+		Task<FdbDirectorySubspace> MoveToAsync(IFdbTransaction trans, FdbPath newAbsolutePath);
 
 		/// <summary>Attempts to move the current directory to <paramref name="newAbsolutePath"/>.
 		/// There is no effect on the physical prefix of the given directory, or on clients that already have the directory open.
@@ -166,7 +166,7 @@ namespace FoundationDB.Client
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="newAbsolutePath">Full path (from the root) where this directory will be moved</param>
 		/// <returns>Returns the directory at its new location if successful. If the directory doesn't exist, then null is returned.</returns>
-		Task<FdbDirectorySubspace?> TryMoveToAsync(IFdbTransaction trans, FdbDirectoryPath newAbsolutePath);
+		Task<FdbDirectorySubspace?> TryMoveToAsync(IFdbTransaction trans, FdbPath newAbsolutePath);
 		//TODO: merge MoveToAsync and TryMoveToAsync into a single method!
 
 		/// <summary>Removes a directory, its contents, and all subdirectories.
@@ -174,33 +174,32 @@ namespace FoundationDB.Client
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to remove. Will remove the current directory if <paramref name="subPath"/> is empty</param>
-		Task RemoveAsync(IFdbTransaction trans, FdbDirectoryPath subPath = default);
+		Task RemoveAsync(IFdbTransaction trans, FdbPath subPath = default);
 
 		/// <summary>Attempts to remove the directory, its contents, and all subdirectories.
 		/// Warning: Clients that have already opened the directory might still insert data into its contents after it is removed.
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to remove. Will remove the current directory if <paramref name="subPath"/> is empty</param>
-		Task<bool> TryRemoveAsync(IFdbTransaction trans, FdbDirectoryPath subPath = default);
+		Task<bool> TryRemoveAsync(IFdbTransaction trans, FdbPath subPath = default);
 		//TODO: merge RemoveAsync and TryRemoveAsync into a single method!
 
 		/// <summary>Checks if this directory exists</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to test</param>
 		/// <returns>Returns true if the directory exists, otherwise false.</returns>
-		Task<bool> ExistsAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
+		Task<bool> ExistsAsync(IFdbReadOnlyTransaction trans, FdbPath subPath = default);
 
 		/// <summary>Returns the list of all the subdirectories of the current directory.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to list</param>
-		Task<List<string>> ListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
+		Task<List<FdbPath>> ListAsync(IFdbReadOnlyTransaction trans, FdbPath subPath = default);
 		//TODO: return a List<FdbDirectoryPath> instead?
 
 		/// <summary>Returns the list of all the subdirectories of the current directory, it it exists.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="subPath">Path of the directory to list</param>
-		Task<List<string>?> TryListAsync(IFdbReadOnlyTransaction trans, FdbDirectoryPath subPath = default);
-		//TODO: return a List<FdbDirectoryPath> instead?
+		Task<List<FdbPath>?> TryListAsync(IFdbReadOnlyTransaction trans, FdbPath subPath = default);
 		//TODO: merge ListAsync and TryListAsync into a single method!
 
 		//TODO: Add BrowseAsync(...) which is the same as ListAsync(...) but returns the FdbDirectorySubspace instances directly?

--- a/FoundationDB.Client/Subspaces/SubspaceLocation.cs
+++ b/FoundationDB.Client/Subspaces/SubspaceLocation.cs
@@ -508,21 +508,20 @@ namespace FoundationDB.Client
 
 		/// <summary>Return a directory version of the current location</summary>
 		/// <param name="self">Existing subspace location</param>
-		/// <param name="layer">Optional layer id of the directory</param>
 		/// <returns>A <see cref="FdbDirectorySubspaceLocation"/> that points to the same location as <paramref name="self"/>.</returns>
 		/// <exception cref="ArgumentException">If the location has a non-zero <see cref="ISubspaceLocation.Prefix"/></exception>
 		[Pure]
-		public static FdbDirectorySubspaceLocation AsDirectory(this ISubspaceLocation self, Slice layer = default)
+		public static FdbDirectorySubspaceLocation AsDirectory(this ISubspaceLocation self)
 		{
 			Contract.NotNull(self, nameof(self));
 
-			if (self is FdbDirectorySubspaceLocation dsl && dsl.Layer == layer)
+			if (self is FdbDirectorySubspaceLocation dsl)
 			{
 				return dsl;
 			}
 
 			if (self.Prefix.Count != 0) throw new ArgumentException($"Cannot convert location '{self}' into a directory location, because it has a non-empty prefix.");
-			return new FdbDirectorySubspaceLocation(self.Path, layer);
+			return new FdbDirectorySubspaceLocation(self.Path);
 		}
 
 		/// <summary>Return a dynamic version of the current path</summary>

--- a/FoundationDB.DependencyInjection/Implementation/FdbDatabaseProvider.cs
+++ b/FoundationDB.DependencyInjection/Implementation/FdbDatabaseProvider.cs
@@ -64,7 +64,7 @@ namespace FoundationDB.DependencyInjection
 		{
 			Contract.NotNull(optionsAccessor, nameof(optionsAccessor));
 			this.Options = optionsAccessor.Value;
-			this.Root = new FdbDirectorySubspaceLocation(this.Options.ConnectionOptions.Root);
+			this.Root = new FdbDirectorySubspaceLocation(this.Options.ConnectionOptions.Root ?? FdbPath.Root);
 			this.DbTask = Task.FromException<IFdbDatabase>(new InvalidOperationException("The database has not been initialized."));
 		}
 

--- a/FoundationDB.Samples/Program.cs
+++ b/FoundationDB.Samples/Program.cs
@@ -126,7 +126,7 @@ namespace FoundationDB.Samples
 			bool stop = false;
 
 			string clusterFile = null;
-			var partition = FdbDirectoryPath.Empty;
+			var partition = FdbPath.Root;
 
 			int pStart = 0;
 			string startCommand = null;
@@ -144,7 +144,7 @@ namespace FoundationDB.Samples
 						}
 						case "P": case "p":
 						{
-							partition = FdbDirectoryPath.Parse(args[pStart + 1].Trim());
+							partition = FdbPath.Parse(args[pStart + 1].Trim());
 							pStart += 2;
 							break;
 						}

--- a/FoundationDB.Tests.Sandbox/Program.cs
+++ b/FoundationDB.Tests.Sandbox/Program.cs
@@ -170,7 +170,7 @@ namespace FoundationDB.Tests.Sandbox
 				var settings = new FdbConnectionOptions()
 				{
 					ClusterFile = CLUSTER_FILE,
-					Root = FdbDirectoryPath.Combine("Sandbox"),
+					Root = FdbPath.Parse("/Sandbox"),
 				};
 
 				Console.WriteLine("Connecting to local cluster...");

--- a/FoundationDB.Tests/DatabaseFacts.cs
+++ b/FoundationDB.Tests/DatabaseFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2018, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,6 @@ namespace FoundationDB.Client.Tests
 	using System.IO;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Doxense.Collections.Tuples;
 	using FoundationDB.Client;
 	using NUnit.Framework;
 

--- a/FoundationDB.Tests/DatabaseFacts.cs
+++ b/FoundationDB.Tests/DatabaseFacts.cs
@@ -52,7 +52,7 @@ namespace FoundationDB.Client.Tests
 				Assert.That(db, Is.Not.Null);
 				Assert.That(db.ClusterFile, Is.Null, ".ClusterFile");
 				Assert.That(db.Root, Is.Not.Null, ".Root");
-				Assert.That(db.Root.Path, Is.EqualTo(FdbDirectoryPath.Empty));
+				Assert.That(db.Root.Path, Is.EqualTo(FdbPath.Root));
 				Assert.That(db.IsReadOnly, Is.False, ".IsReadOnly");
 			}
 		}
@@ -127,7 +127,7 @@ namespace FoundationDB.Client.Tests
 				Assert.That(db, Is.Not.Null, "Should return a valid database");
 				Assert.That(db.ClusterFile, Is.Null, "Cluster path should be null (default)");
 				Assert.That(db.Root, Is.Not.Null, ".Root");
-				Assert.That(db.Root.Path, Is.EqualTo(FdbDirectoryPath.Empty), ".Root");
+				Assert.That(db.Root.Path, Is.EqualTo(FdbPath.Root), ".Root");
 				Assert.That(db.DirectoryLayer, Is.Not.Null, ".DirectoryLayer");
 			}
 		}
@@ -260,12 +260,12 @@ namespace FoundationDB.Client.Tests
 				Assert.That(db, Is.Not.Null);
 
 				Assert.That(db.Root, Is.Not.Null);
-				Assert.That(db.Root.Path, Is.Not.EqualTo(FdbDirectoryPath.Empty));
+				Assert.That(db.Root.Path, Is.Not.EqualTo(FdbPath.Root));
 
 				var dl = db.DirectoryLayer;
 				Assert.That(dl, Is.Not.Null);
 				Assert.That(dl.Content, Is.Not.Null);
-				Assert.That(dl.Content, Is.EqualTo(SubspaceLocation.Empty), "Root DL should be located at the top");
+				Assert.That(dl.Content, Is.EqualTo(SubspaceLocation.Root), "Root DL should be located at the top");
 
 				using (var tr = await db.BeginReadOnlyTransactionAsync(this.Cancellation))
 				{
@@ -320,7 +320,7 @@ namespace FoundationDB.Client.Tests
 			options = new FdbConnectionOptions
 			{
 				ClusterFile = "X:\\some\\path\\to\\fdb.cluster",
-				Root = FdbDirectoryPath.Combine("Hello", "World"),
+				Root = FdbPath.Parse("/Hello/World"),
 			};
 			Assert.That(options.ToString(), Is.EqualTo(@"cluster_file=X:\some\path\to\fdb.cluster; root=/Hello/World"));
 

--- a/FoundationDB.Tests/ErrorFacts.cs
+++ b/FoundationDB.Tests/ErrorFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2018, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/ExoticTestCases.cs
+++ b/FoundationDB.Tests/ExoticTestCases.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2018, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/FdbTest.cs
+++ b/FoundationDB.Tests/FdbTest.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2019, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,6 @@ namespace FoundationDB.Client.Tests
 	using System;
 	using System.Diagnostics;
 	using System.Globalization;
-	using System.IO;
 	using System.Reflection;
 	using System.Threading;
 	using System.Threading.Tasks;

--- a/FoundationDB.Tests/KeyFacts.cs
+++ b/FoundationDB.Tests/KeyFacts.cs
@@ -30,6 +30,7 @@ namespace FoundationDB.Client.Tests
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Globalization;
 	using System.Linq;
 	using System.Threading;
 	using System.Threading.Tasks;
@@ -351,8 +352,9 @@ namespace FoundationDB.Client.Tests
 			Assert.That(FdbKey.Dump(TuPack.EncodeKey(new byte[] { 1, 2, 3 }.AsSlice())), Is.EqualTo("(`<01><02><03>`,)"));
 			Assert.That(FdbKey.Dump(TuPack.EncodeKey(123, 456)), Is.EqualTo("(123, 456)"), "Elements should be separated with a space, and not end up with ','");
 			Assert.That(FdbKey.Dump(TuPack.EncodeKey(default(object), true, false)), Is.EqualTo("(null, true, false)"), "Booleans should be displayed as numbers, and null should be in lowercase"); //note: even though it's tempting to using Python's "Nil", it's not very ".NETty"
-			Assert.That(FdbKey.Dump(TuPack.EncodeKey(1.0d, Math.PI, Math.E)), Is.EqualTo("(1, 3.1415926535897931, 2.7182818284590451)"), "Doubles should used dot and have full precision (17 digits)");
-			Assert.That(FdbKey.Dump(TuPack.EncodeKey(1.0f, (float)Math.PI, (float)Math.E)), Is.EqualTo("(1, 3.14159274, 2.71828175)"), "Singles should used dot and have full precision (10 digits)");
+			//note: the string representation of double is not identical between NetFx and .NET Core! So we cannot used a constant literal here
+			Assert.That(FdbKey.Dump(TuPack.EncodeKey(1.0d, Math.PI, Math.E)), Is.EqualTo("(1, " + Math.PI.ToString("R", CultureInfo.InvariantCulture) + ", " + Math.E.ToString("R", CultureInfo.InvariantCulture) + ")"), "Doubles should used dot and have full precision (17 digits)");
+			Assert.That(FdbKey.Dump(TuPack.EncodeKey(1.0f, (float)Math.PI, (float)Math.E)), Is.EqualTo("(1, " + ((float) Math.PI).ToString("R", CultureInfo.InvariantCulture)+ ", " + ((float) Math.E).ToString("R", CultureInfo.InvariantCulture) + ")"), "Singles should used dot and have full precision (10 digits)");
 			var guid = Guid.NewGuid();
 			Assert.That(FdbKey.Dump(TuPack.EncodeKey(guid)), Is.EqualTo($"({guid:B},)"), "GUIDs should be displayed as a string literal, surrounded by {{...}}, and without quotes");
 			var uuid128 = Uuid128.NewUuid();

--- a/FoundationDB.Tests/KeyFacts.cs
+++ b/FoundationDB.Tests/KeyFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2019, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/Layers/DirectoryFacts.cs
+++ b/FoundationDB.Tests/Layers/DirectoryFacts.cs
@@ -282,7 +282,7 @@ namespace FoundationDB.Client.Tests
 					Assert.That(foo.FullName, Is.EqualTo("/Foo"));
 
 					// via relative path
-					bar = await foo.OpenAsync(tr, FdbPath.MakeRelative("Bar"));
+					bar = await foo.OpenAsync(tr, FdbPath.Relative("Bar"));
 					Assert.That(bar, Is.Not.Null);
 					Assert.That(bar.FullName, Is.EqualTo("/Foo/Bar"));
 
@@ -292,8 +292,8 @@ namespace FoundationDB.Client.Tests
 					Assert.That(bar.FullName, Is.EqualTo("/Foo/Bar"));
 
 					// opening a non existing folder should fail
-					Assert.That(async () => await foo.OpenAsync(tr, FdbPath.MakeRelative("Baz")), Throws.Exception, "Open on a missing folder should fail");
-					Assert.That(await foo.TryOpenAsync(tr, FdbPath.MakeRelative("Baz")), Is.Null, "TryOpen on a missing folder should return null");
+					Assert.That(async () => await foo.OpenAsync(tr, FdbPath.Relative("Baz")), Throws.Exception, "Open on a missing folder should fail");
+					Assert.That(await foo.TryOpenAsync(tr, FdbPath.Relative("Baz")), Is.Null, "TryOpen on a missing folder should return null");
 
 					// attempting to open a "foreign" folder via "foo" should fail
 					Assert.That(async () => await foo.OpenAsync(tr, FdbPath.Parse("/Other/Bar")), Throws.InvalidOperationException, "Should not be able to open a sub-folder with a path outside its parent");
@@ -648,7 +648,7 @@ namespace FoundationDB.Client.Tests
 					Assert.That(partition.DirectoryLayer, Is.SameAs(dl), "Partitions share the same DL");
 
 					Log("Creating sub-directory Bar under partition Foo$ ...");
-					var bar = await partition.CreateAsync(tr, FdbPath.MakeRelative(segBar));
+					var bar = await partition.CreateAsync(tr, FdbPath.Relative(segBar));
 					Dump(bar);
 					await DumpSubspace(tr, location);
 					Assert.That(bar, Is.InstanceOf<FdbDirectorySubspace>());
@@ -707,7 +707,7 @@ namespace FoundationDB.Client.Tests
 
 					Log("Creating /Foo$/Bar ...");
 					// create a 'Bar' under the 'Foo' partition
-					var bar = await foo.CreateAsync(tr, FdbPath.MakeRelative("Bar"));
+					var bar = await foo.CreateAsync(tr, FdbPath.Relative("Bar"));
 					Dump(bar);
 					await DumpSubspace(tr, location);
 
@@ -766,7 +766,7 @@ namespace FoundationDB.Client.Tests
 
 					// create a 'Inner' subpartition under the 'Outer' partition
 					Log("Create [Outer$][Inner$]");
-					var inner = await outer.CreateAsync(tr, FdbPath.MakeRelative(segInner));
+					var inner = await outer.CreateAsync(tr, FdbPath.Relative(segInner));
 					Dump(inner);
 					await DumpSubspace(tr, location);
 
@@ -777,14 +777,14 @@ namespace FoundationDB.Client.Tests
 
 					// create folder /Outer/Foo
 					Log("Create [Outer$][Foo]...");
-					var foo = await outer.CreateAsync(tr, FdbPath.MakeRelative(segFoo));
+					var foo = await outer.CreateAsync(tr, FdbPath.Relative(segFoo));
 					await DumpSubspace(tr, location);
 					Assert.That(foo.FullName, Is.EqualTo("/Outer/Foo"));
 					Assert.That(foo.Path, Is.EqualTo(FdbPath.Absolute(segOuter, segFoo)));
 
 					// create folder /Outer/Inner/Bar
 					Log("Create [Outer$/Inner$][Bar]...");
-					var bar = await inner.CreateAsync(tr, FdbPath.MakeRelative(segBar));
+					var bar = await inner.CreateAsync(tr, FdbPath.Relative(segBar));
 					await DumpSubspace(tr, location);
 					Assert.That(bar.FullName, Is.EqualTo("/Outer/Inner/Bar"));
 					Assert.That(bar.Path, Is.EqualTo(FdbPath.Absolute(segOuter, segInner, segBar)));
@@ -1014,7 +1014,7 @@ namespace FoundationDB.Client.Tests
 					var partition = await dl.CreateAsync(tr, FdbPath.Absolute("Foo[partition]"));
 					Log($"Partition: {partition.Descriptor.Prefix:K}");
 					//note: if we want a testable key INSIDE the partition, we have to get it from a sub-directory
-					var subdir = await partition.CreateOrOpenAsync(tr, FdbPath.MakeRelative("Bar"));
+					var subdir = await partition.CreateOrOpenAsync(tr, FdbPath.Relative("Bar"));
 					Log($"SubDir: {subdir.Descriptor.Prefix:K}");
 					var barKey = subdir.GetPrefix();
 

--- a/FoundationDB.Tests/Layers/DirectoryFacts.cs
+++ b/FoundationDB.Tests/Layers/DirectoryFacts.cs
@@ -190,7 +190,7 @@ namespace FoundationDB.Client.Tests
 
 				Assert.That(foo, Is.Not.Null);
 				Assert.That(foo.FullName, Is.EqualTo("/Foo"));
-				Assert.That(foo.Path, Is.EqualTo(FdbPath.MakeAbsolute(segFoo)));
+				Assert.That(foo.Path, Is.EqualTo(FdbPath.Absolute(segFoo)));
 				Assert.That(foo.Name, Is.EqualTo("Foo"));
 				Assert.That(foo.Layer, Is.EqualTo("AcmeLayer"));
 				Assert.That(foo.DirectoryLayer, Is.SameAs(dl));
@@ -199,7 +199,7 @@ namespace FoundationDB.Client.Tests
 				var foo2 = await logged.ReadAsync(tr => dl.OpenAsync(tr, FdbPath.Parse("/Foo[AcmeLayer]")), this.Cancellation);
 				Assert.That(foo2, Is.Not.Null);
 				Assert.That(foo2.FullName, Is.EqualTo("/Foo"));
-				Assert.That(foo2.Path, Is.EqualTo(FdbPath.MakeAbsolute(segFoo)));
+				Assert.That(foo2.Path, Is.EqualTo(FdbPath.Absolute(segFoo)));
 				Assert.That(foo2.Name, Is.EqualTo("Foo"));
 				Assert.That(foo2.Layer, Is.EqualTo("AcmeLayer"));
 				Assert.That(foo2.DirectoryLayer, Is.SameAs(dl));
@@ -258,7 +258,7 @@ namespace FoundationDB.Client.Tests
 					var folder = await dl.CreateOrOpenAsync(tr, FdbPath.Parse("/Foo/Bar/Baz"));
 					Assert.That(folder, Is.Not.Null);
 					Assert.That(folder.FullName, Is.EqualTo("/Foo/Bar/Baz"));
-					Assert.That(folder.Path, Is.EqualTo(FdbPath.MakeAbsolute("Foo", "Bar", "Baz")));
+					Assert.That(folder.Path, Is.EqualTo(FdbPath.Absolute("Foo", "Bar", "Baz")));
 					await tr.CommitAsync();
 				}
 #if DEBUG
@@ -335,7 +335,7 @@ namespace FoundationDB.Client.Tests
 				{
 					for (int i = 0; i < 10; i++)
 					{
-						await directory.CreateOrOpenAsync(tr, FdbPath.MakeAbsolute("numbers", i.ToString()));
+						await directory.CreateOrOpenAsync(tr, FdbPath.Absolute("numbers", i.ToString()));
 					}
 				}, this.Cancellation);
 #if DEBUG
@@ -367,7 +367,7 @@ namespace FoundationDB.Client.Tests
 				Assert.That(subdirs, Is.Not.Null);
 				foreach (var subdir in subdirs) Log($"- " + subdir);
 				Assert.That(subdirs.Count, Is.EqualTo(10));
-				Assert.That(subdirs, Is.EquivalentTo(Enumerable.Range(0, 10).Select(x => FdbPath.MakeAbsolute("numbers", x.ToString())).ToList()));
+				Assert.That(subdirs, Is.EquivalentTo(Enumerable.Range(0, 10).Select(x => FdbPath.Absolute("numbers", x.ToString())).ToList()));
 
 #if ENABLE_LOGGING
 				foreach (var log in list)
@@ -400,7 +400,7 @@ namespace FoundationDB.Client.Tests
 						var i = rnd.Next(letters.Count);
 						var s = letters[i];
 						letters.RemoveAt(i);
-						await dl.CreateOrOpenAsync(tr, FdbPath.MakeAbsolute("letters", s));
+						await dl.CreateOrOpenAsync(tr, FdbPath.Absolute("letters", s));
 					}
 				}, this.Cancellation);
 
@@ -410,13 +410,13 @@ namespace FoundationDB.Client.Tests
 
 				// they should sorted when listed
 				Log("Listing '/letters':");
-				var subdirs = await db.ReadAsync(tr => dl.ListAsync(tr, FdbPath.MakeAbsolute("letters")), this.Cancellation);
+				var subdirs = await db.ReadAsync(tr => dl.ListAsync(tr, FdbPath.Absolute("letters")), this.Cancellation);
 				Assert.That(subdirs, Is.Not.Null);
 				foreach (var subdir in subdirs) Log($"- " + subdir);
 				Assert.That(subdirs.Count, Is.EqualTo(10));
 				for (int i = 0; i < subdirs.Count; i++)
 				{
-					Assert.That(subdirs[i], Is.EqualTo(FdbPath.MakeAbsolute("letters", new string((char) (65 + i), 1))));
+					Assert.That(subdirs[i], Is.EqualTo(FdbPath.Absolute("letters", new string((char) (65 + i), 1))));
 				}
 
 			}
@@ -452,7 +452,7 @@ namespace FoundationDB.Client.Tests
 #endif
 					Assert.That(original, Is.Not.Null);
 					Assert.That(original.FullName, Is.EqualTo("/Foo"));
-					Assert.That(original.Path, Is.EqualTo(FdbPath.MakeAbsolute("Foo")));
+					Assert.That(original.Path, Is.EqualTo(FdbPath.Absolute("Foo")));
 
 					// rename/move it as ('Bar',)
 					var renamed = await original.MoveToAsync(tr, FdbPath.Parse("/Bar"));
@@ -461,7 +461,7 @@ namespace FoundationDB.Client.Tests
 #endif
 					Assert.That(renamed, Is.Not.Null);
 					Assert.That(renamed.FullName, Is.EqualTo("/Bar"));
-					Assert.That(renamed.Path, Is.EqualTo(FdbPath.MakeAbsolute("Bar")));
+					Assert.That(renamed.Path, Is.EqualTo(FdbPath.Absolute("Bar")));
 					Assert.That(renamed.GetPrefix(), Is.EqualTo(original.GetPrefix()));
 
 					return original.GetPrefix();
@@ -476,7 +476,7 @@ namespace FoundationDB.Client.Tests
 					var folder = await dl.OpenAsync(tr, FdbPath.Parse("/Bar"));
 					Assert.That(folder, Is.Not.Null);
 					Assert.That(folder.FullName, Is.EqualTo("/Bar"));
-					Assert.That(folder.Path, Is.EqualTo(FdbPath.MakeAbsolute("Bar")));
+					Assert.That(folder.Path, Is.EqualTo(FdbPath.Absolute("Bar")));
 					Assert.That(folder.GetPrefix(), Is.EqualTo(originalPrefix));
 
 					// moving the folder under itself should fail
@@ -589,7 +589,7 @@ namespace FoundationDB.Client.Tests
 					Assert.That(folder2, Is.Not.Null);
 					Assert.That(folder2.Layer, Is.EqualTo("bar"));
 					Assert.That(folder2.FullName, Is.EqualTo("/Test"));
-					Assert.That(folder2.Path, Is.EqualTo(FdbPath.MakeAbsolute(FdbPathSegment.Create("Test", "foo"))));
+					Assert.That(folder2.Path, Is.EqualTo(FdbPath.Absolute(FdbPathSegment.Create("Test", "foo"))));
 					Assert.That(folder2.GetPrefix(), Is.EqualTo(folder.GetPrefix()));
 				}, this.Cancellation);
 
@@ -634,7 +634,7 @@ namespace FoundationDB.Client.Tests
 					var segBaz = FdbPathSegment.Create("Baz");
 
 					Log("Creating partition /Foo$ ...");
-					var partition = await dl.CreateAsync(tr, FdbPath.MakeAbsolute(segFoo));
+					var partition = await dl.CreateAsync(tr, FdbPath.Absolute(segFoo));
 					Dump(partition);
 					await DumpSubspace(tr, location);
 					// we can't get the partition key directory (because it's a root directory) so we need to cheat a little bit
@@ -644,7 +644,7 @@ namespace FoundationDB.Client.Tests
 					Assert.That(partition, Is.InstanceOf<FdbDirectoryPartition>());
 					Assert.That(partition.Layer, Is.EqualTo("partition"));
 					Assert.That(partition.FullName, Is.EqualTo("/Foo$"));
-					Assert.That(partition.Path, Is.EqualTo(FdbPath.MakeAbsolute(segFoo)), "Partition's path should be absolute");
+					Assert.That(partition.Path, Is.EqualTo(FdbPath.Absolute(segFoo)), "Partition's path should be absolute");
 					Assert.That(partition.DirectoryLayer, Is.SameAs(dl), "Partitions share the same DL");
 
 					Log("Creating sub-directory Bar under partition Foo$ ...");
@@ -652,30 +652,30 @@ namespace FoundationDB.Client.Tests
 					Dump(bar);
 					await DumpSubspace(tr, location);
 					Assert.That(bar, Is.InstanceOf<FdbDirectorySubspace>());
-					Assert.That(bar.Path, Is.EqualTo(FdbPath.MakeAbsolute(segFoo, FdbPathSegment.Create("Bar"))), "Path of directories under a partition should be absolute");
+					Assert.That(bar.Path, Is.EqualTo(FdbPath.Absolute(segFoo, FdbPathSegment.Create("Bar"))), "Path of directories under a partition should be absolute");
 					Assert.That(bar.GetPrefix(), Is.Not.EqualTo(partitionKey), "{0} should be located under {1}", bar, partition);
 					Assert.That(bar.GetPrefix().StartsWith(partitionKey), Is.True, "{0} should be located under {1}", bar, partition);
 
 					Log("Creating sub-directory /Foo$/Baz starting from the root...");
-					var baz = await dl.CreateAsync(tr, FdbPath.MakeAbsolute(segFoo, FdbPathSegment.Create("Baz")));
+					var baz = await dl.CreateAsync(tr, FdbPath.Absolute(segFoo, FdbPathSegment.Create("Baz")));
 					Dump(baz);
 					await DumpSubspace(tr, location);
 					Assert.That(baz, Is.InstanceOf<FdbDirectorySubspace>());
 					Assert.That(baz.FullName, Is.EqualTo("/Foo$/Baz"));
-					Assert.That(baz.Path, Is.EqualTo(FdbPath.MakeAbsolute(segFoo, FdbPathSegment.Create("Baz"))), "Path of directories under a partition should be absolute");
+					Assert.That(baz.Path, Is.EqualTo(FdbPath.Absolute(segFoo, FdbPathSegment.Create("Baz"))), "Path of directories under a partition should be absolute");
 					Assert.That(baz.GetPrefix(), Is.Not.EqualTo(partitionKey), "{0} should be located under {1}", baz, partition);
 					Assert.That(baz.GetPrefix().StartsWith(partitionKey), Is.True, "{0} should be located under {1}", baz, partition);
 
 					// Rename 'Bar' to 'BarBar'
 					Log("Renaming /Foo$/Bar to /Foo$/BarBar...");
-					var bar2 = await bar.MoveToAsync(tr, FdbPath.MakeAbsolute(segFoo, FdbPathSegment.Create("BarBar")));
+					var bar2 = await bar.MoveToAsync(tr, FdbPath.Absolute(segFoo, FdbPathSegment.Create("BarBar")));
 					Dump(bar2);
 					await DumpSubspace(tr, location);
 					Assert.That(bar2, Is.InstanceOf<FdbDirectorySubspace>());
 					Assert.That(bar2, Is.Not.SameAs(bar));
 					Assert.That(bar2.GetPrefix(), Is.EqualTo(bar.GetPrefix()));
 					Assert.That(bar2.FullName, Is.EqualTo("/Foo$/BarBar"));
-					Assert.That(bar2.Path, Is.EqualTo(FdbPath.MakeAbsolute(segFoo, FdbPathSegment.Create("BarBar"))));
+					Assert.That(bar2.Path, Is.EqualTo(FdbPath.Absolute(segFoo, FdbPathSegment.Create("BarBar"))));
 					Assert.That(bar2.DirectoryLayer, Is.SameAs(bar.DirectoryLayer));
 				}, this.Cancellation);
 			}
@@ -701,7 +701,7 @@ namespace FoundationDB.Client.Tests
 				await logged.WriteAsync(async tr =>
 				{
 					Log("Creating /Foo$ ...");
-					var foo = await dl.CreateAsync(tr, FdbPath.MakeAbsolute("Foo$[partition]"));
+					var foo = await dl.CreateAsync(tr, FdbPath.Absolute("Foo$[partition]"));
 					Dump(foo);
 					await DumpSubspace(tr, location);
 
@@ -712,14 +712,14 @@ namespace FoundationDB.Client.Tests
 					await DumpSubspace(tr, location);
 
 					Assert.That(bar.FullName, Is.EqualTo("/Foo$/Bar"));
-					Assert.That(bar.Path, Is.EqualTo(FdbPath.MakeAbsolute("Foo$[partition]", "Bar")));
+					Assert.That(bar.Path, Is.EqualTo(FdbPath.Absolute("Foo$[partition]", "Bar")));
 					Assert.That(bar.DirectoryLayer, Is.SameAs(dl));
 					Assert.That(bar.DirectoryLayer, Is.SameAs(foo.DirectoryLayer));
 
 					// Attempting to move 'Bar' outside the Foo partition should fail
 					Log("Attempting to move /Foo$/Bar to /Bar ...");
 					Assert.That(
-						async () => await bar.MoveToAsync(tr, FdbPath.MakeAbsolute("Bar")),
+						async () => await bar.MoveToAsync(tr, FdbPath.Absolute("Bar")),
 						Throws.InstanceOf<InvalidOperationException>()
 					);
 
@@ -727,7 +727,7 @@ namespace FoundationDB.Client.Tests
 
 				Log("Attempting to move /Foo$/Bar to /Bar ...");
 				Assert.That(
-					async () => await logged.ReadWriteAsync(tr => dl.MoveAsync(tr, FdbPath.MakeAbsolute("Foo$", "Bar"), FdbPath.MakeAbsolute("Bar")), this.Cancellation),
+					async () => await logged.ReadWriteAsync(tr => dl.MoveAsync(tr, FdbPath.Absolute("Foo$", "Bar"), FdbPath.Absolute("Bar")), this.Cancellation),
 					Throws.InstanceOf<InvalidOperationException>()
 				);
 			}
@@ -760,7 +760,7 @@ namespace FoundationDB.Client.Tests
 					var segSubFolder = FdbPathSegment.Create("SubFolder");
 
 					Log("Create [Outer$]");
-					var outer = await dl.CreateAsync(tr, FdbPath.MakeAbsolute(segOuter));
+					var outer = await dl.CreateAsync(tr, FdbPath.Absolute(segOuter));
 					Dump(outer);
 					await DumpSubspace(tr, location);
 
@@ -771,7 +771,7 @@ namespace FoundationDB.Client.Tests
 					await DumpSubspace(tr, location);
 
 					Assert.That(inner.FullName, Is.EqualTo("/Outer/Inner"));
-					Assert.That(inner.Path, Is.EqualTo(FdbPath.MakeAbsolute(segOuter, segInner)));
+					Assert.That(inner.Path, Is.EqualTo(FdbPath.Absolute(segOuter, segInner)));
 					Assert.That(inner.DirectoryLayer, Is.SameAs(dl));
 					Assert.That(inner.DirectoryLayer, Is.SameAs(outer.DirectoryLayer));
 
@@ -780,44 +780,44 @@ namespace FoundationDB.Client.Tests
 					var foo = await outer.CreateAsync(tr, FdbPath.MakeRelative(segFoo));
 					await DumpSubspace(tr, location);
 					Assert.That(foo.FullName, Is.EqualTo("/Outer/Foo"));
-					Assert.That(foo.Path, Is.EqualTo(FdbPath.MakeAbsolute(segOuter, segFoo)));
+					Assert.That(foo.Path, Is.EqualTo(FdbPath.Absolute(segOuter, segFoo)));
 
 					// create folder /Outer/Inner/Bar
 					Log("Create [Outer$/Inner$][Bar]...");
 					var bar = await inner.CreateAsync(tr, FdbPath.MakeRelative(segBar));
 					await DumpSubspace(tr, location);
 					Assert.That(bar.FullName, Is.EqualTo("/Outer/Inner/Bar"));
-					Assert.That(bar.Path, Is.EqualTo(FdbPath.MakeAbsolute(segOuter, segInner, segBar)));
+					Assert.That(bar.Path, Is.EqualTo(FdbPath.Absolute(segOuter, segInner, segBar)));
 
 					// Attempting to move 'Foo' inside the Inner partition should fail
-					Assert.That(async () => await foo.MoveToAsync(tr, FdbPath.MakeAbsolute(segOuter, segInner, segFoo)), Throws.InstanceOf<InvalidOperationException>());
-					Assert.That(async () => await dl.MoveAsync(tr, FdbPath.MakeAbsolute(segOuter, segFoo), FdbPath.MakeAbsolute(segOuter, segInner, segFoo)), Throws.InstanceOf<InvalidOperationException>());
+					Assert.That(async () => await foo.MoveToAsync(tr, FdbPath.Absolute(segOuter, segInner, segFoo)), Throws.InstanceOf<InvalidOperationException>());
+					Assert.That(async () => await dl.MoveAsync(tr, FdbPath.Absolute(segOuter, segFoo), FdbPath.Absolute(segOuter, segInner, segFoo)), Throws.InstanceOf<InvalidOperationException>());
 
 					// Attempting to move 'Bar' outside the Inner partition should fail
-					Assert.That(async () => await bar.MoveToAsync(tr, FdbPath.MakeAbsolute(segOuter, FdbPathSegment.Create("Bar"))), Throws.InstanceOf<InvalidOperationException>());
-					Assert.That(async () => await dl.MoveAsync(tr, FdbPath.MakeAbsolute(segOuter, segInner, FdbPathSegment.Create("Bar")), FdbPath.MakeAbsolute(segOuter, segBar)), Throws.InstanceOf<InvalidOperationException>());
+					Assert.That(async () => await bar.MoveToAsync(tr, FdbPath.Absolute(segOuter, FdbPathSegment.Create("Bar"))), Throws.InstanceOf<InvalidOperationException>());
+					Assert.That(async () => await dl.MoveAsync(tr, FdbPath.Absolute(segOuter, segInner, FdbPathSegment.Create("Bar")), FdbPath.Absolute(segOuter, segBar)), Throws.InstanceOf<InvalidOperationException>());
 
 					// Moving 'Foo' inside the Outer partition itself should work
 					Log("Create [Outer$/SubFolder]...");
-					await dl.CreateAsync(tr, FdbPath.MakeAbsolute(segOuter, segSubFolder)); // parent of destination folder must already exist when moving...
+					await dl.CreateAsync(tr, FdbPath.Absolute(segOuter, segSubFolder)); // parent of destination folder must already exist when moving...
 					await DumpSubspace(tr, location);
 
 					Log("Move [Outer$/Foo] to [Outer$/SubFolder/Foo]");
-					var foo2 = await dl.MoveAsync(tr, FdbPath.MakeAbsolute(segOuter, segFoo), FdbPath.MakeAbsolute(segOuter, segSubFolder, segFoo));
+					var foo2 = await dl.MoveAsync(tr, FdbPath.Absolute(segOuter, segFoo), FdbPath.Absolute(segOuter, segSubFolder, segFoo));
 					await DumpSubspace(tr, location);
-					Assert.That(foo2.Path, Is.EqualTo(FdbPath.MakeAbsolute(segOuter, segSubFolder, segFoo)));
+					Assert.That(foo2.Path, Is.EqualTo(FdbPath.Absolute(segOuter, segSubFolder, segFoo)));
 					Assert.That(foo2.FullName, Is.EqualTo("/Outer/SubFolder/Foo"));
 					Assert.That(foo2.GetPrefix(), Is.EqualTo(foo.GetPrefix()));
 
 					// Moving 'Bar' inside the Inner partition itself should work
 					Log("Create 'Outer/Inner/SubFolder'...");
-					await dl.CreateAsync(tr, FdbPath.MakeAbsolute(segOuter, segInner, segSubFolder)); // parent of destination folder must already exist when moving...
+					await dl.CreateAsync(tr, FdbPath.Absolute(segOuter, segInner, segSubFolder)); // parent of destination folder must already exist when moving...
 					await DumpSubspace(tr, location);
 
 					Log("Move 'Outer/Inner/Bar' to 'Outer/Inner/SubFolder/Bar'");
-					var bar2 = await dl.MoveAsync(tr, FdbPath.MakeAbsolute(segOuter, segInner, segBar), FdbPath.MakeAbsolute(segOuter, segInner, segSubFolder, segBar));
+					var bar2 = await dl.MoveAsync(tr, FdbPath.Absolute(segOuter, segInner, segBar), FdbPath.Absolute(segOuter, segInner, segSubFolder, segBar));
 					await DumpSubspace(tr, location);
-					Assert.That(bar2.Path, Is.EqualTo(FdbPath.MakeAbsolute(segOuter, segInner, segSubFolder, segBar)));
+					Assert.That(bar2.Path, Is.EqualTo(FdbPath.Absolute(segOuter, segInner, segSubFolder, segBar)));
 					Assert.That(bar2.FullName, Is.EqualTo("/Outer/Inner/SubFolder/Bar"));
 					Assert.That(bar2.GetPrefix(), Is.EqualTo(bar.GetPrefix()));
 				}, this.Cancellation);
@@ -847,12 +847,12 @@ namespace FoundationDB.Client.Tests
 
 					// create foo
 					Log("Creating /Foo$ ...");
-					var foo = await dl.CreateOrOpenAsync(tr, FdbPath.MakeAbsolute(segFoo));
+					var foo = await dl.CreateOrOpenAsync(tr, FdbPath.Absolute(segFoo));
 					Dump(foo);
 					await DumpSubspace(tr, location);
 					Assert.That(foo, Is.Not.Null);
 					Assert.That(foo.FullName, Is.EqualTo("/Foo$"));
-					Assert.That(foo.Path, Is.EqualTo(FdbPath.MakeAbsolute(segFoo)));
+					Assert.That(foo.Path, Is.EqualTo(FdbPath.Absolute(segFoo)));
 					Assert.That(foo.Name, Is.EqualTo("Foo$"));
 					Assert.That(foo.Layer, Is.EqualTo("partition"));
 					Assert.That(foo, Is.InstanceOf<FdbDirectoryPartition>());
@@ -861,15 +861,15 @@ namespace FoundationDB.Client.Tests
 					Log("Checking top...");
 					var folders = await dl.ListAsync(tr);
 					foreach (var f in folders) Log($"- {f}");
-					Assert.That(folders, Is.EqualTo(new[] { FdbPath.MakeAbsolute(segFoo) }));
+					Assert.That(folders, Is.EqualTo(new[] { FdbPath.Absolute(segFoo) }));
 
 					// rename to bar
 					Log("Renaming [Foo$] to [Bar$]");
-					var bar = await foo.MoveToAsync(tr, FdbPath.MakeAbsolute(segBar));
+					var bar = await foo.MoveToAsync(tr, FdbPath.Absolute(segBar));
 					await DumpSubspace(tr, location);
 					Assert.That(bar, Is.Not.Null);
 					Assert.That(bar.FullName, Is.EqualTo("/Bar$"));
-					Assert.That(bar.Path, Is.EqualTo(FdbPath.MakeAbsolute(segBar)));
+					Assert.That(bar.Path, Is.EqualTo(FdbPath.Absolute(segBar)));
 					Assert.That(bar.Name, Is.EqualTo("Bar$"));
 					Assert.That(bar.Layer, Is.EqualTo("partition"));
 					Assert.That(bar, Is.InstanceOf<FdbDirectoryPartition>());
@@ -881,7 +881,7 @@ namespace FoundationDB.Client.Tests
 					// verify list again
 					folders = await dl.ListAsync(tr);
 					foreach (var f in folders) Log($"- {f}");
-					Assert.That(folders, Is.EqualTo(new [] { FdbPath.MakeAbsolute(segBar) }));
+					Assert.That(folders, Is.EqualTo(new [] { FdbPath.Absolute(segBar) }));
 
 					//no need to commit
 				}
@@ -909,16 +909,16 @@ namespace FoundationDB.Client.Tests
 					var segFoo = FdbPathSegment.Partition("foo");
 
 					// create foo
-					var foo = await dl.CreateOrOpenAsync(tr, FdbPath.MakeAbsolute(segFoo));
+					var foo = await dl.CreateOrOpenAsync(tr, FdbPath.Absolute(segFoo));
 					Assert.That(foo, Is.Not.Null);
 					Assert.That(foo.FullName, Is.EqualTo("/foo"));
-					Assert.That(foo.Path, Is.EqualTo(FdbPath.MakeAbsolute(segFoo)));
+					Assert.That(foo.Path, Is.EqualTo(FdbPath.Absolute(segFoo)));
 					Assert.That(foo.Layer, Is.EqualTo("partition"));
 					Assert.That(foo, Is.InstanceOf<FdbDirectoryPartition>());
 
 					// verify list
 					var folders = await dl.ListAsync(tr);
-					Assert.That(folders, Is.EqualTo(new[] { FdbPath.MakeAbsolute(segFoo) }));
+					Assert.That(folders, Is.EqualTo(new[] { FdbPath.Absolute(segFoo) }));
 
 					// delete foo
 					await foo.RemoveAsync(tr);
@@ -931,7 +931,7 @@ namespace FoundationDB.Client.Tests
 					var res = await foo.ExistsAsync(tr);
 					Assert.That(res, Is.False);
 
-					res = await dl.ExistsAsync(tr, FdbPath.MakeAbsolute(segFoo));
+					res = await dl.ExistsAsync(tr, FdbPath.Absolute(segFoo));
 					Assert.That(res, Is.False);
 
 					//no need to commit
@@ -972,12 +972,12 @@ namespace FoundationDB.Client.Tests
 				// Remove
 				Assert.That(async () => await logged.WriteAsync(tr => directory.RemoveAsync(tr, FdbPath.Root), this.Cancellation), Throws.InstanceOf<InvalidOperationException>());
 				Assert.That(async () => await logged.WriteAsync(tr => directory.RemoveAsync(tr, FdbPath.Empty), this.Cancellation), Throws.InstanceOf<InvalidOperationException>());
-				Assert.That(async () => await logged.WriteAsync(tr => directory.RemoveAsync(tr, FdbPath.MakeAbsolute("Foo", " ", "Bar")), this.Cancellation), Throws.InstanceOf<InvalidOperationException>());
+				Assert.That(async () => await logged.WriteAsync(tr => directory.RemoveAsync(tr, FdbPath.Absolute("Foo", " ", "Bar")), this.Cancellation), Throws.InstanceOf<InvalidOperationException>());
 
 				// List
 				Assert.That(async () => await logged.ReadAsync(tr => directory.ListAsync(tr, FdbPath.Root), this.Cancellation), Throws.Nothing);
 				Assert.That(async () => await logged.ReadAsync(tr => directory.ListAsync(tr, FdbPath.Empty), this.Cancellation), Throws.Nothing);
-				Assert.That(async () => await logged.ReadAsync(tr => directory.ListAsync(tr, FdbPath.MakeAbsolute("Foo", " ", "Bar")), this.Cancellation), Throws.InstanceOf<InvalidOperationException>());
+				Assert.That(async () => await logged.ReadAsync(tr => directory.ListAsync(tr, FdbPath.Absolute("Foo", " ", "Bar")), this.Cancellation), Throws.InstanceOf<InvalidOperationException>());
 
 			}
 		}
@@ -1011,7 +1011,7 @@ namespace FoundationDB.Client.Tests
 
 				await logged.WriteAsync(async tr =>
 				{
-					var partition = await dl.CreateAsync(tr, FdbPath.MakeAbsolute("Foo[partition]"));
+					var partition = await dl.CreateAsync(tr, FdbPath.Absolute("Foo[partition]"));
 					Log($"Partition: {partition.Descriptor.Prefix:K}");
 					//note: if we want a testable key INSIDE the partition, we have to get it from a sub-directory
 					var subdir = await partition.CreateOrOpenAsync(tr, FdbPath.MakeRelative("Bar"));
@@ -1114,11 +1114,11 @@ namespace FoundationDB.Client.Tests
 						);
 
 						// T1 creates first directory
-						var first = await dl.CreateAsync(tr1, FdbPath.MakeAbsolute("First"));
+						var first = await dl.CreateAsync(tr1, FdbPath.Absolute("First"));
 						tr1.Set(first.GetPrefix(), Value("This belongs to the first directory"));
 
 						// T2 creates second directory
-						var second = await dl.CreateAsync(tr2, FdbPath.MakeAbsolute("Second"));
+						var second = await dl.CreateAsync(tr2, FdbPath.Absolute("Second"));
 						tr2.Set(second.GetPrefix(), Value("This belongs to the second directory"));
 
 						// T1 commits first
@@ -1160,7 +1160,7 @@ namespace FoundationDB.Client.Tests
 				Dump(dl);
 
 				//to prevent any side effect from first time initialization of the directory layer, already create one dummy folder
-				await logged.ReadWriteAsync(tr => dl.CreateAsync(tr, FdbPath.MakeAbsolute("Zero")), this.Cancellation);
+				await logged.ReadWriteAsync(tr => dl.CreateAsync(tr, FdbPath.Absolute("Zero")), this.Cancellation);
 
 				var logdb = db.Logged((tr) => Log(tr.Log.GetTimingsReport(true)));
 
@@ -1181,10 +1181,10 @@ namespace FoundationDB.Client.Tests
 						var subspace1 = await location.Resolve(tr1, dl);
 						var subspace2 = await location.Resolve(tr2, dl);
 
-						var first = await dl.RegisterAsync(tr1, FdbPath.MakeAbsolute("First"), subspace1.Encode("abc"));
+						var first = await dl.RegisterAsync(tr1, FdbPath.Absolute("First"), subspace1.Encode("abc"));
 						tr1.Set(first.GetPrefix(), Value("This belongs to the first directory"));
 
-						var second = await dl.RegisterAsync(tr2, FdbPath.MakeAbsolute("Second"), subspace2.Encode("def"));
+						var second = await dl.RegisterAsync(tr2, FdbPath.Absolute("Second"), subspace2.Encode("def"));
 						tr2.Set(second.GetPrefix(), Value("This belongs to the second directory"));
 
 						Log("Committing T1...");
@@ -1253,7 +1253,7 @@ namespace FoundationDB.Client.Tests
 					Assert.That(actual.GetPrefix(), Is.EqualTo(expected.GetPrefix()));
 				}
 
-				var pathFoo = FdbPath.MakeAbsolute(FdbPathSegment.Create("Foo"));
+				var pathFoo = FdbPath.Absolute(FdbPathSegment.Create("Foo"));
 				var pathBar = pathFoo[FdbPathSegment.Create("Bar")];
 
 				// first, initialize the subspace
@@ -1380,7 +1380,7 @@ namespace FoundationDB.Client.Tests
 					await logged.WriteAsync(
 						async tr =>
 						{
-							for (int i = 0; i < N; i++) await dl.CreateAsync(tr, FdbPath.MakeAbsolute("Tests", k.ToString(), i.ToString()));
+							for (int i = 0; i < N; i++) await dl.CreateAsync(tr, FdbPath.Absolute("Tests", k.ToString(), i.ToString()));
 						},
 						this.Cancellation);
 
@@ -1394,7 +1394,7 @@ namespace FoundationDB.Client.Tests
 							var res = new List<FdbDirectorySubspace>();
 							for (int i = 0; i < N; i++)
 							{
-								res.Add(await dl.TryOpenCachedAsync(tr, FdbPath.MakeAbsolute("Tests", k.ToString(), i.ToString())));
+								res.Add(await dl.TryOpenCachedAsync(tr, FdbPath.Absolute("Tests", k.ToString(), i.ToString())));
 							}
 
 							return res;
@@ -1427,11 +1427,11 @@ namespace FoundationDB.Client.Tests
 
 				var dl = FdbDirectoryLayer.Create(location);
 
-				await logged.ReadWriteAsync(tr => dl.CreateAsync(tr, FdbPath.MakeAbsolute("Foo")), this.Cancellation);
+				await logged.ReadWriteAsync(tr => dl.CreateAsync(tr, FdbPath.Absolute("Foo")), this.Cancellation);
 
 				var fooCached = await logged.ReadAsync(async tr =>
 				{
-					var folder = await dl.TryOpenCachedAsync(tr, FdbPath.MakeAbsolute("Foo"));
+					var folder = await dl.TryOpenCachedAsync(tr, FdbPath.Absolute("Foo"));
 					Assert.That(folder.Context, Is.InstanceOf<FdbDirectoryLayer.State>());
 					return folder;
 				}, this.Cancellation);
@@ -1439,7 +1439,7 @@ namespace FoundationDB.Client.Tests
 				// the fooCached instance should dead outside the transaction!
 				Assert.That(() => fooCached.GetPrefix(), Throws.InstanceOf<InvalidOperationException>(), "Accessing a cached subspace outside the transaction should throw");
 
-				var fooUncached = await logged.ReadAsync(tr => dl.TryOpenAsync(tr, FdbPath.MakeAbsolute("Foo")), this.Cancellation);
+				var fooUncached = await logged.ReadAsync(tr => dl.TryOpenAsync(tr, FdbPath.Absolute("Foo")), this.Cancellation);
 				Assert.That(() => fooUncached.Context.EnsureIsValid(), Throws.Nothing, "Accessing a non-cached subspace outside the transaction should not throw");
 			}
 		}

--- a/FoundationDB.Tests/Layers/DirectoryFacts.cs
+++ b/FoundationDB.Tests/Layers/DirectoryFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2018, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/Layers/DirectoryFacts.cs
+++ b/FoundationDB.Tests/Layers/DirectoryFacts.cs
@@ -575,7 +575,7 @@ namespace FoundationDB.Client.Tests
 
 				await logged.WriteAsync(async tr =>
 				{
-					var folder = await directory.CreateAsync(tr, FdbPath.Root["Test[foo]"]);
+					var folder = await directory.CreateAsync(tr, FdbPath.Root["Test", "foo"]);
 #if DEBUG
 					await DumpSubspace(db, location);
 #endif
@@ -1380,7 +1380,7 @@ namespace FoundationDB.Client.Tests
 					await logged.WriteAsync(
 						async tr =>
 						{
-							for (int i = 0; i < N; i++) await dl.CreateAsync(tr, FdbPath.Absolute("Tests", k.ToString(), i.ToString()));
+							for (int i = 0; i < N; i++) await dl.CreateAsync(tr, FdbPath.Absolute("Students", k.ToString(), i.ToString()));
 						},
 						this.Cancellation);
 
@@ -1394,7 +1394,7 @@ namespace FoundationDB.Client.Tests
 							var res = new List<FdbDirectorySubspace>();
 							for (int i = 0; i < N; i++)
 							{
-								res.Add(await dl.TryOpenCachedAsync(tr, FdbPath.Absolute("Tests", k.ToString(), i.ToString())));
+								res.Add(await dl.TryOpenCachedAsync(tr, FdbPath.Absolute("Students", k.ToString(), i.ToString())));
 							}
 
 							return res;

--- a/FoundationDB.Tests/Layers/FdbDirectoryPathFacts.cs
+++ b/FoundationDB.Tests/Layers/FdbDirectoryPathFacts.cs
@@ -1,0 +1,285 @@
+﻿#region BSD License
+/* Copyright (c) 2013-2020, Doxense SAS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of Doxense nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#endregion
+
+namespace FoundationDB.Client.Tests
+{
+	using System;
+	using System.Linq;
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class FdbDirectoryPathFacts : FdbTest
+	{
+
+		[Test]
+		public void Test_FdbDirectoryPath_Empty()
+		{
+			var empty = FdbPath.Empty;
+			Assert.That(empty.IsAbsolute, Is.False);
+			Assert.That(empty.IsEmpty, Is.True);
+			Assert.That(empty.IsRoot, Is.False);
+			Assert.That(empty.Count, Is.EqualTo(0));
+			Assert.That(empty.ToString(), Is.EqualTo(string.Empty));
+			Assert.That(empty.Name, Is.EqualTo(string.Empty));
+			Assert.That(empty.Segments.Length, Is.EqualTo(0));
+			Assert.That(empty.ToArray(), Is.EqualTo(new string[0]));
+
+			Assert.That(empty, Is.EqualTo(FdbPath.Empty));
+			Assert.That(empty == FdbPath.Empty, Is.True);
+			Assert.That(empty != FdbPath.Empty, Is.False);
+			Assert.That(empty, Is.Not.EqualTo(FdbPath.Root));
+			Assert.That(empty == FdbPath.Root, Is.False);
+			Assert.That(empty != FdbPath.Root, Is.True);
+
+			Assert.That(FdbPath.Parse("Hello").StartsWith(empty), Is.True);
+			Assert.That(FdbPath.Parse("/Hello").StartsWith(empty), Is.False);
+
+		}
+
+		[Test]
+		public void Test_FdbDirectoryPath_Root()
+		{
+			var root = FdbPath.Root;
+			Assert.That(root.IsAbsolute, Is.True);
+			Assert.That(root.IsEmpty, Is.False);
+			Assert.That(root.IsRoot, Is.True);
+			Assert.That(root.Count, Is.EqualTo(0));
+			Assert.That(root.ToString(), Is.EqualTo("/"));
+			Assert.That(root.Name, Is.EqualTo(string.Empty));
+			Assert.That(root.Segments.Length, Is.EqualTo(0));
+			Assert.That(root.ToArray(), Is.EqualTo(new string[0]));
+
+			Assert.That(root, Is.EqualTo(FdbPath.Root));
+			Assert.That(root == FdbPath.Root, Is.True);
+			Assert.That(root != FdbPath.Root, Is.False);
+			Assert.That(root, Is.Not.EqualTo(FdbPath.Empty));
+			Assert.That(root == FdbPath.Empty, Is.False);
+			Assert.That(root != FdbPath.Empty, Is.True);
+
+			Assert.That(FdbPath.Parse("Hello").StartsWith(root), Is.False);
+			Assert.That(FdbPath.Parse("/Hello").StartsWith(root), Is.True);
+
+		}
+
+		[Test]
+		public void Test_FdbDirectoryPath_Simple_Relative()
+		{
+			var foo = FdbPath.MakeRelative("Foo");
+			Assert.That(foo.ToString(), Is.EqualTo("Foo"));
+			Assert.That(foo.IsAbsolute, Is.False);
+			Assert.That(foo.IsEmpty, Is.False);
+			Assert.That(foo.IsRoot, Is.False);
+			Assert.That(foo.Count, Is.EqualTo(1));
+			Assert.That(foo[0], Is.EqualTo("Foo"));
+			Assert.That(foo.Name, Is.EqualTo("Foo"));
+			Assert.That(foo.ToArray(), Is.EqualTo(new [] { "Foo" }));
+			Assert.That(foo.StartsWith(FdbPath.Empty), Is.True);
+			Assert.That(foo.IsChildOf(FdbPath.Empty), Is.True);
+			Assert.That(foo.EndsWith(FdbPath.Empty), Is.True);
+			Assert.That(foo.IsParentOf(FdbPath.Empty), Is.False);
+
+			var fooBar = foo["Bar"];
+			Assert.That(fooBar.ToString(), Is.EqualTo("Foo/Bar"));
+			Assert.That(fooBar.IsAbsolute, Is.False);
+			Assert.That(fooBar.IsEmpty, Is.False);
+			Assert.That(fooBar.IsRoot, Is.False);
+			Assert.That(fooBar.Count, Is.EqualTo(2));
+			Assert.That(fooBar[0], Is.EqualTo("Foo"));
+			Assert.That(fooBar[1], Is.EqualTo("Bar"));
+			Assert.That(fooBar.Name, Is.EqualTo("Bar"));
+			Assert.That(fooBar.ToArray(), Is.EqualTo(new [] { "Foo", "Bar" }));
+			Assert.That(fooBar.StartsWith(FdbPath.Empty), Is.True);
+			Assert.That(fooBar.IsChildOf(FdbPath.Empty), Is.True);
+			Assert.That(fooBar.IsParentOf(FdbPath.Empty), Is.False);
+			Assert.That(fooBar.EndsWith(FdbPath.Empty), Is.True);
+			Assert.That(fooBar.StartsWith(foo), Is.True);
+			Assert.That(fooBar.IsChildOf(foo), Is.True);
+			Assert.That(fooBar.EndsWith(foo), Is.False);
+			Assert.That(fooBar.IsParentOf(foo), Is.False);
+
+		}
+
+		[Test]
+		public void Test_FdbDirectoryPath_Simple_Absolute()
+		{
+			var foo = FdbPath.MakeAbsolute("Foo");
+			Assert.That(foo.ToString(), Is.EqualTo("/Foo"));
+			Assert.That(foo.IsAbsolute, Is.True);
+			Assert.That(foo.IsEmpty, Is.False);
+			Assert.That(foo.IsRoot, Is.False);
+			Assert.That(foo.Count, Is.EqualTo(1));
+			Assert.That(foo[0], Is.EqualTo("Foo"));
+			Assert.That(foo.Name, Is.EqualTo("Foo"));
+			Assert.That(foo.ToArray(), Is.EqualTo(new [] { "Foo" }));
+			Assert.That(foo.StartsWith(FdbPath.Root), Is.True);
+			Assert.That(foo.IsChildOf(FdbPath.Root), Is.True);
+			Assert.That(foo.EndsWith(FdbPath.Root), Is.False);
+			Assert.That(foo.IsParentOf(FdbPath.Root), Is.False);
+
+			var fooBar = foo["Bar"];
+			Assert.That(fooBar.ToString(), Is.EqualTo("/Foo/Bar"));
+			Assert.That(fooBar.IsAbsolute, Is.True);
+			Assert.That(fooBar.IsEmpty, Is.False);
+			Assert.That(fooBar.IsRoot, Is.False);
+			Assert.That(fooBar.Count, Is.EqualTo(2));
+			Assert.That(fooBar[0], Is.EqualTo("Foo"));
+			Assert.That(fooBar[1], Is.EqualTo("Bar"));
+			Assert.That(fooBar.Name, Is.EqualTo("Bar"));
+			Assert.That(fooBar.ToArray(), Is.EqualTo(new [] { "Foo", "Bar" }));
+			Assert.That(fooBar.StartsWith(FdbPath.Root), Is.True);
+			Assert.That(fooBar.IsChildOf(FdbPath.Root), Is.True);
+			Assert.That(fooBar.IsParentOf(FdbPath.Root), Is.False);
+			Assert.That(fooBar.EndsWith(FdbPath.Root), Is.False);
+			Assert.That(fooBar.StartsWith(foo), Is.True);
+			Assert.That(fooBar.IsChildOf(foo), Is.True);
+			Assert.That(fooBar.IsParentOf(foo), Is.False);
+			Assert.That(fooBar.EndsWith(foo), Is.False);
+		}
+
+		[Test]
+		public void Test_FdbDirectoryPath_Substring_Absolute()
+		{
+			var path = FdbPath.MakeAbsolute("Foo", "Bar", "Baz");
+
+			var slice = path.Substring(0, 2);
+			Assert.That(slice.IsAbsolute, Is.True);
+			Assert.That(slice[0], Is.EqualTo("Foo"));
+			Assert.That(slice[1], Is.EqualTo("Bar"));
+		}
+
+		[Test]
+		public void Test_FdbDirectoryPath_Parse()
+		{
+			// Relative paths
+
+			FdbPath Parse(string value)
+			{
+				Log($"\"{value}\":");
+				var path = FdbPath.Parse(value);
+				if (path.IsEmpty)
+					Log("> <empty>");
+				else if (path.IsRoot)
+					Log("> <root>");
+				else 
+					Log($"> Path='{path.ToString()}', Count={path.Count}, Name='{path.Name}', Absolute={path.IsAbsolute}");
+				return path;
+			}
+
+			{ // Empty
+				var path = Parse("");
+				Assert.That(path.IsAbsolute, Is.False, ".Absolute");
+				Assert.That(path.IsRoot, Is.False, ".IsRoot");
+				Assert.That(path.IsEmpty, Is.True, ".IsEmpty");
+				Assert.That(path.Count, Is.EqualTo(0), ".Count");
+				Assert.That(path.ToString(), Is.EqualTo(""));
+				Assert.That(path.Name, Is.EqualTo(string.Empty));
+			}
+			{ // Foo
+				var path = Parse("Foo");
+				Assert.That(path.IsAbsolute, Is.False, ".Absolute");
+				Assert.That(path.IsRoot, Is.False, ".IsRoot");
+				Assert.That(path.IsEmpty, Is.False, ".IsEmpty");
+				Assert.That(path.Count, Is.EqualTo(1), ".Count");
+				Assert.That(path[0], Is.EqualTo("Foo"));
+				Assert.That(path.ToString(), Is.EqualTo("Foo"));
+				Assert.That(path.Name, Is.EqualTo("Foo"));
+			}
+			{ // Foo/Bar/Baz
+				var path = Parse("Foo/Bar/Baz");
+				Assert.That(path.IsAbsolute, Is.False, ".Absolute");
+				Assert.That(path.IsRoot, Is.False, ".IsRoot");
+				Assert.That(path.IsEmpty, Is.False, ".IsEmpty");
+				Assert.That(path.Count, Is.EqualTo(3), ".Count");
+				Assert.That(path[0], Is.EqualTo("Foo"));
+				Assert.That(path[1], Is.EqualTo("Bar"));
+				Assert.That(path[2], Is.EqualTo("Baz"));
+				Assert.That(path.ToString(), Is.EqualTo("Foo/Bar/Baz"));
+				Assert.That(path.Name, Is.EqualTo("Baz"));
+			}
+
+			// Absolute path
+
+			{ // Root ("/")
+				var path = Parse("/");
+				Assert.That(path.IsAbsolute, Is.True, ".Absolute");
+				Assert.That(path.IsEmpty, Is.False, ".IsEmpty");
+				Assert.That(path.IsRoot, Is.True, ".IsRoot");
+				Assert.That(path.Count, Is.EqualTo(0));
+				Assert.That(path.ToString(), Is.EqualTo("/"));
+				Assert.That(path.Name, Is.EqualTo(string.Empty));
+			}
+			{ // /Foo
+				var path = Parse("/Foo");
+				Assert.That(path.IsAbsolute, Is.True, ".Absolute");
+				Assert.That(path.IsEmpty, Is.False, ".IsEmpty");
+				Assert.That(path.IsRoot, Is.False, ".IsRoot");
+				Assert.That(path.Count, Is.EqualTo(1));
+				Assert.That(path[0], Is.EqualTo("Foo"));
+				Assert.That(path.ToString(), Is.EqualTo("/Foo"));
+				Assert.That(path.Name, Is.EqualTo("Foo"));
+			}
+
+			{ // /Foo/Bar/Baz
+				var path = Parse("/Foo/Bar/Baz");
+				Assert.That(path.IsAbsolute, Is.True, ".Absolute");
+				Assert.That(path.IsEmpty, Is.False, ".IsEmpty");
+				Assert.That(path.IsRoot, Is.False, ".IsRoot");
+				Assert.That(path.Count, Is.EqualTo(3));
+				Assert.That(path[0], Is.EqualTo("Foo"));
+				Assert.That(path[1], Is.EqualTo("Bar"));
+				Assert.That(path[2], Is.EqualTo("Baz"));
+				Assert.That(path.ToString(), Is.EqualTo("/Foo/Bar/Baz"));
+				Assert.That(path.Name, Is.EqualTo("Baz"));
+			}
+			{ // /Foo\/Bar/Baz => { "Foo/Bar", "Baz" }
+				var path = Parse("/Foo\\/Bar/Baz");
+				Assert.That(path.IsAbsolute, Is.True, ".Absolute");
+				Assert.That(path.IsEmpty, Is.False, ".IsEmpty");
+				Assert.That(path.IsRoot, Is.False, ".IsRoot");
+				Assert.That(path.Count, Is.EqualTo(2));
+				Assert.That(path[0], Is.EqualTo("Foo/Bar"));
+				Assert.That(path[1], Is.EqualTo("Baz"));
+				Assert.That(path.ToString(), Is.EqualTo("/Foo\\/Bar/Baz"));
+				Assert.That(path.Name, Is.EqualTo("Baz"));
+			}
+			{ // /Foo[Bar]/Baz => { "Foo[Bar]", "Baz" }
+				var path = Parse("/Foo\\[Bar]/Baz");
+				Assert.That(path.IsAbsolute, Is.True, ".Absolute");
+				Assert.That(path.IsEmpty, Is.False, ".IsEmpty");
+				Assert.That(path.IsRoot, Is.False, ".IsRoot");
+				Assert.That(path.Count, Is.EqualTo(2));
+				Assert.That(path[0], Is.EqualTo("Foo[Bar]"));
+				Assert.That(path[1], Is.EqualTo("Baz"));
+				Assert.That(path.ToString(), Is.EqualTo("/Foo\\[Bar]/Baz"));
+				Assert.That(path.Name, Is.EqualTo("Baz"));
+			}
+
+		}
+
+	}
+}

--- a/FoundationDB.Tests/Layers/FdbPathFacts.cs
+++ b/FoundationDB.Tests/Layers/FdbPathFacts.cs
@@ -90,7 +90,7 @@ namespace FoundationDB.Client.Tests
 		public void Test_FdbPath_Basics()
 		{
 			{
-				var path = FdbPath.MakeRelative("Foo");
+				var path = FdbPath.Relative("Foo");
 				Assert.That(path.IsEmpty, Is.False, "[Foo].IsEmpty");
 				Assert.That(path.Count, Is.EqualTo(1), "[Foo].Count");
 				Assert.That(path.Name, Is.EqualTo("Foo"), "[Foo].Name");
@@ -107,8 +107,8 @@ namespace FoundationDB.Client.Tests
 				// ReSharper restore EqualExpressionComparison
 #pragma warning restore CS1718 // Comparison made to same variable
 
-				Assert.That(path, Is.EqualTo(FdbPath.MakeRelative("Foo")), "[Foo].Equals([Foo]')");
-				Assert.That(path, Is.EqualTo(FdbPath.MakeRelative("Foo", "Bar").GetParent()), "[Foo].Equals([Foo/Bar].GetParent())");
+				Assert.That(path, Is.EqualTo(FdbPath.Relative("Foo")), "[Foo].Equals([Foo]')");
+				Assert.That(path, Is.EqualTo(FdbPath.Relative("Foo", "Bar").GetParent()), "[Foo].Equals([Foo/Bar].GetParent())");
 
 				Assert.That(path, Is.Not.EqualTo(FdbPath.Empty), "[Foo].Equals(Empty)");
 				Assert.That(path == FdbPath.Empty, Is.False, "[Foo] == Empty");
@@ -116,7 +116,7 @@ namespace FoundationDB.Client.Tests
 			}
 
 			{
-				var path1 = FdbPath.MakeRelative("Foo", "Bar");
+				var path1 = FdbPath.Relative("Foo", "Bar");
 				var path2 = FdbPath.Parse("Foo/Bar");
 				var path3 = new FdbPath(new[] { FdbPathSegment.Create("Foo"), FdbPathSegment.Create("Bar") }, false);
 
@@ -133,7 +133,7 @@ namespace FoundationDB.Client.Tests
 		[Test]
 		public void Test_FdbPath_Simple_Relative()
 		{
-			var foo = FdbPath.MakeRelative("Foo");
+			var foo = FdbPath.Relative("Foo");
 			Assert.That(foo.ToString(), Is.EqualTo("Foo"));
 			Assert.That(foo.IsAbsolute, Is.False);
 			Assert.That(foo.IsEmpty, Is.False);

--- a/FoundationDB.Tests/Layers/FdbPathFacts.cs
+++ b/FoundationDB.Tests/Layers/FdbPathFacts.cs
@@ -174,7 +174,7 @@ namespace FoundationDB.Client.Tests
 		[Test]
 		public void Test_FdbPath_Simple_Absolute()
 		{
-			var foo = FdbPath.MakeAbsolute("Foo");
+			var foo = FdbPath.Absolute("Foo");
 			Assert.That(foo.ToString(), Is.EqualTo("/Foo"));
 			Assert.That(foo.IsAbsolute, Is.True);
 			Assert.That(foo.IsEmpty, Is.False);
@@ -214,7 +214,7 @@ namespace FoundationDB.Client.Tests
 		[Test]
 		public void Test_FdbPath_Substring_Absolute()
 		{
-			var path = FdbPath.MakeAbsolute("Foo", "Bar", "Baz");
+			var path = FdbPath.Absolute("Foo", "Bar", "Baz");
 
 			var slice = path.Substring(0, 2);
 			Assert.That(slice.IsAbsolute, Is.True);

--- a/FoundationDB.Tests/Layers/FdbPathFacts.cs
+++ b/FoundationDB.Tests/Layers/FdbPathFacts.cs
@@ -33,7 +33,7 @@ namespace FoundationDB.Client.Tests
 	using NUnit.Framework;
 
 	[TestFixture]
-	public class FdbDirectoryPathFacts : FdbTest
+	public class FdbPathFacts : FdbTest
 	{
 
 		[Test]
@@ -277,6 +277,15 @@ namespace FoundationDB.Client.Tests
 				Assert.That(path[1], Is.EqualTo("Baz"));
 				Assert.That(path.ToString(), Is.EqualTo("/Foo\\[Bar]/Baz"));
 				Assert.That(path.Name, Is.EqualTo("Baz"));
+			}
+
+			// invalid paths
+			{ 
+				// "/Foo//Baz" => empty segment
+				Assert.That(() => FdbPath.Parse("/Foo//Baz"), Throws.InstanceOf<FormatException>());
+
+				// "/Foo/Bar/" => last is empty
+				Assert.That(() => FdbPath.Parse("/Foo/Bar/"), Throws.InstanceOf<FormatException>());
 			}
 
 		}

--- a/FoundationDB.Tests/RangeQueryFacts.cs
+++ b/FoundationDB.Tests/RangeQueryFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2019, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
- 
+
 namespace FoundationDB.Client.Tests
 {
 	using System;

--- a/FoundationDB.Tests/RetryableFacts.cs
+++ b/FoundationDB.Tests/RetryableFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2019, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/SubspaceFacts.cs
+++ b/FoundationDB.Tests/SubspaceFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2019, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/TestHelpers.cs
+++ b/FoundationDB.Tests/TestHelpers.cs
@@ -61,7 +61,7 @@ namespace FoundationDB.Client.Tests
 			var options = new FdbConnectionOptions
 			{
 				ClusterFile = TestClusterFile,
-				Root = FdbPath.MakeAbsolute(FdbPathSegment.Partition("Tests"), FdbPathSegment.Create("Fdb"), FdbPathSegment.Partition(Environment.MachineName)),
+				Root = FdbPath.Absolute(FdbPathSegment.Partition("Tests"), FdbPathSegment.Create("Fdb"), FdbPathSegment.Partition(Environment.MachineName)),
 				DefaultTimeout = TimeSpan.FromMilliseconds(DefaultTimeout),
 			};
 			return Fdb.OpenAsync(options, ct);

--- a/FoundationDB.Tests/TestHelpers.cs
+++ b/FoundationDB.Tests/TestHelpers.cs
@@ -49,7 +49,7 @@ namespace FoundationDB.Client.Tests
 			var options = new FdbConnectionOptions
 			{
 				ClusterFile = TestClusterFile,
-				Root = FdbDirectoryPath.Empty, // core tests cannot rely on the DirectoryLayer!
+				Root = FdbPath.Root, // core tests cannot rely on the DirectoryLayer!
 				DefaultTimeout = TimeSpan.FromMilliseconds(DefaultTimeout),
 			};
 			return Fdb.OpenAsync(options, ct);
@@ -61,7 +61,7 @@ namespace FoundationDB.Client.Tests
 			var options = new FdbConnectionOptions
 			{
 				ClusterFile = TestClusterFile,
-				Root = FdbDirectoryPath.Combine("Tests", "Fdb", Environment.MachineName),
+				Root = FdbPath.MakeAbsolute("Tests", "Fdb", "Environment.MachineName"),
 				DefaultTimeout = TimeSpan.FromMilliseconds(DefaultTimeout),
 			};
 			return Fdb.OpenAsync(options, ct);

--- a/FoundationDB.Tests/TestHelpers.cs
+++ b/FoundationDB.Tests/TestHelpers.cs
@@ -61,7 +61,7 @@ namespace FoundationDB.Client.Tests
 			var options = new FdbConnectionOptions
 			{
 				ClusterFile = TestClusterFile,
-				Root = FdbPath.MakeAbsolute("Tests", "Fdb", "Environment.MachineName"),
+				Root = FdbPath.MakeAbsolute(FdbPathSegment.Partition("Tests"), FdbPathSegment.Create("Fdb"), FdbPathSegment.Partition(Environment.MachineName)),
 				DefaultTimeout = TimeSpan.FromMilliseconds(DefaultTimeout),
 			};
 			return Fdb.OpenAsync(options, ct);

--- a/FoundationDB.Tests/TransactionFacts.cs
+++ b/FoundationDB.Tests/TransactionFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2019, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/VersionStampFacts.cs
+++ b/FoundationDB.Tests/VersionStampFacts.cs
@@ -1,5 +1,5 @@
 ﻿#region BSD License
-/* Copyright (c) 2013-2019, Doxense SAS
+/* Copyright (c) 2013-2020, Doxense SAS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This pull request has several objectives, mainly to fix some long-standing issues and also little API annoyances.

These issues are explained in https://forums.foundationdb.org/t/most-common-issues-or-annoyances-when-using-the-directory-layer/2096

They are:
- Being able to distinguish between Absolute and Relative paths, so that the DL API can spot common mistakes and reject invalid paths.
  - the FdbDirectoryLayer implementation itself wants absolute paths.
  - the FdbDirectorySubspace "instance" methods want relative paths.
  - `FdbPath.Empty` is the empty _relative_ paths, mostly used to mean "no path"
  - `FdbPath.Root` is the "/" absolute path, which is now the default location for most locations.
  - When serialized to strings, absolute paths have a leading '/' literal, while relative paths do not
- Embed the layer id of directories right into the path itself, and not as an extra argument only for the leaf.
  - a path "segment" will thus be a pair of the name of the directory node, and an optional layer id.
    - ex: `"/Foo[partition]/ACME/Users[SomeLayer]"` represents the path to a directory "Users" handled by 'SomeLayer', which is nested under the "Foo" partition.
  - when recursively creating missing parents, the DL can now create them with the correct layer id (esp. for partitions!)
    - fix issue when creating in the above example, the "Foo" partition was deleted at some point, but another tool would want to `CreateAsync("/Foo/ACME/Users", "SomeLayer")` and end up with "Foo" being a regular directory and _not_ a partition. Then, subsequent attempts to open Foo as a partition would fail (because now its layer id is empty instead of `"partition"`).
  - since layers have to be represented as string, their base type has been changed from `Slice` to `string`, which are encoded as utf-8 byte strings in the database.
  - rules for escaping are that '\' is the escape literal, and any instance of `/`, `\`, `[` and `]` have to be escaped with a leading `\`.
- Reduce the risks of mixing "formatted" paths (like `"/Foo/Bar/Baz"`) and just the directory name (`"Foo"`) for APIs that take strings as argument.
  - Introduce the `FdbPathSegment` struct that represents a segment, and `FdbPath` is now a collection of these structs.
  - Have factory methods to create path segments from the (name, layer), or parse it from a "formatted string".

This PR also fixes a few issues and bugs in the DL that were found while refactoring:
- Some bugs when Moving or Renaming partitions: the prefix of a partition would be changed when renamed, with an extra `\xFE` byte appended to it.
- The root path ("/") would be considered a regular directory instead of a "partition", though this is only to be in synch with the rest, because a subspace or partition with the empty prefix are virtually the same thing.

Renaming `FdbDirectoryPath` to `FdbPath` is primary to reduce the length of the type, but also to force a code review of any use of that type in the application, to make sure that it is the correct type (absolute vs relative), and that it correctly includes any Layer Id.