### PR TITLE
Add TryGetAsync method to read value with IBufferWriter<byte>.

### DIFF
--- a/FoundationDB.Client/Core/IFdbTransactionHandler.cs
+++ b/FoundationDB.Client/Core/IFdbTransactionHandler.cs
@@ -77,7 +77,7 @@ namespace FoundationDB.Client.Core
 		/// <returns></returns>
 		Task<Slice> GetAsync(ReadOnlySpan<byte> key, bool snapshot, CancellationToken ct);
 
-		/// <summary>Try reas from database and write result to <paramref name="valueWriter"/></summary>
+		/// <summary>Try read from database and write result to <paramref name="valueWriter"/></summary>
 		/// <param name="key">Key to read</param>
 		/// <param name="valueWriter">Buffer writter for which the value is written, if it exists</param>
 		/// <param name="snapshot">Set to true for snapshot reads</param>

--- a/FoundationDB.Client/Core/IFdbTransactionHandler.cs
+++ b/FoundationDB.Client/Core/IFdbTransactionHandler.cs
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace FoundationDB.Client.Core
 {
 	using System;
+	using System.Buffers;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
@@ -75,6 +76,14 @@ namespace FoundationDB.Client.Core
 		/// <param name="ct"></param>
 		/// <returns></returns>
 		Task<Slice> GetAsync(ReadOnlySpan<byte> key, bool snapshot, CancellationToken ct);
+
+		/// <summary>Try reas from database and write result to <paramref name="valueWriter"/></summary>
+		/// <param name="key">Key to read</param>
+		/// <param name="valueWriter">Buffer writter for which the value is written, if it exists</param>
+		/// <param name="snapshot">Set to true for snapshot reads</param>
+		/// <param name="ct"></param>
+		/// <returns>Task with true if the key if it is found</returns>
+		Task<bool> TryGetAsync(ReadOnlySpan<byte> key, IBufferWriter<byte> valueWriter, bool snapshot, CancellationToken ct);
 
 		/// <summary>Reads several values from the database snapshot represented by the current transaction</summary>
 		/// <param name="keys">Keys to be looked up in the database</param>

--- a/FoundationDB.Client/FdbTransaction.Snapshot.cs
+++ b/FoundationDB.Client/FdbTransaction.Snapshot.cs
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace FoundationDB.Client
 {
 	using System;
+	using System.Buffers;
 	using System.Collections.Generic;
 	using System.Threading;
 	using System.Threading.Tasks;
@@ -107,6 +108,22 @@ namespace FoundationDB.Client
 #endif
 
 				return m_parent.PerformGetOperation(key, snapshot: true);
+			}
+
+			/// <inheritdoc />
+			public Task<bool> TryGetAsync(ReadOnlySpan<byte> key, IBufferWriter<byte > valueWriter)
+			{
+				Contract.NotNull(valueWriter);
+
+				EnsureCanRead();
+
+				FdbKey.EnsureKeyIsValid(key);
+
+#if DEBUG
+				if (Logging.On && Logging.IsVerbose) Logging.Verbose(this, "GetAsync", $"Getting value for '{key.ToString()}'");
+#endif
+
+				return m_parent.PerformGetOperation(key, valueWriter, snapshot: true);
 			}
 
 			public Task<Slice[]> GetValuesAsync(Slice[] keys)

--- a/FoundationDB.Client/FdbTransaction.cs
+++ b/FoundationDB.Client/FdbTransaction.cs
@@ -602,7 +602,7 @@ namespace FoundationDB.Client
 			FdbKey.EnsureKeyIsValid(key);
 
 #if DEBUG
-			if (Logging.On && Logging.IsVerbose) Logging.Verbose(this, "GetAsync", $"Getting value for '{key.ToString()}'");
+			if (Logging.On && Logging.IsVerbose) Logging.Verbose(this, "TryGetAsync", $"Getting value for '{key.ToString()}'");
 #endif
 
 			return PerformGetOperation(key, valueWriter, snapshot: false);
@@ -626,9 +626,9 @@ namespace FoundationDB.Client
 			return m_log == null ? m_handler.TryGetAsync(key, valueWriter, snapshot: snapshot, m_cancellation) : ExecuteLogged(this, key, snapshot, valueWriter);
 
 			static Task<bool> ExecuteLogged(FdbTransaction self, ReadOnlySpan<byte> key, bool snapshot, IBufferWriter<byte> valueWriter)
-				=> self.m_log!.ExecuteAsync<FdbTransactionLog.GetBoolCommand, bool>(
+				=> self.m_log!.ExecuteAsync<FdbTransactionLog.TryGetCommand, bool>(
 					self,
-					new FdbTransactionLog.GetBoolCommand(self.m_log.Grab(key)) { Snapshot = snapshot },
+					new FdbTransactionLog.TryGetCommand(self.m_log.Grab(key)) { Snapshot = snapshot },
 					(tr, cmd) => tr.m_handler.TryGetAsync(cmd.Key.Span, valueWriter, cmd.Snapshot,  tr.m_cancellation)
 				);
 		}

--- a/FoundationDB.Client/FdbTransaction.cs
+++ b/FoundationDB.Client/FdbTransaction.cs
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace FoundationDB.Client
 {
 	using System;
+	using System.Buffers;
 	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Diagnostics.CodeAnalysis;
@@ -592,6 +593,22 @@ namespace FoundationDB.Client
 			return PerformGetOperation(key, snapshot: false);
 		}
 
+		public Task<bool> TryGetAsync(ReadOnlySpan<byte> key, IBufferWriter<byte> valueWriter)
+		{
+			Contract.NotNull(valueWriter);
+
+			EnsureCanRead();
+
+			FdbKey.EnsureKeyIsValid(key);
+
+#if DEBUG
+			if (Logging.On && Logging.IsVerbose) Logging.Verbose(this, "GetAsync", $"Getting value for '{key.ToString()}'");
+#endif
+
+			return PerformGetOperation(key, valueWriter, snapshot: false);
+		}
+
+
 		private Task<Slice> PerformGetOperation(ReadOnlySpan<byte> key, bool snapshot)
 		{
 			return m_log == null ? m_handler.GetAsync(key, snapshot: snapshot, m_cancellation) : ExecuteLogged(this, key, snapshot);
@@ -601,6 +618,18 @@ namespace FoundationDB.Client
 					self,
 					new FdbTransactionLog.GetCommand(self.m_log.Grab(key)) { Snapshot =  snapshot },
 					(tr, cmd) => tr.m_handler.GetAsync(cmd.Key.Span, cmd.Snapshot, tr.m_cancellation)
+				);
+		}
+
+		private Task<bool> PerformGetOperation(ReadOnlySpan<byte> key, IBufferWriter<byte> valueWriter,  bool snapshot)
+		{
+			return m_log == null ? m_handler.TryGetAsync(key, valueWriter, snapshot: snapshot, m_cancellation) : ExecuteLogged(this, key, snapshot, valueWriter);
+
+			static Task<bool> ExecuteLogged(FdbTransaction self, ReadOnlySpan<byte> key, bool snapshot, IBufferWriter<byte> valueWriter)
+				=> self.m_log!.ExecuteAsync<FdbTransactionLog.GetBoolCommand, bool>(
+					self,
+					new FdbTransactionLog.GetBoolCommand(self.m_log.Grab(key)) { Snapshot = snapshot },
+					(tr, cmd) => tr.m_handler.TryGetAsync(cmd.Key.Span, valueWriter, cmd.Snapshot,  tr.m_cancellation)
 				);
 		}
 

--- a/FoundationDB.Client/IFdbReadOnlyTransaction.cs
+++ b/FoundationDB.Client/IFdbReadOnlyTransaction.cs
@@ -34,6 +34,7 @@ namespace FoundationDB.Client
 	using System.Threading;
 	using System.Threading.Tasks;
 	using FoundationDB.Filters.Logging;
+	using System.Buffers;
 
 	/// <summary>Transaction that allows read operations</summary>
 	[PublicAPI]
@@ -71,6 +72,12 @@ namespace FoundationDB.Client
 		/// <exception cref="System.ObjectDisposedException">If the transaction has already been completed</exception>
 		/// <exception cref="System.InvalidOperationException">If the operation method is called from the Network Thread</exception>
 		Task<Slice> GetAsync(ReadOnlySpan<byte> key);
+
+		/// <summary>Try reas from database snapshot represented by by the current transaction and write result to <paramref name="valueWriter"/>. </summary>
+		/// <param name="key">Key to be looked up in the database</param>
+		/// <param name="bufferWriter">Buffer writter for which the value is written, if it exists</param>
+		/// <returns>Task with true if the key if it is found</returns>
+		Task<bool> TryGetAsync(ReadOnlySpan<byte> key, IBufferWriter<byte> valueWriter);
 
 		/// <summary>Reads several values from the database snapshot represented by the current transaction</summary>
 		/// <param name="keys">Keys to be looked up in the database</param>

--- a/FoundationDB.Client/IFdbReadOnlyTransaction.cs
+++ b/FoundationDB.Client/IFdbReadOnlyTransaction.cs
@@ -73,7 +73,7 @@ namespace FoundationDB.Client
 		/// <exception cref="System.InvalidOperationException">If the operation method is called from the Network Thread</exception>
 		Task<Slice> GetAsync(ReadOnlySpan<byte> key);
 
-		/// <summary>Try reas from database snapshot represented by by the current transaction and write result to <paramref name="valueWriter"/>. </summary>
+		/// <summary>Try reads from database snapshot represented by by the current transaction and write result to <paramref name="valueWriter"/>. </summary>
 		/// <param name="key">Key to be looked up in the database</param>
 		/// <param name="bufferWriter">Buffer writter for which the value is written, if it exists</param>
 		/// <returns>Task with true if the key if it is found</returns>

--- a/FoundationDB.Client/Tracing/FdbTransactionLog.Commands.cs
+++ b/FoundationDB.Client/Tracing/FdbTransactionLog.Commands.cs
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace FoundationDB.Filters.Logging
 {
 	using System;
+	using System.Buffers;
 	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Globalization;
@@ -668,6 +669,42 @@ namespace FoundationDB.Filters.Logging
 				return value.ToString("P");
 			}
 
+		}
+
+		public sealed class GetBoolCommand : Command<bool>
+		{
+			/// <summary>Key read from the database</summary>
+			public Slice Key { get; }
+
+			public override Operation Op => Operation.Get;
+
+			public GetBoolCommand(Slice key)
+			{
+				this.Key = key;
+			}
+
+			public override int? ArgumentBytes => this.Key.Count;
+
+			public override int? ResultBytes => default;
+
+			public override string GetArguments(KeyResolver resolver)
+			{
+				return resolver.Resolve(this.Key);
+			}
+
+			public override string GetResult(KeyResolver resolver)
+			{
+				if (this.Result.HasValue)
+				{
+						return this.Result.Value.ToString();
+				}
+				return base.GetResult(resolver);
+			}
+
+			protected override string Dump(bool value)
+			{
+				return value.ToString();
+			}
 		}
 
 		public sealed class GetKeyCommand : Command<Slice>

--- a/FoundationDB.Client/Tracing/FdbTransactionLog.Commands.cs
+++ b/FoundationDB.Client/Tracing/FdbTransactionLog.Commands.cs
@@ -671,14 +671,14 @@ namespace FoundationDB.Filters.Logging
 
 		}
 
-		public sealed class GetBoolCommand : Command<bool>
+		public sealed class TryGetCommand : Command<bool>
 		{
 			/// <summary>Key read from the database</summary>
 			public Slice Key { get; }
 
 			public override Operation Op => Operation.Get;
 
-			public GetBoolCommand(Slice key)
+			public TryGetCommand(Slice key)
 			{
 				this.Key = key;
 			}


### PR DESCRIPTION
Add method `Task<bool> TryGetAsync(ReadOnlySpan<byte> key, IBufferWriter<byte> valueWriter)` into `IFdbReadOnlyTransaction`  for read value without allocation intenal byte array for `Slice`. How the value buffer is allocated is left to the API consumer.

The method uses standard `TryGet...` logic and returns `true` if the key exists, `false` otherwise.
