### PR TITLE
Upgrade NUnit to 4.0.1

### DIFF
--- a/Doxense.Core.Testing.Common/AsyncAssert.cs
+++ b/Doxense.Core.Testing.Common/AsyncAssert.cs
@@ -24,6 +24,8 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
+#if DEPRECATED // scream-test to check if people still using it can easily rewrite to a more modern version
+
 namespace Doxense
 {
 	using Doxense.Tools;
@@ -165,3 +167,5 @@ namespace Doxense
 	}
 
 }
+
+#endif

--- a/Doxense.Core.Testing.Common/CatchExceptionConstraint.cs
+++ b/Doxense.Core.Testing.Common/CatchExceptionConstraint.cs
@@ -46,7 +46,7 @@ namespace Doxense
 
 			public TException Exception => (this.CapturedException ?? throw new AssertionException("No exception was captured!")) as TException ?? throw new AssertionException($"Captured exception was of type {this.CapturedException.GetType().GetFriendlyName()} instead of expected type {typeof(TException).GetFriendlyName()}");
 
-			internal void Capture(Exception e) => this.CapturedException = e;
+			internal void Capture(Exception? e) => this.CapturedException = e;
 
 			public override string ToString()
 			{
@@ -86,13 +86,15 @@ namespace Doxense
 			this.Ball = ball;
 		}
 
+		public override string Description => $"Catch<{typeof(TException).GetFriendlyName()}>";
+
 		public override ConstraintResult ApplyTo<TActual>(TActual actual)
 		{
 			if (typeof(TActual) != typeof(Exception))
 			{
-				throw new InvalidOperationException($"Unexpected type {typeof(TActual).GetFriendlyName()} while expecting Exception result");
+				throw new InvalidOperationException($"Unexpected type {typeof(TActual).GetFriendlyName()} while expecting {typeof(TException).GetFriendlyName()} exception.");
 			}
-			this.Ball.Capture((Exception) (object) actual);
+			this.Ball.Capture((Exception?) (object?) actual);
 			// success!
 			return new ConstraintResult(this, this.Ball.Exception, true);
 		}

--- a/Doxense.Core.Testing.Common/Doxense.Core.Testing.Common.csproj
+++ b/Doxense.Core.Testing.Common/Doxense.Core.Testing.Common.csproj
@@ -20,7 +20,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
 		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 		<PackageReference Include="NodaTime.Testing" Version="3.1.9" />
-		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit" Version="4.0.1" />
 		<PackageReference Include="NUnit.Console" Version="3.16.3" />
 		<PackageReference Include="NUnit.ConsoleRunner" Version="3.16.3" />
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/Doxense.Core.Testing.Common/DoxenseTest.cs
+++ b/Doxense.Core.Testing.Common/DoxenseTest.cs
@@ -606,7 +606,7 @@ namespace Doxense.Testing
 
 					if (!task.IsCompleted)
 					{
-						Assert.Fail("Task did not complete in time ({0})", task.Status);
+						Assert.Fail($"Task did not complete in time ({task.Status})");
 					}
 				}
 
@@ -1341,6 +1341,8 @@ namespace Doxense.Testing
 
 		#region Simple Test Runners...
 
+#if DEPRECATED // would need to be rewritten for NUnit 4. Do we still use this??
+
 		// code permettant d'exécuter un test NUnit directement depuis un void Main(), sans devoir passer par un Test Runner externe
 
 		private static void WriteToConsole(TextWriter writer, string msg, ConsoleColor? color = null)
@@ -1534,6 +1536,8 @@ namespace Doxense.Testing
 			public void SendMessage(TestMessage message)
 			{ }
 		}
+
+#endif
 
 		#endregion
 

--- a/Doxense.Core.Testing.Common/TaskAssert.cs
+++ b/Doxense.Core.Testing.Common/TaskAssert.cs
@@ -24,9 +24,10 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
+#if DEPRECATED // scream-test to check if people still using it can easily rewrite to a more modern version
+
 namespace Doxense
 {
-	using Doxense.Threading.Tasks;
 	using NUnit.Framework;
 	using NUnit.Framework.Constraints;
 	using System;
@@ -105,3 +106,5 @@ namespace Doxense
 	}
 
 }
+
+#endif

--- a/Doxense.Core.Tests/Collections/Tuples/TuPackFacts.cs
+++ b/Doxense.Core.Tests/Collections/Tuples/TuPackFacts.cs
@@ -1011,7 +1011,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(key.ToHexaString(' '), Is.EqualTo(expected));
 				var t2 = TuPack.Unpack(key);
 				Assert.That(t2, Is.Not.Null);
-				Assert.That(t2.Count, Is.EqualTo(t.Count), "{0}", t2);
+				Assert.That(t2.Count, Is.EqualTo(t.Count), $"{t2}.Count");
 				Assert.That(t2, Is.EqualTo(t));
 			}
 
@@ -1717,7 +1717,7 @@ namespace Doxense.Collections.Tuples.Tests
 		{
 			Slice slice;
 
-			slice = TuPack.EncodeKey<object>(default(object));
+			slice = TuPack.EncodeKey<object?>(default);
 			Assert.That(slice.ToString(), Is.EqualTo("<00>"));
 
 			slice = TuPack.EncodeKey<object>(1);
@@ -2053,7 +2053,7 @@ namespace Doxense.Collections.Tuples.Tests
 
 			#region PackRange(Slice, ...)
 
-			string[] words = {"hello", "world", "très bien", "断トツ", "abc\0def", null, String.Empty};
+			string?[] words = {"hello", "world", "très bien", "断トツ", "abc\0def", null, string.Empty};
 
 			var merged = TuPack.EncodePrefixedKeys(Slice.FromByte(42), words);
 			Assert.That(merged, Is.Not.Null);
@@ -2071,10 +2071,10 @@ namespace Doxense.Collections.Tuples.Tests
 			// corner cases
 			// ReSharper disable AssignNullToNotNullAttribute
 			Assert.That(
-				() => TuPack.EncodePrefixedKeys<int>(Slice.Empty, default(int[])),
+				() => TuPack.EncodePrefixedKeys<int>(Slice.Empty, default(int[])!),
 				Throws.InstanceOf<ArgumentNullException>().With.Property("ParamName").EqualTo("keys"));
 			Assert.That(
-				() => TuPack.EncodePrefixedKeys<int>(Slice.Empty, default(IEnumerable<int>)),
+				() => TuPack.EncodePrefixedKeys<int>(Slice.Empty, default(IEnumerable<int>)!),
 				Throws.InstanceOf<ArgumentNullException>().With.Property("ParamName").EqualTo("keys"));
 			// ReSharper restore AssignNullToNotNullAttribute
 

--- a/Doxense.Core.Tests/Collections/Tuples/TupleFacts.cs
+++ b/Doxense.Core.Tests/Collections/Tuples/TupleFacts.cs
@@ -559,7 +559,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(item8, Is.EqualTo(Math.PI));
 			}
 
-			Assert.That(tn.Concat(STuple.Create("foo", "bar")), Is.EqualTo(STuple.Create(new object[] { "hello world", 123, false, 1234L, -1234, "six", true, Math.PI, "foo", "bar" })));
+			Assert.That(tn.Concat(STuple.Create("foo", "bar")), Is.EqualTo(STuple.Create(new object?[] { "hello world", 123, false, 1234L, -1234, "six", true, Math.PI, "foo", "bar" })));
 		}
 
 		[Test]
@@ -842,8 +842,8 @@ namespace Doxense.Collections.Tuples.Tests
 			Assert.That(tn.Last<int>(), Is.EqualTo(6));
 			Assert.That(tn.Last<string>(), Is.EqualTo("6"));
 
-			Assert.That(() => ((IVarTuple) STuple.Empty).First<string>(), Throws.InstanceOf<InvalidOperationException>());
-			Assert.That(() => ((IVarTuple) STuple.Empty).Last<string>(), Throws.InstanceOf<InvalidOperationException>());
+			Assert.That(() => STuple.Empty.First<string>(), Throws.InstanceOf<InvalidOperationException>());
+			Assert.That(() => STuple.Empty.Last<string>(), Throws.InstanceOf<InvalidOperationException>());
 		}
 
 		[Test]
@@ -851,7 +851,7 @@ namespace Doxense.Collections.Tuples.Tests
 		{
 			IVarTuple tuple;
 
-			tuple = STuple.CreateBoxed(default(object));
+			tuple = STuple.CreateBoxed(default);
 			Assert.That(tuple.Count, Is.EqualTo(1));
 			Assert.That(tuple[0], Is.Null);
 
@@ -881,8 +881,8 @@ namespace Doxense.Collections.Tuples.Tests
 		{
 			// (A,B).Append((C,D)) should return (A,B,(C,D)) (length 3) and not (A,B,C,D) (length 4)
 
-			STuple<string, string> x = STuple.Create("A", "B");
-			STuple<string, string> y = STuple.Create("C", "D");
+			var x = STuple.Create("A", "B");
+			var y = STuple.Create("C", "D");
 
 			// using the instance method that returns a STuple<T1, T2, T3>
 			IVarTuple z = x.Append(y);
@@ -943,7 +943,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(a, Is.EqualTo(123));
 				return 42;
 			}), Is.EqualTo(42));
-			Assert.That(() => t.With((int a) => throw new InvalidOperationException("BOOM")), Throws.InvalidOperationException.With.Message.EqualTo("BOOM"));
+			Assert.That(() => t.With((int _) => throw new InvalidOperationException("BOOM")), Throws.InvalidOperationException.With.Message.EqualTo("BOOM"));
 
 			// Size 2
 
@@ -1325,7 +1325,7 @@ namespace Doxense.Collections.Tuples.Tests
 			var b1 = (Tuple<string>) t1; // explicit
 			Assert.That(b1, Is.Not.Null);
 			Assert.That(b1.Item1, Is.EqualTo("Hello"));
-			STuple<string> r1 = t1; // implicit
+			ValueTuple<string> r1 = t1; // implicit
 			Assert.That(r1.Item1, Is.EqualTo("Hello"));
 
 			var t2 = STuple.Create("Hello", 123);
@@ -1333,7 +1333,7 @@ namespace Doxense.Collections.Tuples.Tests
 			Assert.That(b2, Is.Not.Null);
 			Assert.That(b2.Item1, Is.EqualTo("Hello"));
 			Assert.That(b2.Item2, Is.EqualTo(123));
-			STuple<string, int> r2 = t2; // implicit
+			ValueTuple<string, int> r2 = t2; // implicit
 			Assert.That(r2.Item1, Is.EqualTo("Hello"));
 			Assert.That(r2.Item2, Is.EqualTo(123));
 
@@ -1343,7 +1343,7 @@ namespace Doxense.Collections.Tuples.Tests
 			Assert.That(b3.Item1, Is.EqualTo("Hello"));
 			Assert.That(b3.Item2, Is.EqualTo(123));
 			Assert.That(b3.Item3, Is.False);
-			STuple<string, int, bool> r3 = t3; // implicit
+			ValueTuple<string, int, bool> r3 = t3; // implicit
 			Assert.That(r3.Item1, Is.EqualTo("Hello"));
 			Assert.That(r3.Item2, Is.EqualTo(123));
 			Assert.That(r3.Item3, Is.False);
@@ -1355,21 +1355,21 @@ namespace Doxense.Collections.Tuples.Tests
 			Assert.That(b4.Item2, Is.EqualTo(123));
 			Assert.That(b4.Item3, Is.False);
 			Assert.That(b4.Item4, Is.EqualTo(TimeSpan.FromSeconds(5)));
-			STuple<string, int, bool, TimeSpan> r4 = t4; // implicit
+			ValueTuple<string, int, bool, TimeSpan> r4 = t4; // implicit
 			Assert.That(r4.Item1, Is.EqualTo("Hello"));
 			Assert.That(r4.Item2, Is.EqualTo(123));
 			Assert.That(r4.Item3, Is.False);
 			Assert.That(r4.Item4, Is.EqualTo(TimeSpan.FromSeconds(5)));
 
 			var t5 = STuple.Create("Hello", 123, false, TimeSpan.FromSeconds(5), "World");
-			var b5 = (Tuple<string, int, bool, TimeSpan, string>)t5;	// explicit
+			var b5 = (Tuple<string?, int, bool, TimeSpan, string?>) t5;	// explicit
 			Assert.That(b5, Is.Not.Null);
 			Assert.That(b5.Item1, Is.EqualTo("Hello"));
 			Assert.That(b5.Item2, Is.EqualTo(123));
 			Assert.That(b5.Item3, Is.False);
 			Assert.That(b5.Item4, Is.EqualTo(TimeSpan.FromSeconds(5)));
 			Assert.That(b5.Item5, Is.EqualTo("World"));
-			STuple<string, int, bool, TimeSpan, string> r5 = t5; // implicit
+			ValueTuple<string, int, bool, TimeSpan, string> r5 = t5; // implicit
 			Assert.That(r5.Item1, Is.EqualTo("Hello"));
 			Assert.That(r5.Item2, Is.EqualTo(123));
 			Assert.That(r5.Item3, Is.False);
@@ -1412,31 +1412,31 @@ namespace Doxense.Collections.Tuples.Tests
 #if DEBUG
 				if (System.Diagnostics.Debugger.IsAttached) System.Diagnostics.Debugger.Break();
 #endif
-				Assert.Fail("{0}: Count mismatch between observed {1} and expected {2} for tuple of type {3}", message, t, STuple.Formatter.ToString(expected.AsSpan()), t.GetType().Name);
+				Assert.Fail($"{message}: Count mismatch between observed {t} and expected {STuple.Formatter.ToString(expected.AsSpan())} for tuple of type {t.GetType().Name}");
 			}
 
 			// direct access
 			for (int i = 0; i < expected.Length; i++)
 			{
-				Assert.That(ComparisonHelper.AreSimilar(t[i], expected[i]), Is.True, "{0}: t[{1}] != expected[{1}]", message, i);
+				Assert.That(ComparisonHelper.AreSimilar(t[i], expected[i]), Is.True, $"{message}: t[{i}] != expected[{i}]");
 			}
 
 			// iterator
 			int p = 0;
 			foreach (var obj in t)
 			{
-				if (p >= expected.Length) Assert.Fail("Spliced iterator overshoot at t[{0}] = {1}", p, obj);
-				Assert.That(ComparisonHelper.AreSimilar(obj, expected[p]), Is.True, "{0}: Iterator[{1}], {2} ~= {3}", message, p, obj, expected[p]);
+				if (p >= expected.Length) Assert.Fail($"Spliced iterator overshoot at t[{p}] = {obj}");
+				Assert.That(ComparisonHelper.AreSimilar(obj, expected[p]), Is.True, $"{message}: Iterator[{p}], {obj} ~= {expected[p]}");
 				++p;
 			}
-			Assert.That(p, Is.EqualTo(expected.Length), "{0}: t.GetEnumerator() returned only {1} elements out of {2} expected", message, p, expected.Length);
+			Assert.That(p, Is.EqualTo(expected.Length), $"{message}: t.GetEnumerator() returned only {p} elements out of {expected.Length} expected");
 
 			// CopyTo
-			var tmp = new object[expected.Length];
+			var tmp = new object?[expected.Length];
 			t.CopyTo(tmp, 0);
 			for (int i = 0; i < tmp.Length; i++)
 			{
-				Assert.That(ComparisonHelper.AreSimilar(tmp[i], expected[i]), Is.True, "{0}: CopyTo[{1}], {2} ~= {3}", message, i, tmp[i], expected[i]);
+				Assert.That(ComparisonHelper.AreSimilar(tmp[i], expected[i]), Is.True, $"{message}: CopyTo[{i}], {tmp[i]} ~= {expected[i]}");
 			}
 
 			// Memoize
@@ -1454,7 +1454,7 @@ namespace Doxense.Collections.Tuples.Tests
 				tmp = u.ToArray();
 				for (int i = 0; i < tmp.Length - 1; i++)
 				{
-					Assert.That(ComparisonHelper.AreSimilar(tmp[i], expected[i]), Is.True, "{0}: Appended[{1}], {2} ~= {3}", message, i, tmp[i], expected[i]);
+					Assert.That(ComparisonHelper.AreSimilar(tmp[i], expected[i]), Is.True, $"{message}: Appended[{i}], {tmp[i]} ~= {expected[i]}");
 				}
 			}
 		}
@@ -1527,7 +1527,7 @@ namespace Doxense.Collections.Tuples.Tests
 
 		private static object[] GetRange(int fromIncluded, int toExcluded, int count)
 		{
-			if (count == 0) return new object[0];
+			if (count == 0) return Array.Empty<object>();
 
 			if (fromIncluded < 0) fromIncluded += count;
 			if (toExcluded < 0) toExcluded += count;
@@ -1581,10 +1581,10 @@ namespace Doxense.Collections.Tuples.Tests
 				var tuple = tuples[len];
 				if (tuple.Count != len)
 				{
-					Assert.That(tuple.Count, Is.EqualTo(len), "Invalid length for tuple {0}", tuple);
+					Assert.That(tuple.Count, Is.EqualTo(len), $"Invalid length for tuple {tuple}");
 				}
 
-				string prefix = tuple.ToString();
+				var prefix = tuple.ToString();
 
 				//if (rnd.Next(5) == 0)
 				//{ // randomly pack/unpack
@@ -1602,25 +1602,25 @@ namespace Doxense.Collections.Tuples.Tests
 					case 0:
 					{ // [:+rnd]
 						int x = rnd.Next(len);
-						VerifyTuple(prefix + "[:" + x.ToString() + "]", tuple[null, x], GetRange(0, x, len));
+						VerifyTuple($"{prefix}[:{x}]", tuple[null, x], GetRange(0, x, len));
 						break;
 					}
 					case 1:
 					{ // [+rnd:]
 						int x = rnd.Next(len);
-						VerifyTuple(prefix + "[" + x.ToString() + ":]", tuple[x, null], GetRange(x, int.MaxValue, len));
+						VerifyTuple($"{prefix}[{x}:]", tuple[x, null], GetRange(x, int.MaxValue, len));
 						break;
 					}
 					case 2:
 					{ // [:-rnd]
 						int x = -1 - rnd.Next(len);
-						VerifyTuple(prefix + "[:" + x.ToString() + "]", tuple[null, x], GetRange(0, len + x, len));
+						VerifyTuple($"{prefix}[:{x}]", tuple[null, x], GetRange(0, len + x, len));
 						break;
 					}
 					case 3:
 					{ // [-rnd:]
 						int x = -1 - rnd.Next(len);
-						VerifyTuple(prefix + "[" + x.ToString() + ":]", tuple[x, null], GetRange(len + x, int.MaxValue, len));
+						VerifyTuple($"{prefix}[{x}:]", tuple[x, null], GetRange(len + x, int.MaxValue, len));
 						break;
 					}
 					case 4:
@@ -1628,7 +1628,7 @@ namespace Doxense.Collections.Tuples.Tests
 						int x = rnd.Next(len);
 						int y;
 						do { y = rnd.Next(len); } while (y < x);
-						VerifyTuple(prefix + " [" + x.ToString() + ":" + y.ToString() + "]", tuple[x, y], GetRange(x, y, len));
+						VerifyTuple($"{prefix} [{x}:{y}]", tuple[x, y], GetRange(x, y, len));
 						break;
 					}
 					case 5:
@@ -1636,7 +1636,7 @@ namespace Doxense.Collections.Tuples.Tests
 						int x = -1 - rnd.Next(len);
 						int y;
 						do { y = -1 - rnd.Next(len); } while (y < x);
-						VerifyTuple(prefix + " [" + x.ToString() + ":" + y.ToString() + "]", tuple[x, y], GetRange(len + x, len + y, len));
+						VerifyTuple($"{prefix} [{x}:{y}]", tuple[x, y], GetRange(len + x, len + y, len));
 						break;
 					}
 				}
@@ -1760,13 +1760,13 @@ namespace Doxense.Collections.Tuples.Tests
 			// ReSharper restore PossibleUnintendedReferenceComparison
 
 			// It should work on STuple<..> though (but with a compiler warning)
-			STuple<string> aa = STuple.Create<string>("A");
-			STuple<string> bb = STuple.Create<string>("A");
+			var aa = STuple.Create<string>("A");
+			var bb = STuple.Create<string>("A");
 			// ReSharper disable CannotApplyEqualityOperatorToType
 			Assert.That(aa == bb, Is.True, "Operator '==' should work on struct tuples.");
 			// ReSharper restore CannotApplyEqualityOperatorToType
 			Assert.That(aa.Equals(bb), Is.True, "Equals(..) should work on struct tuples.");
-			STuple<string> cc = STuple.Create<string>(new string('A', 1)); // make sure we have an "A" string that is not the same pointers as the others
+			var cc = STuple.Create<string>(new string('A', 1)); // make sure we have an "A" string that is not the same pointers as the others
 			Assert.That(aa.Item1, Is.Not.SameAs(cc.Item1), "Did your compiler optimize the new string('A', 1). If so, need to find another way");
 			Assert.That(aa.Equals(cc), Is.True, "Equals(..) should compare the values, not the pointers.");
 
@@ -1875,7 +1875,7 @@ namespace Doxense.Collections.Tuples.Tests
 		public void Test_Can_Deformat_Simple_Tuples()
 		{
 
-			void Check<TTuple>(string expr, TTuple expected) where TTuple : IVarTuple
+			static void Check<TTuple>(string expr, TTuple expected) where TTuple : IVarTuple
 			{
 				Log("> " + expr);
 				var actual = STuple.Deformatter.Parse(expr);
@@ -2195,25 +2195,25 @@ namespace Doxense.Collections.Tuples.Tests
 		public void Test_Deconstruct_STuple_TupleSyntax()
 		{
 			{
-				(var a, var b) = STuple.Create(11, 22);
+				var (a, b) = STuple.Create(11, 22);
 				Assert.That(a, Is.EqualTo(11));
 				Assert.That(b, Is.EqualTo(22));
 			}
 			{
-				(var a, var b, var c) = STuple.Create(11, 22, 33);
+				var (a, b, c) = STuple.Create(11, 22, 33);
 				Assert.That(a, Is.EqualTo(11));
 				Assert.That(b, Is.EqualTo(22));
 				Assert.That(c, Is.EqualTo(33));
 			}
 			{
-				(var a, var b, var c, var d) = STuple.Create(11, 22, 33, 44);
+				var (a, b, c, d) = STuple.Create(11, 22, 33, 44);
 				Assert.That(a, Is.EqualTo(11));
 				Assert.That(b, Is.EqualTo(22));
 				Assert.That(c, Is.EqualTo(33));
 				Assert.That(d, Is.EqualTo(44));
 			}
 			{
-				(var a, var b, var c, var d, var e) = STuple.Create(11, 22, 33, 44, 55);
+				var (a, b, c, d, e) = STuple.Create(11, 22, 33, 44, 55);
 				Assert.That(a, Is.EqualTo(11));
 				Assert.That(b, Is.EqualTo(22));
 				Assert.That(c, Is.EqualTo(33));
@@ -2221,7 +2221,7 @@ namespace Doxense.Collections.Tuples.Tests
 				Assert.That(e, Is.EqualTo(55));
 			}
 			{
-				(var a, var b, var c, var d, var e, var f) = STuple.Create(11, 22, 33, 44, 55, 66);
+				var (a, b, c, d, e, f) = STuple.Create(11, 22, 33, 44, 55, 66);
 				Assert.That(a, Is.EqualTo(11));
 				Assert.That(b, Is.EqualTo(22));
 				Assert.That(c, Is.EqualTo(33));
@@ -2234,4 +2234,5 @@ namespace Doxense.Collections.Tuples.Tests
 		#endregion
 
 	}
+
 }

--- a/Doxense.Core.Tests/Doxense.Core.Tests.csproj
+++ b/Doxense.Core.Tests/Doxense.Core.Tests.csproj
@@ -20,7 +20,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
 		<PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.9.0-preview-23577-04" />
 		<PackageReference Include="NodaTime.Testing" Version="3.1.9" />
-		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit" Version="4.0.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Doxense.Core.Tests/IO/Hashing/CRCTest.cs
+++ b/Doxense.Core.Tests/IO/Hashing/CRCTest.cs
@@ -113,13 +113,13 @@ namespace Doxense.Tools.Tests
 			//TODO: je n'ai pas vraiment trouvé de test suite avec des valeurs de ref
 			// tout ce que j'ai trouvé c'est que Hash(123, "test") => 2758658570
 
-			Assert.That(XxHash32.Compute(new byte[0]), Is.EqualTo(0x02CC5D05));
+			Assert.That(XxHash32.Compute(Array.Empty<byte>()), Is.EqualTo(0x02CC5D05));
 			Assert.That(XxHash32.Compute(new byte[] { 65, 66, 67 }), Is.EqualTo(0x80712ED5));
 			Assert.That(XxHash32.Compute(new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64 }), Is.EqualTo(0xB1FD16EE));
 			Assert.That(XxHash32.Compute(new byte[] { 1, 2, 3, 4, 65, 66, 67, 5, 6 }, 4, 3), Is.EqualTo(0x80712ED5));
 			Assert.That(XxHash32.Compute(new byte[] { 65, 66, 67 }, 1, 0), Is.EqualTo(0x02CC5D05));
-			Assert.That(() => XxHash32.Compute(default(byte[])), Throws.InstanceOf<ArgumentNullException>());
-			Assert.That(() => XxHash32.Compute(default(byte[]), 0, 0), Throws.InstanceOf<ArgumentNullException>());
+			Assert.That(() => XxHash32.Compute(default(byte[])!), Throws.InstanceOf<ArgumentNullException>());
+			Assert.That(() => XxHash32.Compute(default(byte[])!, 0, 0), Throws.InstanceOf<ArgumentNullException>());
 
 			Assert.That(XxHash32.Compute(Slice.Empty), Is.EqualTo(0x02CC5D05));
 			Assert.That(XxHash32.Compute(new byte[] { 65, 66, 67 }.AsSlice()), Is.EqualTo(0x80712ED5));
@@ -137,13 +137,13 @@ namespace Doxense.Tools.Tests
 			Assert.That(XxHash32.Compute("Hello World "), Is.EqualTo(1029714533));
 			Assert.That(XxHash32.Compute("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"), Is.EqualTo(2453304613));
 			Assert.That(XxHash32.Compute("foobar", 1, 0), Is.EqualTo(0x02CC5D05));
-			Assert.That(() => XxHash32.Compute(default(string)), Throws.InstanceOf<ArgumentNullException>());
-			Assert.That(() => XxHash32.Compute(default(string), 0, 0), Throws.InstanceOf<ArgumentNullException>());
+			Assert.That(() => XxHash32.Compute(default(string)!), Throws.InstanceOf<ArgumentNullException>());
+			Assert.That(() => XxHash32.Compute(default(string)!, 0, 0), Throws.InstanceOf<ArgumentNullException>());
 
-			Assert.That(XxHash32.Compute(new char[0], 0, 0), Is.EqualTo(0x02CC5D05));
+			Assert.That(XxHash32.Compute(Array.Empty<char>(), 0, 0), Is.EqualTo(0x02CC5D05));
 			Assert.That(XxHash32.Compute("foobar".ToCharArray(), 0, 0), Is.EqualTo(0x02CC5D05));
 			Assert.That(XxHash32.Compute("foobar".ToCharArray(), 0, 6), Is.EqualTo(319326668));
-			Assert.That(() => XxHash32.Compute(default(char[]), 0, 0), Throws.InstanceOf<ArgumentNullException>());
+			Assert.That(() => XxHash32.Compute(default(char[])!, 0, 0), Throws.InstanceOf<ArgumentNullException>());
 
 		}
 
@@ -161,25 +161,25 @@ namespace Doxense.Tools.Tests
 				prime *= prime;
 			}
 
-			Action<byte[], int, uint, uint> testSequence = (sentence, len, seed, nresult) =>
+			static void TestSequence(byte[] sentence, int len, uint seed, uint nresult)
 			{
 				uint h = XxHash32.Continue(seed, sentence, 0, len);
-				Assert.That(h, Is.EqualTo(nresult), "[{2}, {3}] => 0x{0:X8} != 0x{1:X8}", h, nresult, len, seed);
-			};
+				Assert.That(h, Is.EqualTo(nresult), $"[{len}, {seed}] => 0x{h:X8} != 0x{nresult:X8}");
+			}
 
-			testSequence(sanityBuffer, 1, 0, 0xB85CBEE5);
-		 	testSequence(sanityBuffer, 1, PRIME, 0xD5845D64);
-		 	testSequence(sanityBuffer, 14, 0, 0xE5AA0AB4);
-		 	testSequence(sanityBuffer, 14, PRIME, 0x4481951D);
-		 	testSequence(sanityBuffer, SANITY_BUFFER_SIZE, 0, 0x1F1AA412);
-		 	testSequence(sanityBuffer, SANITY_BUFFER_SIZE, PRIME, 0x498EC8E2);
+			TestSequence(sanityBuffer, 1, 0, 0xB85CBEE5);
+		 	TestSequence(sanityBuffer, 1, PRIME, 0xD5845D64);
+		 	TestSequence(sanityBuffer, 14, 0, 0xE5AA0AB4);
+		 	TestSequence(sanityBuffer, 14, PRIME, 0x4481951D);
+		 	TestSequence(sanityBuffer, SANITY_BUFFER_SIZE, 0, 0x1F1AA412);
+		 	TestSequence(sanityBuffer, SANITY_BUFFER_SIZE, PRIME, 0x498EC8E2);
 		}
 
 		[Test]
 		[SuppressMessage("ReSharper", "AssignNullToNotNullAttribute")]
 		public void TestXxHash64()
 		{
-			Assert.That(XxHash64.FromBytes(new byte[0]), Is.EqualTo(17241709254077376921), "Empty should still return something");
+			Assert.That(XxHash64.FromBytes(Array.Empty<byte>()), Is.EqualTo(17241709254077376921), "Empty should still return something");
 			Assert.That(XxHash64.FromBytes(Slice.Empty), Is.EqualTo(17241709254077376921), "Empty should still return something");
 			Assert.That(XxHash64.FromBytes(new byte[] { 65, 66, 67 }), Is.EqualTo(16603337192413064856));
 			Assert.That(XxHash64.FromBytes(new byte[] { 65, 66, 67 }.AsSlice()), Is.EqualTo(16603337192413064856));
@@ -187,7 +187,7 @@ namespace Doxense.Tools.Tests
 			Assert.That(XxHash64.FromBytes(new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64 }.AsSlice()), Is.EqualTo(7148569436472236994));
 			Assert.That(XxHash64.FromBytes(new byte[] { 1, 2, 3, 4, 65, 66, 67, 5, 6 }.AsSlice(4, 3)), Is.EqualTo(16603337192413064856));
 			Assert.That(XxHash64.FromBytes(new byte[] { 65, 66, 67 }.AsSlice(1, 0)), Is.EqualTo(17241709254077376921));
-			Assert.That(() => XxHash64.FromBytes(default(byte[])), Throws.InstanceOf<ArgumentNullException>());
+			Assert.That(() => XxHash64.FromBytes(default(byte[])!), Throws.InstanceOf<ArgumentNullException>());
 			Assert.That(() => XxHash64.FromBytes(Slice.Nil), Throws.InstanceOf<ArgumentNullException>());
 
 			Assert.That(XxHash64.FromText(""), Is.EqualTo(17241709254077376921UL), "Empty should still return something");
@@ -203,7 +203,7 @@ namespace Doxense.Tools.Tests
 			Assert.That(XxHash64.FromText("This is Spın̈al Tap!!!".AsSpan("This is ".Length, "Spın̈al Tap".Length)), Is.EqualTo(14255674348978296242UL));
 			Assert.That(XxHash64.FromText("foobar".ToCharArray().AsSpan().Slice(0, 0)), Is.EqualTo(17241709254077376921));
 			Assert.That(XxHash64.FromText("foobar".ToCharArray().AsSpan()), Is.EqualTo(5814087441338904397UL));
-			Assert.That(() => XxHash64.FromText(default(string)), Throws.InstanceOf<ArgumentNullException>());
+			Assert.That(() => XxHash64.FromText(default(string)!), Throws.InstanceOf<ArgumentNullException>());
 		}
 
 		[Test]
@@ -223,7 +223,7 @@ namespace Doxense.Tools.Tests
 			void TestSequence64(byte[] sentence, int len, ulong seed, ulong nresult)
 			{
 				ulong h = XxHash64.Continue(seed, sentence.AsSpan(0, len));
-				Assert.That(h, Is.EqualTo(nresult), "[{2}, {3}] => 0x{0:X16} != 0x{1:X16}", h, nresult, len, seed);
+				Assert.That(h, Is.EqualTo(nresult), $"[{len}, {seed}] => 0x{h:X16} != 0x{nresult:X16}");
 			}
 
 			TestSequence64(sanityBuffer, 1, 0, 0x4FCE394CC88952D8UL);
@@ -243,7 +243,7 @@ namespace Doxense.Tools.Tests
 		const double NANOS_PER_TICK = 1E9 / TimeSpan.TicksPerSecond;
 		const double CPU_GHZ = 3.4;
 
-		private static void Hash32Bench(string label, Func<int, byte[], uint> f, byte[] sample, int iter)
+		private static void Hash32Bench(string? label, Func<int, byte[], uint> f, byte[] sample, int iter)
 		{
 			f(1, sample); // Warmup
 			var t = Stopwatch.StartNew();
@@ -252,11 +252,11 @@ namespace Doxense.Tools.Tests
 			if (label != null)
 			{
 				double nanos = (t.Elapsed.Ticks * NANOS_PER_TICK) / iter;
-				Console.WriteLine("{0,6} = {1:x8} > {2,8:F1} ns => {3,5:F1} cycles/byte  @ {4} GHz, {5,7:F1} MB/sec", label, h, nanos, (nanos / sample.Length) * CPU_GHZ, CPU_GHZ, (1.0 * sample.Length * iter) / (1024 * 1024 * t.Elapsed.TotalSeconds));
+				Log($"{label,6} = {h:x8} > {nanos,8:F1} ns => {(nanos / sample.Length) * CRCTest.CPU_GHZ,5:F1} cycles/byte  @ {CRCTest.CPU_GHZ} GHz, {(1.0 * sample.Length * iter) / (1024 * 1024 * t.Elapsed.TotalSeconds),7:F1} MB/sec");
 			}
 		}
 
-		private static void Hash64Bench(string label, Func<int, byte[], ulong> f, byte[] sample, int iter)
+		private static void Hash64Bench(string? label, Func<int, byte[], ulong> f, byte[] sample, int iter)
 		{
 			f(1, sample); // Warmup
 			var t = Stopwatch.StartNew();
@@ -265,11 +265,11 @@ namespace Doxense.Tools.Tests
 			if (label != null)
 			{
 				double nanos = (t.Elapsed.TotalSeconds / iter) * NANOS_PER_SEC;
-				Console.WriteLine("{0,6} = {1:x16} > {2,8:F1} ns => {3,5:F1} cycles/byte @ {4} GHz, {5,7:F1} MB/sec", label, h, nanos, (nanos / sample.Length) * CPU_GHZ, CPU_GHZ, (1.0 * sample.Length * iter) / (1024 * 1024 * t.Elapsed.TotalSeconds));
+				Log($"{label,6} = {h:x16} > {nanos,8:F1} ns => {(nanos / sample.Length) * CRCTest.CPU_GHZ,5:F1} cycles/byte @ {CRCTest.CPU_GHZ} GHz, {(1.0 * sample.Length * iter) / (1024 * 1024 * t.Elapsed.TotalSeconds),7:F1} MB/sec");
 			}
 		}
 
-		private static void Hash128Bench(string label, Func<int, byte[], Guid> f, byte[] sample, int iter)
+		private static void Hash128Bench(string? label, Func<int, byte[], Guid> f, byte[] sample, int iter)
 		{
 			f(1, sample); // Warmup
 			var t = Stopwatch.StartNew();
@@ -279,7 +279,7 @@ namespace Doxense.Tools.Tests
 			if (label != null)
 			{
 				double nanos = (t.Elapsed.TotalSeconds / iter) * NANOS_PER_SEC;
-				Console.WriteLine("{0,6} = {1:n} > {2,8:F1} ns => {3,5:F1} cycles/byte @ {4} GHz, {5,7:F1} MB/sec", label, h, nanos, (nanos / sample.Length) * CPU_GHZ, CPU_GHZ, (1.0 * sample.Length * iter) / (1024 * 1024 * t.Elapsed.TotalSeconds));
+				Log($"{label,6} = {h:n} > {nanos,8:F1} ns => {(nanos / sample.Length) * CRCTest.CPU_GHZ,5:F1} cycles/byte @ {CRCTest.CPU_GHZ} GHz, {(1.0 * sample.Length * iter) / (1024 * 1024 * t.Elapsed.TotalSeconds),7:F1} MB/sec");
 			}
 		}
 
@@ -336,8 +336,8 @@ namespace Doxense.Tools.Tests
 
 			foreach (var test in hashFunctions32)
 			{
-				Console.WriteLine();
-				Console.WriteLine("==== " + test.Key + " ==================");
+				Log();
+				Log("==== " + test.Key + " ==================");
 
 				// warmup
 				Hash32Bench(null, test.Value, new byte[15], 1);
@@ -350,8 +350,8 @@ namespace Doxense.Tools.Tests
 
 			foreach (var test in hashFunctions64)
 			{
-				Console.WriteLine();
-				Console.WriteLine("==== " + test.Key + " ==================");
+				Log();
+				Log("==== " + test.Key + " ==================");
 
 				// warmup
 				Hash64Bench(null, test.Value, new byte[31], 1);
@@ -364,8 +364,8 @@ namespace Doxense.Tools.Tests
 
 			foreach (var test in hashFunctions128)
 			{
-				Console.WriteLine();
-				Console.WriteLine("==== " + test.Key + " ==================");
+				Log();
+				Log("==== " + test.Key + " ==================");
 
 				// warmup
 				Hash128Bench(null, test.Value, new byte[63], 1);
@@ -395,8 +395,8 @@ namespace Doxense.Tools.Tests
 			// Concatènes chaque hash dans un tableau de 4 * 256 bytes (ie : bytes 0-3 = hash de {0}, bytes 4-7 = hash de {0, 1}, bytes 1023-1023 = hash de {0, ..., 255 }
 			// Calcul le hash final sur le vecteur total
 
-			byte[] key = new byte[256];
-			byte[] hashes = new byte[hashBytes * 256];
+			var key = new byte[256];
+			var hashes = new byte[hashBytes * 256];
 			for (int i = 0; i < key.Length; i++)
 			{
 				key[i] = (byte)i;
@@ -405,13 +405,13 @@ namespace Doxense.Tools.Tests
 				var tmp = new byte[i];
 				Array.Copy(key, 0, tmp, 0, i);
 				byte[] h = hashFunction(seed, tmp);
-				Assert.That(h, Is.Not.Null, "h[{0}]", i);
-				Assert.That(h.Length, Is.EqualTo(hashBytes), "h[{0}].Length", i);
+				Assert.That(h, Is.Not.Null, $"h[{i}]");
+				Assert.That(h.Length, Is.EqualTo(hashBytes), $"h[{i}].Length");
 
 				Array.Copy(h, 0, hashes, i * hashBytes, hashBytes);
 			}
 
-			byte[] result = hashFunction(0U, hashes);
+			var result = hashFunction(0U, hashes);
 			return result.AsSpan(0, 4).ToUInt32();
 		}
 
@@ -423,7 +423,7 @@ namespace Doxense.Tools.Tests
 			using (var md5 = System.Security.Cryptography.MD5.Create())
 			{
 				var h = md5.ComputeHash(bytes);
-				byte[] t = new byte[4];
+				var t = new byte[4];
 				Array.Copy(h, 0, t, 0, 4);
 				return t;
 			}

--- a/Doxense.Core.Tests/IO/Hashing/HighestRandomWeighHashFacts.cs
+++ b/Doxense.Core.Tests/IO/Hashing/HighestRandomWeighHashFacts.cs
@@ -198,12 +198,12 @@ namespace Doxense.IO.Hashing.Tests
 
 				if (b1 != "MARCELUS")
 				{ // the key should not change bucket!
-					if (b2 != b1) Assert.That(b2, Is.EqualTo(b1), "The bucket for key {0} was changed from {1} to {2} even though it should not have been affected!", keys1[i].Key, b1, b2);
+					if (b2 != b1) Assert.That(b2, Is.EqualTo(b1), $"The bucket for key {keys1[i].Key} was changed from {b1} to {b2} even though it should not have been affected!");
 				}
 				else
 				{ // the key should be remaped to someone else!
-					if (b2 == "MARCELUS") Assert.That(b2, Is.Not.EqualTo("MARCELUS"), "The bucket for key {0} should have been reassigned, but is still equal to {1} !", keys1[i].Key, b2);
-					gained[b2] = (gained.TryGetValue(b2, out int x) ? x : 0) + 1;
+					if (b2 == "MARCELUS") Assert.That(b2, Is.Not.EqualTo("MARCELUS"), $"The bucket for key {keys1[i].Key} should have been reassigned, but is still equal to {b2} !");
+					gained[b2] = (gained.GetValueOrDefault(b2, 0)) + 1;
 				}
 			}
 			Log($"Found {changed:N0} keys out of {KEYS:N0} that have been reassigned (1 in {1.0*KEYS/changed:F3})");
@@ -250,11 +250,11 @@ namespace Doxense.IO.Hashing.Tests
 
 				if (b2 == "ROBERTA")
 				{
-					stolen[b1] = (stolen.TryGetValue(b1, out int x) ? x : 0) + 1;
+					stolen[b1] = (stolen.GetValueOrDefault(b1, 0)) + 1;
 				}
 				else
 				{ // the key should not change assignment
-					if (b1 != b2) Assert.That(b2, Is.EqualTo(b1), "The bucket for key {0} should not have been reassigned, but has changed from {1} to {2} !", keys1[i].Key, b1, b2);
+					if (b1 != b2) Assert.That(b2, Is.EqualTo(b1), $"The bucket for key {keys1[i].Key} should not have been reassigned, but has changed from {b1} to {b2} !");
 				}
 			}
 			Log($"Found {changed:N0} keys out of {KEYS:N0} that have been reassigned (1 in {1.0*KEYS/changed:F3})");

--- a/Doxense.Core.Tests/Linq/AsyncEnumerableFacts.cs
+++ b/Doxense.Core.Tests/Linq/AsyncEnumerableFacts.cs
@@ -1309,7 +1309,7 @@ namespace Doxense.Linq.Async.Tests
 				var withPrefetchingK = await source.Prefetch(K).Select(Record).ToListAsync(this.Cancellation);
 				Log($"P{K}: {string.Join(", ", withPrefetchingK)}");
 				Assert.That(withPrefetchingK.Select(x => x.Value), Is.EqualTo(Enumerable.Range(0, 10)));
-				Assert.That(withPrefetchingK[0].Called, Is.EqualTo(K + 1), "Generator must have {0} call(s) in advance!", K);
+				Assert.That(withPrefetchingK[0].Called, Is.EqualTo(K + 1), $"Generator must have {K} call(s) in advance!");
 				Assert.That(withPrefetchingK.Select(x => x.Called), Is.All.LessThanOrEqualTo(11));
 			}
 
@@ -1440,14 +1440,14 @@ namespace Doxense.Linq.Async.Tests
 							try
 							{
 								Assert.That(n, Is.LessThanOrEqualTo(MAX_CONCURRENCY));
-								Log("** " + sw.Elapsed + " start " + x + " (" + n + ")");
+								Log($"** {sw.Elapsed} start {x} ({n})");
 #if DEBUG_STACK_TRACES
 								Log("> " + new StackTrace().ToString().Replace("\r\n", "\r\n> "));
 #endif
 								int ms;
 								lock (rnd) { ms = rnd.Next(25) + 50; }
 								await Task.Delay(ms, this.Cancellation);
-								Log("** " + sw.Elapsed + " stop " + x + " (" + Volatile.Read(ref concurrent) + ")");
+								Log($"** {sw.Elapsed} stop {x} ({Volatile.Read(ref concurrent)})");
 
 								return x * x;
 							}
@@ -1459,7 +1459,7 @@ namespace Doxense.Linq.Async.Tests
 						}
 						catch(Exception e)
 						{
-							Console.Error.WriteLine("Thread #" + x + " failed: " + e.ToString());
+							Console.Error.WriteLine($"Thread #{x} failed: {e}");
 							throw;
 						}
 					},
@@ -1567,22 +1567,22 @@ namespace Doxense.Linq.Async.Tests
 
 			if (asyncError != null)
 			{
-				if (referenceError == null) Assert.Fail("{0}(): The async query failed but not there reference query {1} : {2}", label, witness.Expression, asyncError);
+				if (referenceError == null) Assert.Fail($"{label}(): The async query failed but not there reference query {witness.Expression} : {asyncError}");
 				//TODO: compare exception types ?
 			}
 			else if (referenceError != null)
 			{
-				Assert.Fail("{0}(): The referency query {1} failed ({2}) but the async query returned: {3}", label, witness.Expression, referenceError.Message, asyncResult);
+				Assert.Fail($"{label}(): The referency query {witness.Expression} failed ({referenceError.Message}) but the async query returned: {asyncResult}");
 			}
 			else
 			{
 				try
 				{
-					Assert.That(asyncResult, Is.EqualTo(referenceResult), "{0}(): {1}", label, witness.Expression);
+					Assert.That(asyncResult, Is.EqualTo(referenceResult), $"{label}(): {witness.Expression}");
 				}
 				catch(AssertionException x)
 				{
-					Log("FAIL: " + witness.Expression + "\r\n >  " + x.Message);
+					Log($"FAIL: {witness.Expression}\r\n >  {x.Message}");
 				}
 			}
 
@@ -1605,18 +1605,18 @@ namespace Doxense.Linq.Async.Tests
 
 			if (asyncError != null)
 			{
-				if (referenceError == null) Assert.Fail("{0}(): The async query failed but not there reference query {1} : {2}", label, witness.Expression, asyncError);
+				if (referenceError == null) Assert.Fail($"{label}(): The async query failed but not there reference query {witness.Expression} : {asyncError}");
 				//TODO: compare exception types ?
 			}
 			else if (referenceError != null)
 			{
-				Assert.Fail("{0}(): The referency query {1} failed ({2}) but the async query returned: {3}", label, witness.Expression, referenceError.Message, asyncResult);
+				Assert.Fail($"{label}(): The referency query {witness.Expression} failed ({referenceError.Message}) but the async query returned: {asyncResult}");
 			}
 			else
 			{
 				try
 				{
-					Assert.That(asyncResult, Is.EqualTo(referenceResult), "{0}(): {1}", label, witness.Expression);
+					Assert.That(asyncResult, Is.EqualTo(referenceResult), $"{label}(): {witness.Expression}");
 				}
 				catch (AssertionException x)
 				{

--- a/Doxense.Core.Tests/Mathematics/FastDtoaFacts.cs
+++ b/Doxense.Core.Tests/Mathematics/FastDtoaFacts.cs
@@ -74,57 +74,58 @@ namespace Doxense.Mathematics.Test
 		[Test]
 		public void Test_DiyDouble_Properties()
 		{
-
-			Func<double, DiyDouble> test = (value) =>
+			static void Check(double value)
 			{
 				DiyDouble d = value;
 				Log(d);
 
-				Assert.That(d.Value, Is.EqualTo(value), "Value {0}", d);
+				Assert.That(d.Value, Is.EqualTo(value), $"Value {d}");
 				ulong r;
-				unsafe { r = *((ulong*)(&d)); }
-				Assert.That(d.Raw, Is.EqualTo(r), "Raw {0}", d);
+				unsafe
+				{
+					r = *((ulong*) (&d));
+				}
 
-				Assert.That(d.IsNaN, Is.EqualTo(double.IsNaN(value)), "NaN? {0}", d);
-				Assert.That(d.IsInfinite, Is.EqualTo(double.IsInfinity(value)), "Infinity? {0}", d);
-				Assert.That(d.Sign, Is.EqualTo(value >= 0 ? +1 : -1), "Sign? {0}", d);
+				Assert.That(d.Raw, Is.EqualTo(r), $"Raw {d}");
 
-				Assert.That(d.IsInteger, Is.EqualTo(!double.IsInfinity(value) && !double.IsNaN(value) && (value - Math.Truncate(value)) == 0.0), "Integer? {0}", d);
+				Assert.That(d.IsNaN, Is.EqualTo(double.IsNaN(value)), $"NaN? {d}");
+				Assert.That(d.IsInfinite, Is.EqualTo(double.IsInfinity(value)), $"Infinity? {d}");
+				Assert.That(d.Sign, Is.EqualTo(value >= 0 ? +1 : -1), $"Sign? {d}");
 
-				return d;
-			};
+				Assert.That(d.IsInteger, Is.EqualTo(!double.IsInfinity(value) && !double.IsNaN(value) && (value - Math.Truncate(value)) == 0.0), $"Integer? {d}");
+			}
 
-			test(0.0);
-			test(double.Epsilon);
-			test(1.0);
-			test(-1.0);
-			test(double.NaN);
-			test(double.PositiveInfinity);
-			test(double.NegativeInfinity);
-			test((double)int.MaxValue);
-			test((double)long.MaxValue);
-			test(Math.PI);
-			test(Math.E);
-			test(1.0 / 3.0);
-			test(11.0 / 10.0);
-			test(1025.0 / 1024.0);
+			Check(0.0);
+			Check(double.Epsilon);
+			Check(1.0);
+			Check(-1.0);
+			Check(double.NaN);
+			Check(double.PositiveInfinity);
+			Check(double.NegativeInfinity);
+			Check((double)int.MaxValue);
+			Check((double)long.MaxValue);
+			Check(Math.PI);
+			Check(Math.E);
+			Check(1.0 / 3.0);
+			Check(11.0 / 10.0);
+			Check(1025.0 / 1024.0);
 
 			var rnd = new Random(7654321);
 			for (int i = 0; i < 10; i++)
 			{
-				test(rnd.NextDouble());
+				Check(rnd.NextDouble());
 			}
 			for (int i = 0; i < 10; i++)
 			{
-				test((double)rnd.Next());
+				Check((double)rnd.Next());
 			}
 			for (int i = 0; i < 10; i++)
 			{
-				test(0.5d + (double)rnd.Next());
+				Check(0.5d + (double)rnd.Next());
 			}
 			for (int i = 0; i < 63; i++)
 			{
-				test(rnd.NextDouble() * (1UL << i));
+				Check(rnd.NextDouble() * (1UL << i));
 			}
 
 		}
@@ -132,55 +133,56 @@ namespace Doxense.Mathematics.Test
 		[Test]
 		public void Test_DiySingle_Properties()
 		{
-
-			Func<float, DiySingle> test = (value) =>
+			static void Check(float value)
 			{
 				DiySingle d = value;
 				Log(d);
 
-				Assert.That(d.Value, Is.EqualTo(value), "Value {0}", d);
+				Assert.That(d.Value, Is.EqualTo(value), $"Value {d}");
 				uint r;
-				unsafe { r = *((uint*)(&d)); }
-				Assert.That(d.Raw, Is.EqualTo(r), "Raw {0}", d);
+				unsafe
+				{
+					r = *((uint*) (&d));
+				}
 
-				Assert.That(d.IsNaN, Is.EqualTo(float.IsNaN(value)), "NaN? {0}", d);
-				Assert.That(d.IsInfinite, Is.EqualTo(float.IsInfinity(value)), "Infinity? {0}", d);
-				Assert.That(d.Sign, Is.EqualTo(value >= 0 ? +1 : -1), "Sign? {0}", d);
+				Assert.That(d.Raw, Is.EqualTo(r), $"Raw {d}");
 
-				Assert.That(d.IsInteger, Is.EqualTo(!float.IsInfinity(value) && !float.IsNaN(value) && (value - (float)(int)value) == 0), "Integer? {0}", d);
+				Assert.That(d.IsNaN, Is.EqualTo(float.IsNaN(value)), $"NaN? {d}");
+				Assert.That(d.IsInfinite, Is.EqualTo(float.IsInfinity(value)), $"Infinity? {d}");
+				Assert.That(d.Sign, Is.EqualTo(value >= 0 ? +1 : -1), $"Sign? {d}");
 
-				return d;
-			};
+				Assert.That(d.IsInteger, Is.EqualTo(!float.IsInfinity(value) && !float.IsNaN(value) && (value - (float) (int) value) == 0), $"Integer? {d}");
+			}
 
-			test(0.0f);
-			test(float.Epsilon);
-			test(1.0f);
-			test(-1.0f);
-			test(float.NaN);
-			test(float.PositiveInfinity);
-			test(float.NegativeInfinity);
-			test((float)Math.PI);
-			test((float)Math.E);
-			test(1.0f / 3.0f);
-			test(11.0f / 10.0f);
-			test(1025.0f / 1024.0f);
+			Check(0.0f);
+			Check(float.Epsilon);
+			Check(1.0f);
+			Check(-1.0f);
+			Check(float.NaN);
+			Check(float.PositiveInfinity);
+			Check(float.NegativeInfinity);
+			Check((float)Math.PI);
+			Check((float)Math.E);
+			Check(1.0f / 3.0f);
+			Check(11.0f / 10.0f);
+			Check(1025.0f / 1024.0f);
 
 			var rnd = new Random(7654321);
 			for (int i = 0; i < 10; i++)
 			{
-				test((float)rnd.NextDouble());
+				Check((float)rnd.NextDouble());
 			}
 			for (int i = 0; i < 10; i++)
 			{
-				test((float)rnd.Next());
+				Check((float)rnd.Next());
 			}
 			for (int i = 0; i < 10; i++)
 			{
-				test(0.5f + (float)rnd.Next());
+				Check(0.5f + (float)rnd.Next());
 			}
 			for (int i = 0; i < 31; i++)
 			{
-				test((float)(rnd.NextDouble() * (1U << i)));
+				Check((float)(rnd.NextDouble() * (1U << i)));
 			}
 
 		}
@@ -190,7 +192,7 @@ namespace Doxense.Mathematics.Test
 		{
 			var chars = new char[32];
 
-			Func<double, string, string> test = (d, expected) =>
+			string Check(double d, string expected)
 			{
 				Array.Clear(chars, 0, chars.Length);
 				string s = FastDtoa.FormatDouble(d);
@@ -198,50 +200,50 @@ namespace Doxense.Mathematics.Test
 				Assert.That(s.Length, Is.GreaterThan(0));
 				//Log("dtoa({0}) => \"{1}\" [{2}]", d.ToString("R", CultureInfo.InvariantCulture), s, n);
 
-				Assert.That(s, Is.EqualTo(expected), "ToShortest({0:R}, {0:G17}, (0x{1:X16})", d, BitConverter.DoubleToInt64Bits(d));
+				Assert.That(s, Is.EqualTo(expected), $"ToShortest({d:R}, {d:G17}, (0x{BitConverter.DoubleToInt64Bits(d):X16})");
 
 				double roundTrip = Double.Parse(s, CultureInfo.InvariantCulture);
 				Log("0x{4:X16} : {0:R} ~> \"{1}\" ~> 0x{5:X16} : {2:R} => {3}", d, s, roundTrip, d == roundTrip, BitConverter.DoubleToInt64Bits(d), BitConverter.DoubleToInt64Bits(roundTrip));
-				Assert.That(roundTrip, Is.EqualTo(d), "MISTMATCH {0:X16} -> {1} -> {2:X16}", BitConverter.DoubleToInt64Bits(d), s, BitConverter.DoubleToInt64Bits(roundTrip));
+				Assert.That(roundTrip, Is.EqualTo(d), $"MISTMATCH {BitConverter.DoubleToInt64Bits(d):X16} -> {s} -> {BitConverter.DoubleToInt64Bits(roundTrip):X16}");
 
 				return s;
-			};
+			}
 
-			test(0.0, "0");
-			test(1.0, "1");
-			test(1.23, "1.23");
-			test(12345.0, "12345");
-			test(12345e23, "1.2345E+27");
-			test(1.0 / 3.0, "0.3333333333333333");
-			test(10.0 / 11.0, "0.9090909090909091");
-			test(Math.PI, "3.141592653589793");
-			test(Math.E, "2.718281828459045");
-			test(1e21, "1E+21");
-			test(1e20, "100000000000000000000");
-			test(111111111111111111111.0, "111111111111111110000");
-			test(1111111111111111111111.0, "1.1111111111111111E+21");
-			test(11111111111111111111111.0, "1.1111111111111111E+22");
-			test(-0.00001, "-0.00001");
-			test(-0.000001, "-0.000001");
-			test(-0.0000001, "-1E-7");
-			test(-0.0, "0");
-			test(5e-324, "5E-324");
-			test(double.MaxValue, "1.7976931348623157E+308");
-			test(double.MinValue, "-1.7976931348623157E+308");
-			test(2147483648.0, "2147483648");
-			test(4294967272.0, "4294967272");
-			test(4.1855804968213567e298, "4.185580496821357E+298");
+			Check(0.0, "0");
+			Check(1.0, "1");
+			Check(1.23, "1.23");
+			Check(12345.0, "12345");
+			Check(12345e23, "1.2345E+27");
+			Check(1.0 / 3.0, "0.3333333333333333");
+			Check(10.0 / 11.0, "0.9090909090909091");
+			Check(Math.PI, "3.141592653589793");
+			Check(Math.E, "2.718281828459045");
+			Check(1e21, "1E+21");
+			Check(1e20, "100000000000000000000");
+			Check(111111111111111111111.0, "111111111111111110000");
+			Check(1111111111111111111111.0, "1.1111111111111111E+21");
+			Check(11111111111111111111111.0, "1.1111111111111111E+22");
+			Check(-0.00001, "-0.00001");
+			Check(-0.000001, "-0.000001");
+			Check(-0.0000001, "-1E-7");
+			Check(-0.0, "0");
+			Check(5e-324, "5E-324");
+			Check(double.MaxValue, "1.7976931348623157E+308");
+			Check(double.MinValue, "-1.7976931348623157E+308");
+			Check(2147483648.0, "2147483648");
+			Check(4294967272.0, "4294967272");
+			Check(4.1855804968213567e298, "4.185580496821357E+298");
 
 			// corner cases
-			test(3.5844466002796428e+298, "3.5844466002796428E+298"); //BUGBUG: BCL rajoute le '+' pour l'exponent
+			Check(3.5844466002796428e+298, "3.5844466002796428E+298"); //BUGBUG: BCL rajoute le '+' pour l'exponent
 
 
 			// x86/x64 rounding mode differences
 			if (IntPtr.Size == 4)
 			{
 				//BUGBUG: ces valeurs ne roundtrippent pas exactement en x64 ! :(
-				test(1.0000000012588799, "1.00000000125888");
-				test(5.5626846462680035e-309, "5.562684646268003E-309");
+				Check(1.0000000012588799, "1.00000000125888");
+				Check(5.5626846462680035e-309, "5.562684646268003E-309");
 			}
 
 		}
@@ -249,7 +251,7 @@ namespace Doxense.Mathematics.Test
 		[Test, Category("LongRunning")]
 		public void Test_All_The_Things()
 		{
-			Log("Test running in " + (IntPtr.Size == 4 ? "x86" : "x64"));
+			Log($"Test running in {(IntPtr.Size == 4 ? "x86" : "x64")}");
 			long b = BitConverter.DoubleToInt64Bits(1);
 			int num = 0;
 			int notParsed = 0;
@@ -262,27 +264,36 @@ namespace Doxense.Mathematics.Test
 				var s = FastDtoa.FormatDouble(d);
 				double dd;
 				++num;
-				if (!Double.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out dd))
+				if (!double.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out dd))
 				{
 					++notParsed;
 				}
 				else if (d != dd)
 				{
 					if (Math.Abs(BitConverter.DoubleToInt64Bits(dd) - BitConverter.DoubleToInt64Bits(d)) <= 1)
+					{
 						++notEqualOneUlp;
+					}
 					else
+					{
 						++notEqual;
+					}
 					Log(d.ToString("R") + " / " + s);
 				}
 			}
-			Log("{0} tests: {1} failed to parse, {2} != more than 1 ULP, {3} != by exactly 1 ULP", num, notParsed, notEqual, notEqualOneUlp);
+
+			Log($"{num} tests: {notParsed} failed to parse, {notEqual} != more than 1 ULP, {notEqualOneUlp} != by exactly 1 ULP");
 			Assert.That(notParsed, Is.EqualTo(0), "Numbers that failed parsing should be 0");
 			Assert.That(notEqual, Is.EqualTo(0), "Numbers that differ from more than one ULP after roundtripping");
 			// le rounding mode de x64 n'est pas le même que x86, ce qui entraine des différences de 1 ULP dans certaisn cas en x86
 			if (IntPtr.Size == 4)
+			{
 				Assert.That(notEqualOneUlp, Is.EqualTo(0), "Numbers that differ by only one ULP after roundtripping (x86)");
+			}
 			else
+			{
 				Assert.That(notEqualOneUlp, Is.LessThanOrEqualTo(227), "Numbers that differ by only one ULP after roundtripping (x64)");
+			}
 		}
 
 		[Test]
@@ -317,7 +328,7 @@ namespace Doxense.Mathematics.Test
 				RUNS,
 				ITER
 			);
-			Log("Int64.ToString()    : Med={0:N1}, Best={1:N1}, StdDev={2:N2}, GCs={3} / {4} / {5}", report.MedianIterationsNanos / 5, report.BestIterationsNanos / 5, report.StdDevIterationNanos / 5, report.GC0, report.GC1, report.GC2);
+			Log($"Int64.ToString()    : Med={report.MedianIterationsNanos / 5:N1}, Best={report.BestIterationsNanos / 5:N1}, StdDev={report.StdDevIterationNanos / 5:N2}, GCs={report.GC0} / {report.GC1} / {report.GC2}");
 
 			// Double Baseline
 			report = RobustBenchmark.Run(
@@ -336,7 +347,7 @@ namespace Doxense.Mathematics.Test
 				RUNS,
 				ITER
 			);
-			Log("Double.ToString('R'): Med={0:N1}, Best={1:N1}, StdDev={2:N2}, GCs={3} / {4} / {5}", report.MedianIterationsNanos / 5, report.BestIterationsNanos / 5, report.StdDevIterationNanos / 5, report.GC0, report.GC1, report.GC2);
+			Log($"Double.ToString('R'): Med={report.MedianIterationsNanos / 5:N1}, Best={report.BestIterationsNanos / 5:N1}, StdDev={report.StdDevIterationNanos / 5:N2}, GCs={report.GC0} / {report.GC1} / {report.GC2}");
 
 			// Double Baseline (no decimals)
 			report = RobustBenchmark.Run(
@@ -355,7 +366,7 @@ namespace Doxense.Mathematics.Test
 				RUNS,
 				ITER
 			);
-			Log("  (integer)         : Med={0:N1}, Best={1:N1}, StdDev={2:N2}, GCs={3} / {4} / {5}", report.MedianIterationsNanos / 5, report.BestIterationsNanos / 5, report.StdDevIterationNanos / 5, report.GC0, report.GC1, report.GC2);
+			Log($"  (integer)         : Med={report.MedianIterationsNanos / 5:N1}, Best={report.BestIterationsNanos / 5:N1}, StdDev={report.StdDevIterationNanos / 5:N2}, GCs={report.GC0} / {report.GC1} / {report.GC2}");
 
 			// Grisu3 ToString()
 			report = RobustBenchmark.Run(
@@ -374,7 +385,7 @@ namespace Doxense.Mathematics.Test
 				RUNS,
 				ITER
 			);
-			Log("Grisu3 string       : Med={0:N1}, Best={1:N1}, StdDev={2:N2}, GCs={3} / {4} / {5}", report.MedianIterationsNanos / 5, report.BestIterationsNanos / 5, report.StdDevIterationNanos / 5, report.GC0, report.GC1, report.GC2);
+			Log($"Grisu3 string       : Med={report.MedianIterationsNanos / 5:N1}, Best={report.BestIterationsNanos / 5:N1}, StdDev={report.StdDevIterationNanos / 5:N2}, GCs={report.GC0} / {report.GC1} / {report.GC2}");
 
 			// Grisu3 ToString() (no decimals)
 			report = RobustBenchmark.Run(
@@ -393,7 +404,7 @@ namespace Doxense.Mathematics.Test
 				RUNS,
 				ITER
 			);
-			Log("  (integer)         : Med={0:N1}, Best={1:N1}, StdDev={2:N2}, GCs={3} / {4} / {5}", report.MedianIterationsNanos / 5, report.BestIterationsNanos / 5, report.StdDevIterationNanos / 5, report.GC0, report.GC1, report.GC2);
+			Log($"  (integer)         : Med={report.MedianIterationsNanos / 5:N1}, Best={report.BestIterationsNanos / 5:N1}, StdDev={report.StdDevIterationNanos / 5:N2}, GCs={report.GC0} / {report.GC1} / {report.GC2}");
 
 			// Grisu3 ToBuffer()
 			var chars = new char[32];
@@ -416,7 +427,7 @@ namespace Doxense.Mathematics.Test
 			);
 
 			// Grisu3 ToBuffer() (no decimals)
-			Log("Grisu3 char[]       : Med={0:N1}, Best={1:N1}, StdDev={2:N2}, GCs={3} / {4} / {5}", report.MedianIterationsNanos / 5, report.BestIterationsNanos / 5, report.StdDevIterationNanos / 5, report.GC0, report.GC1, report.GC2);
+			Log($"Grisu3 char[]       : Med={report.MedianIterationsNanos / 5:N1}, Best={report.BestIterationsNanos / 5:N1}, StdDev={report.StdDevIterationNanos / 5:N2}, GCs={report.GC0} / {report.GC1} / {report.GC2}");
 			report = RobustBenchmark.Run(
 				() => nums,
 				(t, i) =>
@@ -434,8 +445,7 @@ namespace Doxense.Mathematics.Test
 				RUNS,
 				ITER
 			);
-			Log("  (integer)         : Med={0:N1}, Best={1:N1}, StdDev={2:N2}, GCs={3} / {4} / {5}", report.MedianIterationsNanos / 5, report.BestIterationsNanos / 5, report.StdDevIterationNanos / 5, report.GC0, report.GC1, report.GC2);
-
+			Log($"  (integer)         : Med={report.MedianIterationsNanos / 5:N1}, Best={report.BestIterationsNanos / 5:N1}, StdDev={report.StdDevIterationNanos / 5:N2}, GCs={report.GC0} / {report.GC1} / {report.GC2}");
 		}
 
 	}

--- a/Doxense.Core.Tests/Memory/BitHelpersFacts.cs
+++ b/Doxense.Core.Tests/Memory/BitHelpersFacts.cs
@@ -118,9 +118,9 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(BitHelpers.IsPowerOfTwo(2), Is.True, "2 == 2^1");
 			for (int i = 2; i < 30; i++)
 			{
-				Assert.That(BitHelpers.IsPowerOfTwo((1 << i) - 1), Is.False, "2^{0} - 1 is NOT a power of two", i);
-				Assert.That(BitHelpers.IsPowerOfTwo(1 << i), Is.True, "2^{0} IS a power of two", i);
-				Assert.That(BitHelpers.IsPowerOfTwo((1 << i) + 1), Is.False, "2^{0} + 1 is NOT a power of two", i);
+				Assert.That(BitHelpers.IsPowerOfTwo((1 << i) - 1), Is.False, $"2^{i} - 1 is NOT a power of two");
+				Assert.That(BitHelpers.IsPowerOfTwo(1 << i), Is.True, $"2^{i} IS a power of two");
+				Assert.That(BitHelpers.IsPowerOfTwo((1 << i) + 1), Is.False, $"2^{i} + 1 is NOT a power of two");
 			}
 			Assert.That(BitHelpers.IsPowerOfTwo(int.MaxValue), Is.False);
 			Assert.That(BitHelpers.IsPowerOfTwo(-1), Is.False);
@@ -132,9 +132,9 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(BitHelpers.IsPowerOfTwo(2L), Is.True, "2 == 2^1");
 			for (int i = 2; i < 62; i++)
 			{
-				Assert.That(BitHelpers.IsPowerOfTwo((1L << i) - 1), Is.False, "2^{0} - 1 is NOT a power of two", i);
-				Assert.That(BitHelpers.IsPowerOfTwo(1L << i), Is.True, "2^{0} IS a power of two", i);
-				Assert.That(BitHelpers.IsPowerOfTwo((1L << i) + 1), Is.False, "2^{0} + 1 is NOT a power of two", i);
+				Assert.That(BitHelpers.IsPowerOfTwo((1L << i) - 1), Is.False, $"2^{i} - 1 is NOT a power of two");
+				Assert.That(BitHelpers.IsPowerOfTwo(1L << i), Is.True, $"2^{i} IS a power of two");
+				Assert.That(BitHelpers.IsPowerOfTwo((1L << i) + 1), Is.False, $"2^{i} + 1 is NOT a power of two");
 			}
 			Assert.That(BitHelpers.IsPowerOfTwo(long.MaxValue), Is.False);
 			Assert.That(BitHelpers.IsPowerOfTwo((long)int.MaxValue), Is.False);
@@ -151,9 +151,9 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(BitHelpers.IsPowerOfTwo(2U), Is.True, "2 == 2^1");
 			for (int i = 2; i < 31; i++)
 			{
-				Assert.That(BitHelpers.IsPowerOfTwo((1U << i) - 1), Is.False, "2^{0} - 1 is NOT a power of two", i);
-				Assert.That(BitHelpers.IsPowerOfTwo(1U << i), Is.True, "2^{0} is a power of two", i);
-				Assert.That(BitHelpers.IsPowerOfTwo((1U << i) + 1), Is.False, "2^{0} + 1 is NOT a power of two", i);
+				Assert.That(BitHelpers.IsPowerOfTwo((1U << i) - 1), Is.False, $"2^{i} - 1 is NOT a power of two");
+				Assert.That(BitHelpers.IsPowerOfTwo(1U << i), Is.True, $"2^{i} is a power of two");
+				Assert.That(BitHelpers.IsPowerOfTwo((1U << i) + 1), Is.False, $"2^{i} + 1 is NOT a power of two");
 			}
 			Assert.That(BitHelpers.IsPowerOfTwo(uint.MaxValue), Is.False);
 
@@ -162,9 +162,9 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(BitHelpers.IsPowerOfTwo(2UL), Is.True, "2 == 2^1");
 			for (int i = 2; i < 62; i++)
 			{
-				Assert.That(BitHelpers.IsPowerOfTwo((1UL << i) - 1), Is.False, "2^{0} - 1 is NOT a power of two", i);
-				Assert.That(BitHelpers.IsPowerOfTwo(1UL << i), Is.True, "2^{0} is a power of two", i);
-				Assert.That(BitHelpers.IsPowerOfTwo((1UL << i) + 1), Is.False, "2^{0} + 1 is NOT a power of two", i);
+				Assert.That(BitHelpers.IsPowerOfTwo((1UL << i) - 1), Is.False, $"2^{i} - 1 is NOT a power of two");
+				Assert.That(BitHelpers.IsPowerOfTwo(1UL << i), Is.True, $"2^{i} is a power of two");
+				Assert.That(BitHelpers.IsPowerOfTwo((1UL << i) + 1), Is.False, $"2^{i} + 1 is NOT a power of two");
 			}
 			Assert.That(BitHelpers.IsPowerOfTwo((ulong)uint.MaxValue), Is.False);
 			Assert.That(BitHelpers.IsPowerOfTwo(ulong.MaxValue), Is.False);
@@ -248,14 +248,14 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(BitHelpers.AlignPowerOfTwo(0), Is.EqualTo(16));
 			Assert.That(BitHelpers.AlignPowerOfTwo(0L), Is.EqualTo(16));
 			// 1..16 => 16
-			for (int i = 1; i <= 16; i++) { Assert.That(BitHelpers.AlignPowerOfTwo(i), Is.EqualTo(16), "Align({0}) => 16", i); }
-			for (int i = 1; i <= 16; i++) { Assert.That(BitHelpers.AlignPowerOfTwo((long) i), Is.EqualTo(16), "Align({0}) => 16", i); }
+			for (int i = 1; i <= 16; i++) { Assert.That(BitHelpers.AlignPowerOfTwo(i), Is.EqualTo(16), $"Align({i}) => 16"); }
+			for (int i = 1; i <= 16; i++) { Assert.That(BitHelpers.AlignPowerOfTwo((long) i), Is.EqualTo(16), $"Align({i}) => 16"); }
 			// 17..32 => 32
-			for (int i = 17; i <= 32; i++) { Assert.That(BitHelpers.AlignPowerOfTwo(i), Is.EqualTo(32), "Align({0}) => 32", i); }
-			for (int i = 17; i <= 32; i++) { Assert.That(BitHelpers.AlignPowerOfTwo((long) i), Is.EqualTo(32), "Align({0}) => 32", i); }
+			for (int i = 17; i <= 32; i++) { Assert.That(BitHelpers.AlignPowerOfTwo(i), Is.EqualTo(32), $"Align({i}) => 32"); }
+			for (int i = 17; i <= 32; i++) { Assert.That(BitHelpers.AlignPowerOfTwo((long) i), Is.EqualTo(32), $"Align({i}) => 32"); }
 			// 33..48 => 48
-			for (int i = 33; i <= 48; i++) { Assert.That(BitHelpers.AlignPowerOfTwo(i), Is.EqualTo(48), "Align({0}) => 48", i); }
-			for (int i = 33; i <= 48; i++) { Assert.That(BitHelpers.AlignPowerOfTwo((long) i), Is.EqualTo(48), "Align({0}) => 48", i); }
+			for (int i = 33; i <= 48; i++) { Assert.That(BitHelpers.AlignPowerOfTwo(i), Is.EqualTo(48), $"Align({i}) => 48"); }
+			for (int i = 33; i <= 48; i++) { Assert.That(BitHelpers.AlignPowerOfTwo((long) i), Is.EqualTo(48), $"Align({i}) => 48"); }
 
 			// 2^N-1
 			for (int i = 6; i < 30; i++)

--- a/Doxense.Core.Tests/Memory/BitMapFacts.cs
+++ b/Doxense.Core.Tests/Memory/BitMapFacts.cs
@@ -323,7 +323,7 @@ namespace Doxense.IO.Tests
 #endif
 				if (actual != expect)
 				{
-					Assert.That(actual, Is.EqualTo(expect), "Invalid result in range {0} <= idx < {1}", start, end);
+					Assert.That(actual, Is.EqualTo(expect), $"Invalid result in range {start} <= idx < {end}");
 				}
 			};
 
@@ -425,7 +425,7 @@ namespace Doxense.IO.Tests
 				for (int i = 0; i < 256; i++)
 				{
 					Assert.That(it.MoveNext(), Is.True);
-					Assert.That(it.Current, Is.EqualTo(map[i]), "#{0}", i);
+					Assert.That(it.Current, Is.EqualTo(map[i]), $"#{i}");
 				}
 				Assert.That(it.MoveNext(), Is.False, "Should be done after 256 bits");
 			}
@@ -438,7 +438,7 @@ namespace Doxense.IO.Tests
 			Assert.That(bits.Length, Is.EqualTo(256));
 			for (int i = 0; i < bits.Length; i++)
 			{
-				Assert.That(bits[i], Is.EqualTo(map[i]), "#{0}", i);
+				Assert.That(bits[i], Is.EqualTo(map[i]), $"#{i}");
 			}
 
 		}

--- a/Doxense.Core.Tests/Memory/SliceFacts.cs
+++ b/Doxense.Core.Tests/Memory/SliceFacts.cs
@@ -222,7 +222,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(Slice.Random(rng, 0), Is.EqualTo(Slice.Empty));
 
 			// ReSharper disable once AssignNullToNotNullAttribute
-			Assert.That(() => Slice.Random(default(Random), 16), Throws.ArgumentNullException);
+			Assert.That(() => Slice.Random(default(Random)!, 16), Throws.ArgumentNullException);
 			Assert.That(() => Slice.Random(rng, -1), Throws.InstanceOf<ArgumentOutOfRangeException>());
 		}
 
@@ -252,7 +252,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 
 			Assert.That(Slice.Random(rng, 0), Is.EqualTo(Slice.Empty));
 			// ReSharper disable once AssignNullToNotNullAttribute
-			Assert.That(() => Slice.Random(default(System.Security.Cryptography.RandomNumberGenerator), 16), Throws.ArgumentNullException);
+			Assert.That(() => Slice.Random(default(System.Security.Cryptography.RandomNumberGenerator)!, 16), Throws.ArgumentNullException);
 			Assert.That(() => Slice.Random(rng, -1), Throws.InstanceOf<ArgumentException>());
 		}
 
@@ -260,7 +260,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		public void Test_Slice_FromStringAscii()
 		{
 			Assert.That(Slice.FromStringAscii(default(string)).GetBytes(), Is.Null);
-			Assert.That(Slice.FromStringAscii(string.Empty).GetBytes(), Is.EqualTo(new byte[0]));
+			Assert.That(Slice.FromStringAscii(string.Empty).GetBytes(), Is.EqualTo(Array.Empty<byte>()));
 			Assert.That(Slice.FromStringAscii("A").GetBytes(), Is.EqualTo(new byte[] { 0x41 }));
 			Assert.That(Slice.FromStringAscii("AB").GetBytes(), Is.EqualTo(new byte[] { 0x41, 0x42 }));
 			Assert.That(Slice.FromStringAscii("ABC").GetBytes(), Is.EqualTo(new byte[] { 0x41, 0x42, 0x43 }));
@@ -450,9 +450,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 
 			// 128 and above is multi-byte UTF-8
 			Assert.That(Slice.FromChar('\x80').GetBytes(), Is.EqualTo(new byte[] { 0xC2, 0x80 }));
-			Assert.That(Slice.FromChar('é').GetBytes(), Is.EqualTo(new byte[] { 0xC3, 0xA9 }));
-			Assert.That(Slice.FromChar('\u221E').GetBytes(), Is.EqualTo(new byte[] { 0xE2, 0x88, 0x9E }));
-			Assert.That(Slice.FromChar('\uFFFE').GetBytes(), Is.EqualTo(new byte[] { 0xEF, 0xBF, 0xBE}));
+			Assert.That(Slice.FromChar('é').GetBytes(), Is.EqualTo("é"u8.ToArray()));
+			Assert.That(Slice.FromChar('\u221E').GetBytes(), Is.EqualTo("\u221e"u8.ToArray()));
+			Assert.That(Slice.FromChar('\uFFFE').GetBytes(), Is.EqualTo("\ufffe"u8.ToArray()));
 		}
 
 		#region Signed...
@@ -468,7 +468,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 
 			void Verify(short value, string expected)
 			{
-				Assert.That(Slice.FromInt16(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromInt16(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12, "12");
@@ -533,9 +533,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 32-bit integers should be encoded in little endian, and with 1, 2 or 4 bytes
 
-			void Verify(short value, string expected)
+			static void Verify(short value, string expected)
 			{
-				Assert.That(Slice.FromInt16BE(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromInt16BE(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12, "12");
@@ -661,9 +661,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 32-bit integers should be encoded in little endian, and with 1, 2 or 4 bytes
 
-			void Verify(int value, string expected)
+			static void Verify(int value, string expected)
 			{
-				Assert.That(Slice.FromInt32(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromInt32(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12, "12");
@@ -744,9 +744,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 32-bit integers should be encoded in little endian, and with 1, 2 or 4 bytes
 
-			void Verify(int value, string expected)
+			static void Verify(int value, string expected)
 			{
-				Assert.That(Slice.FromInt32BE(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromInt32BE(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12, "12");
@@ -831,9 +831,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 64-bit integers should be encoded in little endian, and with 1, 2, 4 or 8 bytes
 
-			void Verify(long value, string expected)
+			static void Verify(long value, string expected)
 			{
-				Assert.That(Slice.FromInt64(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromInt64(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12, "12");
@@ -866,9 +866,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// FromFixed64 always produce 8 bytes and uses Little Endian
 
-			void Verify(long value, byte[] expected)
+			static void Verify(long value, byte[] expected)
 			{
-				Assert.That(Slice.FromFixed64(value).GetBytes(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromFixed64(value).GetBytes(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0L, new byte[8]);
@@ -935,7 +935,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			var x = new byte[] { 0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12 }.AsSlice();
 			Assert.That(() => MutateOffset(x, -1).ToInt64(), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(x, 9).ToInt64(), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(x, null).ToInt64(), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(x, null!).ToInt64(), Throws.InstanceOf<FormatException>());
 		}
 
 		#endregion
@@ -947,9 +947,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 64-bit integers should be encoded in little endian, and with 1, 2, 4 or 8 bytes
 
-			void Verify(long value, string expected)
+			static void Verify(long value, string expected)
 			{
-				Assert.That(Slice.FromInt64BE(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromInt64BE(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12, "12");
@@ -998,9 +998,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// FromFixed64 always produce 8 bytes and uses Little Endian
 
-			void Verify(long value, byte[] expected)
+			static void Verify(long value, byte[] expected)
 			{
-				Assert.That(Slice.FromFixed64BE(value).GetBytes(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromFixed64BE(value).GetBytes(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0L, new byte[8]);
@@ -1067,7 +1067,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			var x = new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0 }.AsSlice();
 			Assert.That(() => MutateOffset(x, -1).ToInt64BE(), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(x, 9).ToInt64BE(), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(x, null).ToInt64BE(), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(x, null!).ToInt64BE(), Throws.InstanceOf<FormatException>());
 		}
 
 		#endregion
@@ -1087,9 +1087,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 32-bit integers should be encoded in little endian, and with 1, 2 or 4 bytes
 
-			void Verify(uint value, string expected)
+			static void Verify(uint value, string expected)
 			{
-				Assert.That(Slice.FromUInt32(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromUInt32(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12, "12");
@@ -1112,9 +1112,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// FromFixed32 always produce 4 bytes and uses Little Endian
 
-			void Verify(uint value, byte[] expected)
+			static void Verify(uint value, byte[] expected)
 			{
-				Assert.That(Slice.FromFixedU32(value).GetBytes(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromFixedU32(value).GetBytes(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0, new byte[4]);
@@ -1169,9 +1169,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 32-bit integers should be encoded in big endian, and with 1, 2 or 4 bytes
 
-			void Verify(uint value, string expected)
+			static void Verify(uint value, string expected)
 			{
-				Assert.That(Slice.FromUInt32BE(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromUInt32BE(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12, "12");
@@ -1194,9 +1194,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// FromFixedU32BE always produce 4 bytes and uses Big Endian
 
-			void Verify(uint value, byte[] expected)
+			static void Verify(uint value, byte[] expected)
 			{
-				Assert.That(Slice.FromFixedU32BE(value).GetBytes(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromFixedU32BE(value).GetBytes(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0, new byte[4]);
@@ -1253,9 +1253,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 64-bit integers should be encoded in little endian, and with 1, 2, 4 or 8 bytes
 
-			void Verify(ulong value, string expected)
+			static void Verify(ulong value, string expected)
 			{
-				Assert.That(Slice.FromUInt64(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromUInt64(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12UL, "12");
@@ -1288,9 +1288,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// FromFixed64 always produce 8 bytes and uses Little Endian
 
-			void Verify(ulong value, byte[] expected)
+			static void Verify(ulong value, byte[] expected)
 			{
-				Assert.That(Slice.FromFixedU64(value).GetBytes(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromFixedU64(value).GetBytes(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0UL, new byte[8]);
@@ -1353,7 +1353,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			var x = new byte[] { 0x78, 0x56, 0x34, 0x12 }.AsSlice();
 			Assert.That(() => MutateOffset(x, -1).ToUInt64(), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(x, 5).ToUInt64(), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(x, null).ToUInt64(), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(x, null!).ToUInt64(), Throws.InstanceOf<FormatException>());
 		}
 
 		[Test]
@@ -1361,9 +1361,9 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// 64-bit integers should be encoded in big endian, and using from 1 to 8 bytes
 
-			void Verify(ulong value, string expected)
+			static void Verify(ulong value, string expected)
 			{
-				Assert.That(Slice.FromUInt64BE(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromUInt64BE(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0x12UL, "12");
@@ -1398,7 +1398,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 
 			void Verify(ulong value, byte[] expected)
 			{
-				Assert.That(Slice.FromFixedU64BE(value).GetBytes(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromFixedU64BE(value).GetBytes(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0UL, new byte[8]);
@@ -1461,7 +1461,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			var x = new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0 }.AsSlice();
 			Assert.That(() => MutateOffset(x, -1).ToUInt64BE(), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(x, 9).ToUInt64BE(), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(x, null).ToUInt64BE(), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(x, null!).ToUInt64BE(), Throws.InstanceOf<FormatException>());
 		}
 
 		#endregion
@@ -1485,10 +1485,10 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		[Test]
 		public void Test_Slice_FromSingle()
 		{
-			void Verify(float value, string expected)
+			static void Verify(float value, string expected)
 			{
-				Assert.That(Slice.FromSingle(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0} (Little Endian)", value);
-				Assert.That(Slice.FromSingleBE(value).ToHexaString(), Is.EqualTo(SwapHexa(expected)), "Invalid encoding for {0} (Big Endian)", value);
+				Assert.That(Slice.FromSingle(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value} (Little Endian)");
+				Assert.That(Slice.FromSingleBE(value).ToHexaString(), Is.EqualTo(SwapHexa(expected)), $"Invalid encoding for {value} (Big Endian)");
 			}
 
 			Verify(0f, "00000000");
@@ -1545,10 +1545,10 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		[Test]
 		public void Test_Slice_FromDouble()
 		{
-			void Verify(double value, string expected)
+			static void Verify(double value, string expected)
 			{
-				Assert.That(Slice.FromDouble(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0} (Little Endian)", value);
-				Assert.That(Slice.FromDoubleBE(value).ToHexaString(), Is.EqualTo(SwapHexa(expected)), "Invalid encoding for {0} (Big Endian)", value);
+				Assert.That(Slice.FromDouble(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value} (Little Endian)");
+				Assert.That(Slice.FromDoubleBE(value).ToHexaString(), Is.EqualTo(SwapHexa(expected)), $"Invalid encoding for {value} (Big Endian)");
 			}
 
 			Verify(0d, "0000000000000000");
@@ -1608,7 +1608,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			void Verify(decimal value, string expected)
 			{
-				Assert.That(Slice.FromDecimal(value).ToHexaString(), Is.EqualTo(expected), "Invalid encoding for {0}", value);
+				Assert.That(Slice.FromDecimal(value).ToHexaString(), Is.EqualTo(expected), $"Invalid encoding for {value}");
 			}
 
 			Verify(0m, "00000000000000000000000000000000");
@@ -1707,7 +1707,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			var x = Slice.FromGuid(guid);
 			Assert.That(() => MutateOffset(x, -1).ToGuid(), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(x, 17).ToGuid(), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(x, null).ToGuid(), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(x, null!).ToGuid(), Throws.InstanceOf<FormatException>());
 
 		}
 
@@ -1762,7 +1762,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			var x = Slice.FromUuid128(uuid);
 			Assert.That(() => MutateOffset(x, -1).ToUuid128(), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(x, 17).ToUuid128(), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(x, null).ToUuid128(), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(x, null!).ToUuid128(), Throws.InstanceOf<FormatException>());
 		}
 
 		[Test]
@@ -1815,7 +1815,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			var x = Slice.FromUuid64(uuid);
 			Assert.That(() => MutateOffset(x, -1).ToUuid64(), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(x, 9).ToUuid64(), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(x, null).ToUuid64(), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(x, null!).ToUuid64(), Throws.InstanceOf<FormatException>());
 		}
 
 		#endregion
@@ -1824,7 +1824,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		public void Test_Slice_FromBase64()
 		{
 			// null string is Nil slice
-			var slice = Slice.FromBase64(default(string));
+			var slice = Slice.FromBase64(default(string)!);
 			Assert.That(slice, Is.EqualTo(Slice.Nil));
 
 			// empty string is empty slice
@@ -2008,13 +2008,13 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			// argument should be validated
 			Assert.That(() => good.Equals(MutateOffset(evil, -1)), Throws.InstanceOf<FormatException>());
 			Assert.That(() => good.Equals(MutateCount(evil, 666)), Throws.InstanceOf<FormatException>());
-			Assert.That(() => good.Equals(MutateArray(evil, null)), Throws.InstanceOf<FormatException>());
+			Assert.That(() => good.Equals(MutateArray(evil, null!)), Throws.InstanceOf<FormatException>());
 			Assert.That(() => good.Equals(MutateOffset(MutateCount(evil, 5), -1)), Throws.InstanceOf<FormatException>());
 
 			// instance should also be validated
 			Assert.That(() => MutateOffset(evil, -1).Equals(good), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(evil, 666).Equals(good), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(evil, null).Equals(good), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(evil, null!).Equals(good), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateOffset(MutateCount(evil, 5), -1).Equals(good), Throws.InstanceOf<FormatException>());
 		}
 
@@ -2041,7 +2041,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			var x = Slice.FromString("evil");
 			Assert.That(() => MutateOffset(x, -1).GetHashCode(), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(x, 17).GetHashCode(), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(x, null).GetHashCode(), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(x, null!).GetHashCode(), Throws.InstanceOf<FormatException>());
 		}
 
 		[Test]
@@ -2151,13 +2151,13 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			// argument should be validated
 			Assert.That(() => good.CompareTo(MutateOffset(evil, -1)), Throws.InstanceOf<FormatException>());
 			Assert.That(() => good.CompareTo(MutateCount(evil, 666)), Throws.InstanceOf<FormatException>());
-			Assert.That(() => good.CompareTo(MutateArray(evil, null)), Throws.InstanceOf<FormatException>());
+			Assert.That(() => good.CompareTo(MutateArray(evil, null!)), Throws.InstanceOf<FormatException>());
 			Assert.That(() => good.CompareTo(MutateOffset(MutateCount(evil, 5), -1)), Throws.InstanceOf<FormatException>());
 
 			// instance should also be validated
 			Assert.That(() => MutateOffset(evil, -1).CompareTo(good), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateCount(evil, 666).CompareTo(good), Throws.InstanceOf<FormatException>());
-			Assert.That(() => MutateArray(evil, null).CompareTo(good), Throws.InstanceOf<FormatException>());
+			Assert.That(() => MutateArray(evil, null!).CompareTo(good), Throws.InstanceOf<FormatException>());
 			Assert.That(() => MutateOffset(MutateCount(evil, 5), -1).CompareTo(good), Throws.InstanceOf<FormatException>());
 		}
 
@@ -2180,7 +2180,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(slice.ToUnicode(), Is.EqualTo(UNICODE_TEXT));
 
 			// ReSharper disable once AssignNullToNotNullAttribute
-			Assert.That(() => Slice.FromStream(null), Throws.ArgumentNullException, "Should throw if null");
+			Assert.That(() => Slice.FromStream(null!), Throws.ArgumentNullException, "Should throw if null");
 			Assert.That(Slice.FromStream(Stream.Null), Is.EqualTo(Slice.Nil), "Stream.Null should return Slice.Nil");
 
 			using(var ms = new MemoryStream())
@@ -2432,7 +2432,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(joined, Is.Not.Null);
 			Assert.That(joined.Length, Is.EqualTo(0));
 
-			joined = Slice.JoinBytes(sep, new Slice[0], 0, 0);
+			joined = Slice.JoinBytes(sep, Array.Empty<Slice>(), 0, 0);
 			Assert.That(joined, Is.Not.Null);
 			Assert.That(joined.Length, Is.EqualTo(0));
 
@@ -2441,8 +2441,8 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(joined.Length, Is.EqualTo(0));
 
 			// ReSharper disable AssignNullToNotNullAttribute
-			Assert.That(() => Slice.JoinBytes(sep, default(Slice[]), 0, 0), Throws.ArgumentNullException);
-			Assert.That(() => Slice.JoinBytes(sep, default(IEnumerable<Slice>)), Throws.ArgumentNullException);
+			Assert.That(() => Slice.JoinBytes(sep, default(Slice[])!, 0, 0), Throws.ArgumentNullException);
+			Assert.That(() => Slice.JoinBytes(sep, default(IEnumerable<Slice>)!), Throws.ArgumentNullException);
 			// ReSharper restore AssignNullToNotNullAttribute
 
 			Assert.That(() => Slice.JoinBytes(sep, tokens, 0, 4), Throws.InstanceOf<ArgumentOutOfRangeException>());
@@ -2470,11 +2470,11 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			// edge cases
 			// > should behave the same as String.Split()
 			Assert.That(Slice.Empty.Split(comma, StringSplitOptions.None), Is.EqualTo(new [] { Slice.Empty }));
-			Assert.That(Slice.Empty.Split(comma, StringSplitOptions.RemoveEmptyEntries), Is.EqualTo(new Slice[0]));
+			Assert.That(Slice.Empty.Split(comma, StringSplitOptions.RemoveEmptyEntries), Is.EqualTo(Array.Empty<Slice>()));
 			Assert.That(Value("A,").Split(comma, StringSplitOptions.None), Is.EqualTo(new[] { a, Slice.Empty }));
 			Assert.That(Value("A,").Split(comma, StringSplitOptions.RemoveEmptyEntries), Is.EqualTo(new [] { a }));
-			Assert.That(Value(",").Split(comma, StringSplitOptions.RemoveEmptyEntries), Is.EqualTo(new Slice[0]));
-			Assert.That(Value(",,,").Split(comma, StringSplitOptions.RemoveEmptyEntries), Is.EqualTo(new Slice[0]));
+			Assert.That(Value(",").Split(comma, StringSplitOptions.RemoveEmptyEntries), Is.EqualTo(Array.Empty<Slice>()));
+			Assert.That(Value(",,,").Split(comma, StringSplitOptions.RemoveEmptyEntries), Is.EqualTo(Array.Empty<Slice>()));
 
 			// multi-bytes separator with an offset
 			var sep = Value("!<@>!").Substring(1, 3);
@@ -2618,7 +2618,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// Don't try this at home !
 			object tmp = value;
-			typeof(Slice).GetField("Offset").SetValue(tmp, offset);
+			typeof(Slice).GetField("Offset")!.SetValue(tmp, offset);
 			return (Slice) tmp;
 		}
 
@@ -2626,7 +2626,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// Don't try this at home !
 			object tmp = value;
-			typeof(Slice).GetField("Offset").SetValue(tmp, offset);
+			typeof(Slice).GetField("Offset")!.SetValue(tmp, offset);
 			return (Slice) tmp;
 		}
 
@@ -2634,7 +2634,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		{
 			// Don't try this at home !
 			object tmp = value;
-			typeof(Slice).GetField("Array").SetValue(tmp, array);
+			typeof(Slice).GetField("Array")!.SetValue(tmp, array);
 			return (Slice) tmp;
 		}
 

--- a/Doxense.Core.Tests/Memory/SliceWriterFacts.cs
+++ b/Doxense.Core.Tests/Memory/SliceWriterFacts.cs
@@ -50,7 +50,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 
 		private delegate void TestHandler<in T>(ref SliceWriter writer, T value);
 
-		private static void PerformWriterTest<T>(TestHandler<T> action, [AllowNull] T value, string expectedResult, string? message = null)
+		private static void PerformWriterTest<T>(TestHandler<T?> action, T? value, string expectedResult, string? message = null)
 		{
 			var writer = default(SliceWriter);
 			action(ref writer, value);
@@ -58,10 +58,7 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 			Assert.That(
 				writer.ToSlice().ToHexaString(' '),
 				Is.EqualTo(expectedResult),
-				"Value {0} ({1}) was not properly packed. {2}",
-				value == null ? "<null>" : value is string s ? Clean(s) : value.ToString(),
-				value == null ? "null" : value.GetType().Name,
-				message
+				$"Value {(value == null ? "<null>" : value is string s ? Clean(s) : value.ToString())} ({(value == null ? "null" : value.GetType().Name)}) was not properly packed. {message}"
 			);
 		}
 
@@ -79,10 +76,10 @@ namespace Doxense.Slices.Tests //IMPORTANT: don't rename or else we loose all pe
 		public void Test_WriteBytes()
 		{
 			{
-				static void Test(ref SliceWriter writer, byte[] value) => writer.WriteBytes(value);
+				static void Test(ref SliceWriter writer, byte[]? value) => writer.WriteBytes(value);
 
-				PerformWriterTest((TestHandler<byte[]>) Test, null, "");
-				PerformWriterTest(Test, new byte[0], "");
+				PerformWriterTest(Test, default(byte[]), "");
+				PerformWriterTest(Test, Array.Empty<byte>(), "");
 				PerformWriterTest(Test, new byte[] {66}, "42");
 				PerformWriterTest(Test, new byte[] {65, 66, 67}, "41 42 43");
 			}

--- a/Doxense.Core.Tests/Memory/UnsafeHelpersFacts.cs
+++ b/Doxense.Core.Tests/Memory/UnsafeHelpersFacts.cs
@@ -54,7 +54,7 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 			byte* stop = ptr + count;
 			while (ptr < stop)
 			{
-				if (*ptr != b) Assert.That(*ptr, Is.EqualTo(b), "Unexpected byte at offset {0}", ptr - buffer);
+				if (*ptr != b) Assert.That(*ptr, Is.EqualTo(b), $"Unexpected byte at offset {ptr - buffer}");
 				ptr++;
 			}
 		}
@@ -221,12 +221,12 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 
 					ushort decoded;
 					ptr2 = UnsafeHelpers.ReadVarint16(ptr, ptr + data.Length, out decoded);
-					Assert.That(ptr2 - ptr, Is.EqualTo(size), "Read({0} => {1}) size", value, expected);
-					Assert.That(decoded, Is.EqualTo(value), "Read({0} => {1}) value", value, expected);
+					Assert.That(ptr2 - ptr, Is.EqualTo(size), $"Read({value} => {expected}) size");
+					Assert.That(decoded, Is.EqualTo(value), $"Read({value} => {expected}) value");
 
 					ptr2 = UnsafeHelpers.ReadVarint16Unsafe(ptr, out decoded);
-					Assert.That(ptr2 - ptr, Is.EqualTo(size), "ReadUnsafe({0} => {1}) size", value, expected);
-					Assert.That(decoded, Is.EqualTo(value), "ReadUnsafe({0} => {1}) value", value, expected);
+					Assert.That(ptr2 - ptr, Is.EqualTo(size), $"ReadUnsafe({value} => {expected}) size");
+					Assert.That(decoded, Is.EqualTo(value), $"ReadUnsafe({value} => {expected}) value");
 
 					Wipe(data);
 					ptr2 = UnsafeHelpers.WriteVarInt16(ptr, ptr + size, value);
@@ -269,12 +269,12 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 
 					uint decoded;
 					ptr2 = UnsafeHelpers.ReadVarint32(ptr, ptr + data.Length, out decoded);
-					Assert.That(ptr2 - ptr, Is.EqualTo(size), "Read({0} => {1}) size", value, expected);
-					Assert.That(decoded, Is.EqualTo(value), "Read({0} => {1}) value", value, expected);
+					Assert.That(ptr2 - ptr, Is.EqualTo(size), $"Read({value} => {expected}) size");
+					Assert.That(decoded, Is.EqualTo(value), $"Read({value} => {expected}) value");
 
 					ptr2 = UnsafeHelpers.ReadVarint32Unsafe(ptr, out decoded);
-					Assert.That(ptr2 - ptr, Is.EqualTo(size), "ReadUnsafe({0} => {1}) size", value, expected);
-					Assert.That(decoded, Is.EqualTo(value), "ReadUnsafe({0} => {1}) value", value, expected);
+					Assert.That(ptr2 - ptr, Is.EqualTo(size), $"ReadUnsafe({value} => {expected}) size");
+					Assert.That(decoded, Is.EqualTo(value), $"ReadUnsafe({value} => {expected}) value");
 
 					Wipe(data);
 					ptr2 = UnsafeHelpers.WriteVarInt32(ptr, ptr + size, value);
@@ -325,12 +325,12 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 
 					ulong decoded;
 					ptr2 = UnsafeHelpers.ReadVarint64(ptr, ptr + data.Length, out decoded);
-					Assert.That(ptr2 - ptr, Is.EqualTo(size), "Read({0} => {1}) size", value, expected);
-					Assert.That(decoded, Is.EqualTo(value), "Read({0} => {1}) value", value, expected);
+					Assert.That(ptr2 - ptr, Is.EqualTo(size), $"Read({value} => {expected}) size");
+					Assert.That(decoded, Is.EqualTo(value), $"Read({value} => {expected}) value");
 
 					ptr2 = UnsafeHelpers.ReadVarint64Unsafe(ptr, out decoded);
-					Assert.That(ptr2 - ptr, Is.EqualTo(size), "ReadUnsafe({0} => {1}) size", value, expected);
-					Assert.That(decoded, Is.EqualTo(value), "ReadUnsafe({0} => {1}) value", value, expected);
+					Assert.That(ptr2 - ptr, Is.EqualTo(size), $"ReadUnsafe({value} => {expected}) size");
+					Assert.That(decoded, Is.EqualTo(value), $"ReadUnsafe({value} => {expected}) value");
 
 					Wipe(data);
 					ptr2 = UnsafeHelpers.WriteVarInt64(ptr, ptr + size, value);
@@ -902,7 +902,7 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 						var res = new ReadOnlySpan<byte>(ptr, (int)(c1 - ptr));
 						Log($"x = 1 << {k,2} {i:+ 0;- 0;'   '} = 0x{x:X8} = {x,10} => ({res.Length}) {res.ToString("X")}");
 						Assert.That(c1 - ptr, Is.GreaterThan(0).And.LessThanOrEqualTo(5), "Should emit between 1 and 5 bytes");
-						Assert.That(UnsafeHelpers.SizeOfOrderedUInt32(x), Is.EqualTo(res.Length), "SizeOf({0} does not match encoded size", x);
+						Assert.That(UnsafeHelpers.SizeOfOrderedUInt32(x), Is.EqualTo(res.Length), $"SizeOf({x}) does not match encoded size");
 
 						uint y;
 						byte* c2 = UnsafeHelpers.ReadOrderedUInt32Unsafe(ptr, out y);
@@ -924,7 +924,7 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 					byte* c1 = UnsafeHelpers.WriteOrderedUInt32Unsafe(ptr, x);
 					var res = new ReadOnlySpan<byte>(ptr, (int)(c1 - ptr));
 					Assert.That(c1 - ptr, Is.GreaterThan(0).And.LessThanOrEqualTo(5), "Should emit between 1 and 5 bytes");
-					Assert.That(UnsafeHelpers.SizeOfOrderedUInt32(x), Is.EqualTo(res.Length), "SizeOf({0} does not match encoded size", x);
+					Assert.That(UnsafeHelpers.SizeOfOrderedUInt32(x), Is.EqualTo(res.Length), $"SizeOf({x} does not match encoded size");
 
 					// read it back
 					uint y;
@@ -935,7 +935,7 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 
 					// should be > the previous one
 					string s = res.ToString("X");
-					if (prev != null) Assert.That(s, Is.GreaterThan(prev), "Encoded({0}) should be greater than Encoded({1})", x, xs[i - 1]);
+					if (prev != null) Assert.That(s, Is.GreaterThan(prev), $"Encoded({x}) should be greater than Encoded({xs[i - 1]})");
 					prev = s;
 				}
 			}
@@ -960,7 +960,7 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 						var res = new ReadOnlySpan<byte>(ptr, (int)(c1 - ptr));
 						Log($"x = 1 << {k,2} {i:+ 0;- 0;'   '} = 0x{x:X16} = {x,19} => ({res.Length}) {res.ToString("X")}");
 						Assert.That(c1 - ptr, Is.GreaterThan(0).And.LessThanOrEqualTo(8), "Should emit between 1 and 8 bytes");
-						Assert.That(UnsafeHelpers.SizeOfOrderedUInt64(x), Is.EqualTo(res.Length), "SizeOf({0} does not match encoded size", x);
+						Assert.That(UnsafeHelpers.SizeOfOrderedUInt64(x), Is.EqualTo(res.Length), $"SizeOf({x}) does not match encoded size");
 
 						ulong y;
 						byte* c2 = UnsafeHelpers.ReadOrderedUInt64Unsafe(ptr, out y);
@@ -982,7 +982,7 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 					byte* c1 = UnsafeHelpers.WriteOrderedUInt64Unsafe(ptr, x);
 					var res = new ReadOnlySpan<byte>(ptr, (int) (c1 - ptr));
 					Assert.That(c1 - ptr, Is.GreaterThan(0).And.LessThanOrEqualTo(8), "Should emit between 1 and 8 bytes");
-					Assert.That(UnsafeHelpers.SizeOfOrderedUInt64(x), Is.EqualTo(res.Length), "SizeOf({0} does not match encoded size", x);
+					Assert.That(UnsafeHelpers.SizeOfOrderedUInt64(x), Is.EqualTo(res.Length), $"SizeOf({x}) does not match encoded size");
 
 					// read it back
 					ulong y;
@@ -993,7 +993,7 @@ namespace Doxense.Unsafe.Tests //IMPORTANT: don't rename or else we loose all pe
 
 					// should be > the previous one
 					string s = res.ToString("X");
-					if (prev != null) Assert.That(s, Is.GreaterThan(prev), "Encoded({0}) should be greater than Encoded({1})", x, xs[i - 1]);
+					if (prev != null) Assert.That(s, Is.GreaterThan(prev), $"Encoded({x}) should be greater than Encoded({xs[i - 1]})");
 					prev = s;
 				}
 			}

--- a/Doxense.Core.Tests/Monads/MaybeTest.cs
+++ b/Doxense.Core.Tests/Monads/MaybeTest.cs
@@ -92,17 +92,17 @@ namespace Doxense.Monads.Tests
 					{
 						if (i == j)
 						{
-							Assert.That(ms[i].Equals(ms[j]), Is.True, "{0}.Equals({1})", ms[i], ms[j]);
-							Assert.That(ms[i] == ms[j], Is.True, "{0} ==  {1}", ms[i], ms[j]);
-							Assert.That(ms[i] != ms[j], Is.False, "{0} !=  {1}", ms[i], ms[j]);
-							Assert.That(ms[i].Equals((object) ms[j]), Is.True, "{0}.Equals((object) {1})", ms[i], ms[j]);
+							Assert.That(ms[i].Equals(ms[j]), Is.True, $"{ms[i]}.Equals({ms[j]})");
+							Assert.That(ms[i] == ms[j], Is.True, $"{ms[i]} ==  {ms[j]}");
+							Assert.That(ms[i] != ms[j], Is.False, $"{ms[i]} !=  {ms[j]}");
+							Assert.That(ms[i].Equals((object) ms[j]), Is.True, $"{ms[i]}.Equals((object) {ms[j]})");
 						}
 						else
 						{
-							Assert.That(ms[i].Equals(ms[j]), Is.False, "{0}.Equals({1})", ms[i], ms[j]);
-							Assert.That(ms[i] == ms[j], Is.False, "{0} ==  {1}", ms[i], ms[j]);
-							Assert.That(ms[i] != ms[j], Is.True, "{0} !=  {1}", ms[i], ms[j]);
-							Assert.That(ms[i].Equals((object) ms[j]), Is.False, "{0}.Equals((object) {1})", ms[i], ms[j]);
+							Assert.That(ms[i].Equals(ms[j]), Is.False, $"{ms[i]}.Equals({1})");
+							Assert.That(ms[i] == ms[j], Is.False, $"{ms[i]} ==  {ms[j]}");
+							Assert.That(ms[i] != ms[j], Is.True, $"{ms[i]} !=  {ms[j]}");
+							Assert.That(ms[i].Equals((object) ms[j]), Is.False, $"{ms[i]}.Equals((object) {ms[j]})");
 						}
 					}
 				}
@@ -144,15 +144,15 @@ namespace Doxense.Monads.Tests
 						int cmp = ms[i].CompareTo(ms[j]);
 						if (i == j)
 						{
-							Assert.That(cmp, Is.Zero, "{0} cmp {1}", ms[i], ms[j]);
+							Assert.That(cmp, Is.Zero, $"{ms[i]} cmp {ms[j]}");
 						}
 						else if (i < j)
 						{
-							Assert.That(cmp, Is.Negative, "{0} cmp {1}", ms[i], ms[j]);
+							Assert.That(cmp, Is.Negative, $"{ms[i]} cmp {ms[j]}");
 						}
 						else
 						{
-							Assert.That(cmp, Is.GreaterThan(0), "{0} cmp {1}", ms[i], ms[j]);
+							Assert.That(cmp, Is.GreaterThan(0), $"{ms[i]} cmp {ms[j]}");
 						}
 					}
 				}
@@ -191,9 +191,9 @@ namespace Doxense.Monads.Tests
 			Assert.That(m.HasValue, Is.False);
 			Assert.That(m.Error, Is.Null);
 
-			m = f(new Exception("KABOOM"));
+			m = f(new InvalidOperationException("KABOOM"));
 			Assert.That(m.HasValue, Is.False);
-			Assert.IsInstanceOf<Exception>(m.Error);
+			Assert.That(m.Error, Is.InstanceOf<InvalidOperationException>());
 			Assert.That(m.Error.Message, Is.EqualTo("KABOOM"));
 		}
 
@@ -265,7 +265,7 @@ namespace Doxense.Monads.Tests
 
 			var safeSqrt = Maybe<double>.Bind((x) =>
 			{
-				Console.WriteLine("safeSqrt(" + x + ")");
+				//Console.WriteLine("safeSqrt(" + x + ")");
 				if (double.IsNaN(x) || x < 0) return Maybe<double>.Nothing;
 				return Math.Sqrt(x);
 			});
@@ -282,9 +282,9 @@ namespace Doxense.Monads.Tests
 			m = safeSqrt(Maybe<double>.Nothing);
 			Assert.That(m.HasValue, Is.False);
 
-			m = safeSqrt(Maybe<double>.Failure(new Exception("PAF")));
+			m = safeSqrt(Maybe<double>.Failure(new InvalidOperationException("PAF")));
 			Assert.That(m.HasValue, Is.False);
-			Assert.IsInstanceOf<Exception>(m.Error);
+			Assert.That(m.Error, Is.InstanceOf<InvalidOperationException>());
 
 		}
 
@@ -293,7 +293,7 @@ namespace Doxense.Monads.Tests
 		{
 			var safeDivide = Maybe<int>.Bind((x, y) =>
 			{
-				Console.WriteLine("safeDivide(" + x + ", " + y + ")");
+				//Console.WriteLine("safeDivide(" + x + ", " + y + ")");
 				if (y == 0) return Maybe<int>.Nothing;
 				return x / y;
 			});
@@ -311,13 +311,13 @@ namespace Doxense.Monads.Tests
 			m = safeDivide(3, Maybe<int>.Nothing);
 			Assert.That(m.HasValue, Is.False);
 
-			m = safeDivide(3, new Exception("BOOM"));
+			m = safeDivide(3, new InvalidOperationException("BOOM"));
 			Assert.That(m.HasValue, Is.False);
-			Assert.IsInstanceOf<Exception>(m.Error);
+			Assert.That(m.Error, Is.InstanceOf<InvalidOperationException>());
 
-			m = safeDivide(new Exception("POW"), 2);
+			m = safeDivide(new InvalidOperationException("POW"), 2);
 			Assert.That(m.HasValue, Is.False);
-			Assert.IsInstanceOf<Exception>(m.Error);
+			Assert.That(m.Error, Is.InstanceOf<InvalidOperationException>());
 		}
 
 		[Test]
@@ -350,7 +350,7 @@ namespace Doxense.Monads.Tests
 
 			m = combined(new Exception("KABOOM"));
 			Assert.That(m.HasValue, Is.False);
-			Assert.IsInstanceOf<Exception>(m.Error);
+			Assert.That(m.Error, Is.InstanceOf<Exception>());
 			Assert.That(m.Error.Message, Is.EqualTo("KABOOM"));
 
 			// première fonction intercepte...
@@ -360,7 +360,7 @@ namespace Doxense.Monads.Tests
 
 			m = combined(666);
 			Assert.That(m.HasValue, Is.False);
-			Assert.IsInstanceOf<Exception>(m.Error);
+			Assert.That(m.Error, Is.InstanceOf<InvalidOperationException>());
 			Assert.That(m.Error.Message, Is.EqualTo("F"));
 
 			// deuxième fonction intercepte
@@ -370,7 +370,7 @@ namespace Doxense.Monads.Tests
 
 			m = combined(666 * 666);
 			Assert.That(m.HasValue, Is.False);
-			Assert.IsInstanceOf<Exception>(m.Error);
+			Assert.That(m.Error, Is.InstanceOf<Exception>());
 			Assert.That(m.Error.Message, Is.EqualTo("G"));
 
 		}

--- a/Doxense.Core.Tests/Runtime/Comparison/ModelComparerFacts.cs
+++ b/Doxense.Core.Tests/Runtime/Comparison/ModelComparerFacts.cs
@@ -42,7 +42,7 @@ namespace Doxense.Runtime.Comparison.Tests
 			{
 				Dump("LEFT", left);
 				Dump("RIGHT", right);
-				Assert.Fail("{0}: Left and Right {1} should be equal, but were found to be different!", label, typeof(T).Name);
+				Assert.Fail($"{label}: Left and Right {typeof(T).Name} should be equal, but were found to be different!");
 			}
 		}
 
@@ -52,14 +52,14 @@ namespace Doxense.Runtime.Comparison.Tests
 			{
 				Dump("LEFT", left);
 				Dump("RIGHT", right);
-				Assert.Fail("{0}: Left and Right {1} should be different, but were found to be equal!", label, typeof(T).Name);
+				Assert.Fail($"{label}: Left and Right {typeof(T).Name} should be different, but were found to be equal!");
 			}
 		}
 
 		[Test]
 		public void Test_Compare_Sealed_Model()
 		{
-			var cmp = ModelComparer.Comparer<SaMereModel>.Default;
+			var cmp = ModelComparer.Comparer<SomeGenericSealedModel?>.Default;
 			Assert.That(cmp, Is.Not.Null);
 
 			EnsureEqual(
@@ -69,7 +69,7 @@ namespace Doxense.Runtime.Comparison.Tests
 				null
 			);
 
-			var a = new SaMereModel
+			var a = new SomeGenericSealedModel
 			{
 				String = "Hello",
 				Int32 = 123,
@@ -96,7 +96,7 @@ namespace Doxense.Runtime.Comparison.Tests
 				null
 			);
 
-			var a2 = new SaMereModel
+			var a2 = new SomeGenericSealedModel
 			{
 				String = "Hello",
 				Int32 = 123,
@@ -117,7 +117,7 @@ namespace Doxense.Runtime.Comparison.Tests
 				a2
 			);
 
-			var b = new SaMereModel
+			var b = new SomeGenericSealedModel
 			{
 				String = "World",
 				Int32 = 123,
@@ -129,7 +129,7 @@ namespace Doxense.Runtime.Comparison.Tests
 				b
 			);
 
-			var c = new SaMereModel
+			var c = new SomeGenericSealedModel
 			{
 				String = "Hello",
 				Int32 = 456,
@@ -151,42 +151,42 @@ namespace Doxense.Runtime.Comparison.Tests
 		[Test]
 		public void Test_Compare_Abstract_Model()
 		{
-			var cmp = ModelComparer.Comparer<SaMereBase>.Default;
+			var cmp = ModelComparer.Comparer<SomeGenericBaseType?>.Default;
 			Assert.That(cmp, Is.Not.Null);
 
 			EnsureEqual("null == null", cmp, null, null);
 
-			var a = new SaMereEnShort
+			var a = new SomeGenericDerivedType
 			{
 				Foo = "a",
-				Short = "a"
+				Bar = "a"
 			};
 
 			EnsureEqual("A == A (same instance)", cmp, a, a);
 			EnsureDifferent("A != null", cmp, a, null);
 			EnsureDifferent("null != A", cmp, null, a);
 
-			var a2 = new SaMereEnShort
+			var a2 = new SomeGenericDerivedType
 			{
 				Foo = "a",
-				Short = "a"
+				Bar = "a"
 			};
 			EnsureEqual("A == A2 (same content)", cmp, a, a2);
 
 			a2.Foo = "aa";
 			EnsureDifferent("A != A2' (mutated)", cmp, a, a2);
 
-			var b = new SaMereEnShort
+			var b = new SomeGenericDerivedType
 			{
 				Foo = "a",
-				Short = "b"
+				Bar = "b"
 			};
 			EnsureDifferent("A != B (same type, but different content)", cmp, a, b);
 
-			var c = new SaMereEnBikini()
+			var c = new AnoterGenericDerivedType()
 			{
 				Foo = "a",
-				Bikini = "c"
+				Baz = "c"
 			};
 			EnsureDifferent("A != C (different types)", cmp, a, c);
 			EnsureDifferent("B != C (different types)", cmp, b, c);
@@ -214,21 +214,23 @@ namespace Doxense.Runtime.Comparison.Tests
 			EnsureEqual(
 				"[0] == [0] (different instances)",
 				cmp,
-				new ArrayModel { Items = new string[0] },
+				// ReSharper disable UseArrayEmptyMethod
+				new ArrayModel { Items = new string[0] }, //IMPORTANT: both arrays must be different instances!
 				new ArrayModel { Items = new string[0] }
+				// ReSharper restore UseArrayEmptyMethod
 			);
 
 			EnsureDifferent(
 				"[0] == null",
 				cmp,
 				new ArrayModel { Items = new string[0] },
-				new ArrayModel { Items = null }
+				new ArrayModel { Items = null! }
 			);
 
 			EnsureEqual(
 				"Same length and content",
 				cmp,
-				new ArrayModel { Items = new[] {"Hello", "World" } },
+				new ArrayModel { Items = new[] {"Hello", "World" } }, //IMPORTANT: both arrays must be different instances!
 				new ArrayModel { Items = new[] {"Hello", "World" } }
 			);
 
@@ -277,7 +279,7 @@ namespace Doxense.Runtime.Comparison.Tests
 				"[0] == null",
 				cmp,
 				new ListModel { Items = new List<string>() },
-				new ListModel { Items = null }
+				new ListModel { Items = null! }
 			);
 
 			EnsureEqual(
@@ -339,7 +341,7 @@ namespace Doxense.Runtime.Comparison.Tests
 				"[0] == null",
 				cmp,
 				new DictionaryModel { Items = new Dictionary<string, FooModel>() },
-				new DictionaryModel { Items = null }
+				new DictionaryModel { Items = null! }
 			);
 
 			EnsureEqual(
@@ -409,7 +411,7 @@ namespace Doxense.Runtime.Comparison.Tests
 				"[0] == null",
 				cmp,
 				new HashSetModel { Items = new HashSet<string>() },
-				new HashSetModel { Items = null }
+				new HashSetModel { Items = null! }
 			);
 
 			EnsureEqual(
@@ -460,7 +462,7 @@ namespace Doxense.Runtime.Comparison.Tests
 		[Test]
 		public void Test_HashCode_Sealed_Model()
 		{
-			var comparer = ModelComparer.Comparer<SimpleEntity>.Default;
+			var comparer = ModelComparer.Comparer<SimpleEntity?>.Default;
 			Assert.That(comparer, Is.Not.Null);
 
 			// le comparer est "null safe", et retourne toujours 0 dans ce cas
@@ -569,7 +571,7 @@ namespace Doxense.Runtime.Comparison.Tests
 	}
 
 	/// <summary>Exemple d'une classe Model qui est sealed, et contient quelques Nested Types (également sealed)</summary>
-	public sealed class SaMereModel
+	public sealed class SomeGenericSealedModel
 	{
 		public bool Bool { get; set; }
 
@@ -611,19 +613,19 @@ namespace Doxense.Runtime.Comparison.Tests
 
 	}
 
-	public abstract class SaMereBase
+	public abstract class SomeGenericBaseType
 	{
 		public string Foo { get; set; }
 	}
 
-	public sealed class SaMereEnShort : SaMereBase
+	public sealed class SomeGenericDerivedType : SomeGenericBaseType
 	{
-		public string Short { get; set; }
+		public string Bar { get; set; }
 	}
 
-	public sealed class SaMereEnBikini : SaMereBase
+	public sealed class AnoterGenericDerivedType : SomeGenericBaseType
 	{
-		public string Bikini { get; set; }
+		public string Baz { get; set; }
 	}
 
 }

--- a/Doxense.Core.Tests/Serialization/JSON/CrystalJson.cs
+++ b/Doxense.Core.Tests/Serialization/JSON/CrystalJson.cs
@@ -2227,7 +2227,7 @@ namespace Doxense.Serialization.Json.Tests
 			Assert.That(reloaded.Count, Is.EqualTo(list.Count));
 			for (int i = 0; i < list.Count; i++)
 			{
-				Assert.That(reloaded[i], Is.EqualTo(list[i]), "Mismatch at index {0}", i);
+				Assert.That(reloaded[i], Is.EqualTo(list[i]), $"Mismatch at index {i}");
 			}
 
 			{ // Compresse Deflate
@@ -3469,20 +3469,20 @@ namespace Doxense.Serialization.Json.Tests
 			// => on vérifie que le JsonNumber est capable de gérer correctement ce problème
 
 			double x = 7.5318246509562359d;
-			Assert.That((double)((decimal)x), Is.Not.EqualTo(x), "Check that {0:R} gets corrupted during roundtrip by the CLR", x);
+			Assert.That((double)((decimal)x), Is.Not.EqualTo(x), $"Check that {x:R} gets corrupted during roundtrip by the CLR");
 			Assert.That(JsonNumber.Return(x).ToString(), Is.EqualTo(x.ToString("R")));
-			Assert.That(((JsonNumber)CrystalJson.Parse("7.5318246509562359")).ToDouble(), Is.EqualTo(x), "Rounding Bug check: {0:R} should not change!", x);
+			Assert.That(((JsonNumber)CrystalJson.Parse("7.5318246509562359")).ToDouble(), Is.EqualTo(x), $"Rounding Bug check: {x:R} should not change!");
 
 			x = 3.8219629199346357;
-			Assert.That((double)((decimal)x), Is.Not.EqualTo(x), "Check that {0:R} gets corrupted during roundtrip by the CLR", x);
+			Assert.That((double)((decimal)x), Is.Not.EqualTo(x), $"Check that {x:R} gets corrupted during roundtrip by the CLR");
 			Assert.That(JsonNumber.Return(x).ToString(), Is.EqualTo(x.ToString("R")));
-			Assert.That(((JsonNumber)CrystalJson.Parse("3.8219629199346357")).ToDouble(), Is.EqualTo(x), "Rounding Bug check: {0:R} should not change!", x);
+			Assert.That(((JsonNumber)CrystalJson.Parse("3.8219629199346357")).ToDouble(), Is.EqualTo(x), $"Rounding Bug check: {x:R} should not change!");
 
 			// meme problème avec les float !
 			float y = 7.53182459f;
-			Assert.That((float)((decimal)y), Is.Not.EqualTo(y), "Check that {0:R} gets corrupted during roundtrip by the CLR", y);
+			Assert.That((float)((decimal)y), Is.Not.EqualTo(y), $"Check that {y:R} gets corrupted during roundtrip by the CLR");
 			Assert.That(JsonNumber.Return(y).ToString(), Is.EqualTo(y.ToString("R")));
-			Assert.That(((JsonNumber)CrystalJson.Parse("7.53182459")).ToSingle(), Is.EqualTo(y), "Rounding Bug check: {0:R}", y);
+			Assert.That(((JsonNumber)CrystalJson.Parse("7.53182459")).ToSingle(), Is.EqualTo(y), $"Rounding Bug check: {y:R}");
 		}
 
 		[Test]
@@ -3506,7 +3506,7 @@ namespace Doxense.Serialization.Json.Tests
 			Assert.That(arr[0].ToInt32(), Is.EqualTo(0));
 			for (int i = 1; i < arr.Count; i++)
 			{
-				Assert.That(arr[i], Is.SameAs(JsonNumber.Zero), "arr[{0}]", i);
+				Assert.That(arr[i], Is.SameAs(JsonNumber.Zero), $"arr[{i}]");
 			}
 
 			// liste
@@ -3516,7 +3516,7 @@ namespace Doxense.Serialization.Json.Tests
 			Assert.That(arr[0].ToInt64(), Is.EqualTo(0));
 			for (int i = 1; i < arr.Count; i++)
 			{
-				Assert.That(arr[i], Is.SameAs(arr[0]), "arr[{0}]", i);
+				Assert.That(arr[i], Is.SameAs(arr[0]), $"arr[{i}]");
 			}
 
 			// sequence
@@ -3525,7 +3525,7 @@ namespace Doxense.Serialization.Json.Tests
 			Assert.That(arr[0].ToUInt32(), Is.EqualTo(42U));
 			for (int i = 1; i < arr.Count; i++)
 			{
-				Assert.That(arr[i], Is.SameAs(arr[0]), "arr[{0}]", i);
+				Assert.That(arr[i], Is.SameAs(arr[0]), $"arr[{i}]");
 			}
 
 			// la même série de données convertie deux fois
@@ -3538,8 +3538,8 @@ namespace Doxense.Serialization.Json.Tests
 			Assert.That(arr2, Is.Not.Null.And.Count.EqualTo(t2.Length));
 			for (int i = 0; i < t1.Length; i++)
 			{
-				Assert.That(arr1[i], Is.SameAs(arr2[i]), "arr1[{0}] same as arr2[{0}]", i);
-				Assert.That(arr1[i].ToInt32(), Is.EqualTo(t1[i]), "arr1[{0}] == t1[{0}]", i);
+				Assert.That(arr1[i], Is.SameAs(arr2[i]), $"arr1[{i}] same as arr2[{i}]");
+				Assert.That(arr1[i].ToInt32(), Is.EqualTo(t1[i]), $"arr1[{i}] == t1[{i}]");
 			}
 
 		}
@@ -3818,10 +3818,10 @@ namespace Doxense.Serialization.Json.Tests
 			Assert.That(array.Count, Is.EqualTo(3));
 			for (int i = 0; i < array.Count; i++)
 			{
-				Assert.That(array[i], Is.Not.Null.And.InstanceOf<JsonObject>(), "[{0}]", i);
-				Assert.That(((JsonObject)array[i])["Id"], Is.EqualTo(JsonNumber.Return(i + 1)), "[{0}].Id", i);
-				Assert.That(((JsonObject)array[i])["Name"], Is.EqualTo(JsonString.Return((i + 1).ToString())), "[{0}].Name", i);
-				Assert.That(((JsonObject)array[i]).Count, Is.EqualTo(2), "[{0}] Count", i);
+				Assert.That(array[i], Is.Not.Null.And.InstanceOf<JsonObject>(), $"[{i}]");
+				Assert.That(((JsonObject)array[i])["Id"], Is.EqualTo(JsonNumber.Return(i + 1)), $"[{i}].Id");
+				Assert.That(((JsonObject)array[i])["Name"], Is.EqualTo(JsonString.Return((i + 1).ToString())), $"[{i}].Name");
+				Assert.That(((JsonObject)array[i]).Count, Is.EqualTo(2), $"[{i}] Count");
 			}
 
 			// errors
@@ -4664,7 +4664,7 @@ namespace Doxense.Serialization.Json.Tests
 			{
 				var arr = o[name].AsArray(required: false);
 				Assert.That(arr, Is.Not.Null, "Property '{0}' is missing", name);
-				Assert.That(arr.Count, Is.EqualTo(2), "Array should have exactly 2 elements: {0:P}", arr);
+				Assert.That(arr.Count, Is.EqualTo(2), $"Array should have exactly 2 elements: {arr:P}");
 				Assert.That(arr[0].ToStringOrDefault(), Is.EqualTo(expectedType), "Item type does not match for {0}", name);
 				Assert.That(arr[1], valueConstraint, "Value does not match for {0}", name);
 			}
@@ -7030,7 +7030,7 @@ namespace Doxense.Serialization.Json.Tests
 		public static void ParseAreEqual(JsonValue expected, string jsonText, string message = null)
 		{
 			var parsed = CrystalJson.Parse(jsonText);
-			Assert.That(parsed, Is.EqualTo(expected), "CrystalJson.Parse('{0}') into {1}{2}", jsonText, expected.Type, (message == null ? String.Empty : (": " + message)));
+			Assert.That(parsed, Is.EqualTo(expected), $"CrystalJson.Parse('{jsonText}') into {expected.Type}{(message == null ? string.Empty : (": " + message))}");
 		}
 	}
 

--- a/Doxense.Core.Tests/Utils/ConversionFacts.cs
+++ b/Doxense.Core.Tests/Utils/ConversionFacts.cs
@@ -38,10 +38,10 @@ namespace Doxense.Runtime.Converters.Tests
 		[Test]
 		public void Test_Values_Of_Same_Types_Are_Always_Similar()
 		{
-			void Test(object? x, object? y)
+			static void Test(object? x, object? y)
 			{
 				bool expected = x == null ? y == null : y != null && x.Equals(y);
-				Assert.That(ComparisonHelper.AreSimilar(x, y), Is.EqualTo(expected), expected ? "{0} == {1}" : "{0} != {1}", x, y);
+				Assert.That(ComparisonHelper.AreSimilar(x, y), Is.EqualTo(expected), expected ? $"{x} == {y}" : $"{x} != {y}");
 			}
 
 			Test(null, null);
@@ -66,19 +66,19 @@ namespace Doxense.Runtime.Converters.Tests
 		[Test]
 		public void Test_Values_Of_Similar_Types_Are_Similar()
 		{
-			void Similar(object x, object y)
+			static void Similar(object? x, object? y)
 			{
 				if (!ComparisonHelper.AreSimilar(x, y))
 				{
-					Assert.Fail("({0}) {1} ~= ({2}) {3}", x == null ? "object" : x.GetType().Name, x, y == null ? "object" : y.GetType().Name, y);
+					Assert.Fail($"({(x == null ? "object" : x.GetType().Name)}) {x} ~= ({(y == null ? "object" : y.GetType().Name)}) {y}");
 				}
 			}
 
-			void Different(object x, object y)
+			static void Different(object? x, object? y)
 			{
 				if (ComparisonHelper.AreSimilar(x, y))
 				{
-					Assert.Fail("({0}) {1} !~= ({2}) {3}", x == null ? "object" : x.GetType().Name, x, y == null ? "object" : y.GetType().Name, y);
+					Assert.Fail($"({(x == null ? "object" : x.GetType().Name)}) {x} !~= ({(y == null ? "object" : y.GetType().Name)}) {y}");
 				}
 			}
 
@@ -113,4 +113,5 @@ namespace Doxense.Runtime.Converters.Tests
 		}
 
 	}
+
 }

--- a/Doxense.Core.Tests/Utils/TraceRouteFacts.cs
+++ b/Doxense.Core.Tests/Utils/TraceRouteFacts.cs
@@ -50,8 +50,8 @@ namespace Doxense.Networking.Tests
 			var (res, elapsed) = await Time(() => IPAddressHelpers.TracerouteAsync(target, 16, TimeSpan.FromSeconds(2), this.Cancellation));
 			Log($"> [{elapsed.TotalSeconds:N3}s]");
 			Dump(res);
-			Assert.That(res.Status, Is.EqualTo(IPStatus.Success), "Failed to traceroute {0}", target);
-			Assert.That(res.Hops, Has.Count.GreaterThan(3), "Should need at least 3 hops for {0}", target);
+			Assert.That(res.Status, Is.EqualTo(IPStatus.Success), $"Failed to traceroute {target}");
+			Assert.That(res.Hops, Has.Count.GreaterThan(3), $"Should need at least 3 hops for {target}");
 			Assert.That(res.Hops.Select(x => x.Address), Is.All.Not.Null, "Hops[*].Address");
 			//note: on ne peut pas facilement tester "Distance" car parfois il y a des nodes qui ne répondent pas.
 			// => on juste vérifier qu'ils sont positifs, et tous différents
@@ -77,8 +77,8 @@ namespace Doxense.Networking.Tests
 			var (res, elapsed) = await Time(() => IPAddressHelpers.TracerouteAsync(target, 16, TimeSpan.FromSeconds(2), this.Cancellation));
 			Log($"> [{elapsed.TotalSeconds:N3}s]");
 			Dump(res);
-			Assert.That(res.Status, Is.EqualTo(IPStatus.Success), "Failed to traceroute {0}", target);
-			Assert.That(res.Hops, Has.Count.EqualTo(1), "Should only need 1 hop for {0}", target);
+			Assert.That(res.Status, Is.EqualTo(IPStatus.Success), $"Failed to traceroute {target}");
+			Assert.That(res.Hops, Has.Count.EqualTo(1), $"Should only need 1 hop for {target}");
 			Assert.That(res.Hops[0].Address, Is.EqualTo(target), "Hops[0].Address");
 			Assert.That(res.Hops[0].Distance, Is.EqualTo(1), "Hops[0].Distance");
 			Assert.That(res.Hops[0].Private, Is.True, "Hops[0].Private");
@@ -90,14 +90,14 @@ namespace Doxense.Networking.Tests
 		{
 			// on va tracertoute l'ip public du host local
 			var target = IPAddressHelpers.GetPreferredAddress(await Dns.GetHostAddressesAsync(Environment.MachineName, AddressFamily.InterNetwork, this.Cancellation));
-			Assume.That(target, Is.Not.Null);
+			Assert.That(target, Is.Not.Null);
 
 			Log($"# Traceroute: {target}");
 			var (res, elapsed) = await Time(() => IPAddressHelpers.TracerouteAsync(target, 16, TimeSpan.FromSeconds(2), this.Cancellation));
 			Log($"> [{elapsed.TotalSeconds:N3}s]");
 			Dump(res);
-			Assert.That(res.Status, Is.EqualTo(IPStatus.Success), "Traceroute to self should succeed: {0}", target);
-			Assert.That(res.Hops, Has.Count.EqualTo(1), "Only one hop {0}", target);
+			Assert.That(res.Status, Is.EqualTo(IPStatus.Success), $"Traceroute to self should succeed: {target}");
+			Assert.That(res.Hops, Has.Count.EqualTo(1), $"Only one hop {target}");
 		}
 
 		[Test]
@@ -114,8 +114,8 @@ namespace Doxense.Networking.Tests
 			Dump(res);
 			//note: suivant le coefficient de marée, on a soit DestinationHostUnreachable, soit TimedOut.
 			// => les conditions exactes pouir avoir DestinationHostUnreachable sont assez difficiles a reproduire exactement, surtout en CI!
-			Assert.That(res.Status, Is.EqualTo(IPStatus.DestinationHostUnreachable).Or.EqualTo(IPStatus.TimedOut), "Tracroute should have failed: {0}", target);
-			Assert.That(res.Hops, Has.Count.EqualTo(1), "Only one hop {0}", target);
+			Assert.That(res.Status, Is.EqualTo(IPStatus.DestinationHostUnreachable).Or.EqualTo(IPStatus.TimedOut), $"Traceroute should have failed: {target}");
+			Assert.That(res.Hops, Has.Count.EqualTo(1), $"Only one hop {target}");
 		}
 
 		[Test]
@@ -131,8 +131,8 @@ namespace Doxense.Networking.Tests
 			var (res, elapsed) = await Time(() => IPAddressHelpers.TracerouteAsync(target, 16, TimeSpan.FromSeconds(2), this.Cancellation));
 			Log($"> [{elapsed.TotalSeconds:N3}s]");
 			Dump(res);
-			Assert.That(res.Status, Is.EqualTo(IPStatus.TimedOut), "Tracroute should have failed: {0}", target);
-			Assert.That(res.Hops, Has.Count.GreaterThan(1), "Should be at least two hops: {0}", target);
+			Assert.That(res.Status, Is.EqualTo(IPStatus.TimedOut), $"Tracroute should have failed: {target}");
+			Assert.That(res.Hops, Has.Count.GreaterThan(1), $"Should be at least two hops: {target}");
 		}
 
 	}

--- a/Doxense.Core.Tests/Utils/Uuid64Facts.cs
+++ b/Doxense.Core.Tests/Utils/Uuid64Facts.cs
@@ -225,7 +225,7 @@ namespace Doxense.Core.Tests
 			ulong val = 1;
 			for (int i = 0; i <= 10; i++)
 			{
-				Assert.That(new Uuid64(val).ToString("C"), Is.EqualTo("1" + new string('0', i)), "62^{0}", i);
+				Assert.That(new Uuid64(val).ToString("C"), Is.EqualTo("1" + new string('0', i)), $"62^{i}");
 				val *= 62;
 			}
 
@@ -234,7 +234,7 @@ namespace Doxense.Core.Tests
 			for (int i = 1; i <= 10; i++)
 			{
 				val += 61;
-				Assert.That(new Uuid64(val).ToString("C"), Is.EqualTo(new string('z', i)), "62^{0} - 1", i);
+				Assert.That(new Uuid64(val).ToString("C"), Is.EqualTo(new string('z', i)), $"62^{i} - 1");
 				val *= 62;
 			}
 
@@ -298,7 +298,7 @@ namespace Doxense.Core.Tests
 			Assert.That(() => Uuid64.FromBase62("LygHa16AHYG"), Throws.InstanceOf<OverflowException>(), "ulong.MaxValue + 1 => OVERFLOW");
 
 			// invalid length
-			Assert.That(() => Uuid64.FromBase62(default(string)), Throws.ArgumentNullException);
+			Assert.That(() => Uuid64.FromBase62(default(string)!), Throws.ArgumentNullException);
 			Assert.That(() => Uuid64.FromBase62("100000000000"), Throws.InstanceOf<FormatException>(), "62^11 => TOO BIG");
 
 		}
@@ -316,7 +316,7 @@ namespace Doxense.Core.Tests
 			for (int i = 0; i < N; i++)
 			{
 				var uid = Uuid64.NewUuid();
-				if (uids.Contains(uid.ToUInt64())) Assert.Fail("Duplicate Uuid64 generated: {0}", uid);
+				if (uids.Contains(uid.ToUInt64())) Assert.Fail($"Duplicate Uuid64 generated: {uid}");
 				uids.Add(uid.ToUInt64());
 			}
 			Assert.That(uids.Count, Is.EqualTo(N));
@@ -338,7 +338,7 @@ namespace Doxense.Core.Tests
 			for (int i = 0; i < N; i++)
 			{
 				var uid = gen.NewUuid();
-				if (uids.Contains(uid.ToUInt64())) Assert.Fail("Duplicate Uuid64 generated: {0}", uid);
+				if (uids.Contains(uid.ToUInt64())) Assert.Fail($"Duplicate Uuid64 generated: {uid}");
 				uids.Add(uid.ToUInt64());
 			}
 			Assert.That(uids.Count, Is.EqualTo(N));

--- a/Doxense.Core.Tests/Utils/Uuid80Facts.cs
+++ b/Doxense.Core.Tests/Utils/Uuid80Facts.cs
@@ -83,7 +83,7 @@ namespace Doxense.Core.Tests
 			Assert.That(Uuid80.Parse("{ffff-00000000-deadbeef}"), Is.EqualTo(new Uuid80(0xFFFF, 0, 0xDEADBEEFU)));
 
 			// errors
-			Assert.That(() => Uuid80.Parse(default(string)), Throws.ArgumentNullException);
+			Assert.That(() => Uuid80.Parse(default(string)!), Throws.ArgumentNullException);
 			Assert.That(() => Uuid80.Parse("hello"), Throws.InstanceOf<FormatException>());
 			Assert.That(() => Uuid80.Parse("abcd-12345678-9ABCDEFG"), Throws.InstanceOf<FormatException>(), "Invalid hexa character 'G'");
 			Assert.That(() => Uuid80.Parse("0000-00000000-0000000 "), Throws.InstanceOf<FormatException>(), "Two short + extra space");
@@ -147,7 +147,7 @@ namespace Doxense.Core.Tests
 			{
 				var uid = Uuid80.NewUuid();
 				string s = uid.ToString();
-				if (uids.Contains(s)) Assert.Fail("Duplicate Uuid80 generated: {0}", uid);
+				if (uids.Contains(s)) Assert.Fail($"Duplicate Uuid80 generated: {uid}");
 				uids.Add(s);
 			}
 			Assert.That(uids.Count, Is.EqualTo(N));
@@ -169,7 +169,7 @@ namespace Doxense.Core.Tests
 			{
 				var uid = gen.NewUuid();
 				string s = uid.ToString();
-				if (uids.Contains(s)) Assert.Fail("Duplicate Uuid80 generated: {0}", uid);
+				if (uids.Contains(s)) Assert.Fail($"Duplicate Uuid80 generated: {uid}");
 				uids.Add(s);
 			}
 			Assert.That(uids.Count, Is.EqualTo(N));

--- a/Doxense.Core.Tests/Utils/Uuid96Facts.cs
+++ b/Doxense.Core.Tests/Utils/Uuid96Facts.cs
@@ -146,7 +146,7 @@ namespace Doxense.Core.Tests
 			{
 				var uid = Uuid96.NewUuid();
 				string s = uid.ToString();
-				if (uids.Contains(s)) Assert.Fail("Duplicate Uuid96 generated: {0}", uid);
+				if (uids.Contains(s)) Assert.Fail($"Duplicate Uuid96 generated: {uid}");
 				uids.Add(s);
 			}
 			Assert.That(uids.Count, Is.EqualTo(N));
@@ -168,7 +168,7 @@ namespace Doxense.Core.Tests
 			{
 				var uid = gen.NewUuid();
 				string s = uid.ToString();
-				if (uids.Contains(s)) Assert.Fail("Duplicate Uuid96 generated: {0}", uid);
+				if (uids.Contains(s)) Assert.Fail($"Duplicate Uuid96 generated: {uid}");
 				uids.Add(s);
 			}
 			Assert.That(uids.Count, Is.EqualTo(N));

--- a/Doxense.Core.Tests/Web/UrlEncoderTest.cs
+++ b/Doxense.Core.Tests/Web/UrlEncoderTest.cs
@@ -81,7 +81,9 @@ namespace Doxense.Web.Tests
 			Assert.That(UrlEncoding.EncodeData("é", Encoding.Unicode), Is.EqualTo("%e9%00"), "UTF-16");
 			Assert.That(UrlEncoding.EncodeData("é", Encoding.GetEncoding("iso-8859-1")), Is.EqualTo("%e9"), "Latin-1");
 			Assert.That(UrlEncoding.EncodeData("é", Encoding.GetEncoding(437)), Is.EqualTo("%82"), "OEM United States");
+#pragma warning disable SYSLIB0001
 			Assert.That(UrlEncoding.EncodeData("é", Encoding.UTF7), Is.EqualTo("%2bAOk-"), "UTF-7");
+#pragma warning restore SYSLIB0001
 
 			// lossy
 			Assert.That(UrlEncoding.EncodeData("é", Encoding.ASCII), Is.EqualTo("%3f"), "ASCII changes 'é' to '?'");
@@ -392,7 +394,9 @@ namespace Doxense.Web.Tests
 			Assert.That(UrlEncoding.Decode("%e9%00", Encoding.Unicode), Is.EqualTo("é"), "UTF-16");
 			Assert.That(UrlEncoding.Decode("%e9", Encoding.GetEncoding("iso-8859-1")), Is.EqualTo("é"), "Latin-1");
 			Assert.That(UrlEncoding.Decode("%82", Encoding.GetEncoding(437)), Is.EqualTo("é"), "OEM United States");
+#pragma warning disable SYSLIB0001
 			Assert.That(UrlEncoding.Decode("%2bAOk-", Encoding.UTF7), Is.EqualTo("é"), "UTF-7");
+#pragma warning restore SYSLIB0001
 		}
 
 		[Test]
@@ -475,22 +479,22 @@ namespace Doxense.Web.Tests
 			var values = UrlEncoding.ParseQueryString("foo");
 			Assert.That(values, Is.Not.Null);
 			Assert.That(values.Count, Is.EqualTo(1));
-			Assert.True(values.AllKeys.Contains("foo"));
+			Assert.That(values.AllKeys.Contains("foo"), Is.True);
 			Assert.That(values["foo"], Is.Null);
 
 			// Par convention "foo=" tout court est présent, et vaut String.Empty
 			values = UrlEncoding.ParseQueryString("foo=");
 			Assert.That(values, Is.Not.Null);
 			Assert.That(values.Count, Is.EqualTo(1));
-			Assert.True(values.AllKeys.Contains("foo"));
+			Assert.That(values.AllKeys.Contains("foo"), Is.True);
 			Assert.That(values["foo"], Is.EqualTo(String.Empty));
 
 			// La présente d'autres params juste après ne doit rien changer
 			values = UrlEncoding.ParseQueryString("foo&bar=&baz=123");
 			Assert.That(values, Is.Not.Null);
 			Assert.That(values.Count, Is.EqualTo(3));
-			Assert.True(values.AllKeys.Contains("foo"));
-			Assert.True(values.AllKeys.Contains("bar"));
+			Assert.That(values.AllKeys.Contains("foo"), Is.True);
+			Assert.That(values.AllKeys.Contains("bar"), Is.True);
 			Assert.That(values["foo"], Is.Null);
 			Assert.That(values["bar"], Is.EqualTo(String.Empty));
 			Assert.That(values["baz"], Is.EqualTo("123"));

--- a/FoundationDB.Tests/Experimental/Indexing/CompressedBitmapsFacts.cs
+++ b/FoundationDB.Tests/Experimental/Indexing/CompressedBitmapsFacts.cs
@@ -91,7 +91,7 @@ namespace FoundationDB.Layers.Experimental.Indexing.Tests
 			Log($"Set({offset}):");
 			bool actual = builder.Set(offset);
 			bool expected = witness.Set(offset);
-			Assert.That(actual, Is.EqualTo(expected), "Set({0})", offset);
+			Assert.That(actual, Is.EqualTo(expected), $"Set({offset})");
 
 			Verify(builder, witness);
 			return actual;
@@ -103,7 +103,7 @@ namespace FoundationDB.Layers.Experimental.Indexing.Tests
 			Log($"Clear({offset}):");
 			bool actual = builder.Clear(offset);
 			bool expected = witness.Clear(offset);
-			Assert.That(actual, Is.EqualTo(expected), "Clear({0})", offset);
+			Assert.That(actual, Is.EqualTo(expected), $"Clear({offset})");
 
 			Verify(builder, witness);
 			return actual;
@@ -907,12 +907,13 @@ namespace FoundationDB.Layers.Experimental.Indexing.Tests
 			j = 0;
 			foreach (var kv in controlStats)
 			{
-				Assert.That(index.TryGetValue(kv.Value, out CompressedBitmapBuilder builder), Is.True, "{0} is missing from index", kv.Value);
+				Assert.That(index.TryGetValue(kv.Value, out CompressedBitmapBuilder builder), Is.True, $"{kv.Value} is missing from index");
+				Assert.That(builder, Is.Not.Null);
 				var bmp = builder.ToBitmap();
 				bmp.GetStatistics(out int bits, out int words, out int a, out int b, out _);
-				Assert.That(bits, Is.EqualTo(kv.Count), "{0} has invalid count", kv.Value);
+				Assert.That(bits, Is.EqualTo(kv.Count), $"{kv.Value} has invalid count");
 				int sz = bmp.ByteCount;
-				log.WriteLine("{0,8} : {1,5} bits, {2} words ({3} lit. / {4} fil.), {5:N0} bytes, {6:N3} bytes/doc, {7:N2}% compression", kv.Value, bits, words, a, b, sz, 1.0 * sz / bits, 100.0 * (4 + 17 + sz) / (17 + (4 + 17) * bits));
+				log.WriteLine($"{kv.Value,8} : {bits,5} bits, {words} words ({a} lit. / {b} fil.), {sz:N0} bytes, {1.0 * sz / bits:N3} bytes/doc, {100.0 * (4 + 17 + sz) / (17 + (4 + 17) * bits):N2}% compression");
 				totalBitmapSize += sz;
 				//if (j % 500 == 0) Log((100.0 * b / words));
 				//if (j % 500 == 0) Log(bmp.Dump());

--- a/FoundationDB.Tests/FoundationDB.Tests.csproj
+++ b/FoundationDB.Tests/FoundationDB.Tests.csproj
@@ -41,7 +41,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit" Version="4.0.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="protobuf-net" Version="3.2.30" />
 	</ItemGroup>

--- a/FoundationDB.Tests/KeyFacts.cs
+++ b/FoundationDB.Tests/KeyFacts.cs
@@ -173,8 +173,8 @@ namespace FoundationDB.Client.Tests
 					// > count should always be 20
 					// > offset should always be a multiple of 20
 					// > there should never be any overlap between workers
-					Assert.That(chunk.Value, Is.EqualTo(B), "{0}:{1}", chunk.Key, chunk.Value);
-					Assert.That(chunk.Key % B, Is.EqualTo(0), "{0}:{1}", chunk.Key, chunk.Value);
+					Assert.That(chunk.Value, Is.EqualTo(B), $"{chunk.Key}:{chunk.Value}");
+					Assert.That(chunk.Key % B, Is.EqualTo(0), $"{chunk.Key}:{chunk.Value}");
 
 					lock (used)
 					{
@@ -182,7 +182,7 @@ namespace FoundationDB.Client.Tests
 						{
 
 							if (used[i])
-								Assert.Fail("Duplicate index {0} chunk {1}:{2} for worker {3}", i, chunk.Key, chunk.Value, id);
+								Assert.Fail($"Duplicate index {i} chunk {chunk.Key}:{chunk.Value} for worker {id}");
 							else
 								used[i] = true;
 						}

--- a/FoundationDB.Tests/Layers/DirectoryFacts.cs
+++ b/FoundationDB.Tests/Layers/DirectoryFacts.cs
@@ -77,7 +77,7 @@ namespace FoundationDB.Client.Tests
 					if (ids.Contains(id))
 					{
 						await DumpSubspace(db, location);
-						Assert.Fail("Duplicate key allocated: {0} (#{1})", id, i);
+						Assert.Fail($"Duplicate key allocated: {id} (#{i})");
 					}
 
 					ids.Add(id);
@@ -375,37 +375,37 @@ namespace FoundationDB.Client.Tests
 				Log($"- {outer} @ {outer.GetPrefixUnsafe()}");
 				Assert.That(outer.FullName, Is.EqualTo("/Outer"));
 				Assert.That(outer.Layer, Is.EqualTo("partition"));
-				Assert.That(outer.GetPrefixUnsafe().StartsWith(location.Prefix), Is.True, "Outer prefix {0} MUST starts with DL content location prefix {1} because it is contained in that partition", outer.GetPrefixUnsafe(), dl.Content.Prefix);
+				Assert.That(outer.GetPrefixUnsafe().StartsWith(location.Prefix), Is.True, $"Outer prefix {outer.GetPrefixUnsafe()} MUST starts with DL content location prefix {dl.Content.Prefix} because it is contained in that partition");
 
 				var foo = await db.ReadAsync(tr => dl.OpenAsync(tr, FdbPath.Parse("/Outer/Foo")), this.Cancellation);
 				Assert.That(foo, Is.Not.Null);
 				Log($"- {foo} @ {foo.GetPrefixUnsafe()}");
 				Assert.That(foo.FullName, Is.EqualTo("/Outer/Foo"));
 				Assert.That(foo.Layer, Is.EqualTo(string.Empty));
-				Assert.That(foo.GetPrefixUnsafe().StartsWith(outer.GetPrefixUnsafe()), Is.True, "Foo prefix {0} MUST starts with outer prefix {1} because it is contained in that partition", foo.GetPrefixUnsafe(), outer.GetPrefixUnsafe());
+				Assert.That(foo.GetPrefixUnsafe().StartsWith(outer.GetPrefixUnsafe()), Is.True, $"Foo prefix {foo.GetPrefixUnsafe()} MUST starts with outer prefix {outer.GetPrefixUnsafe()} because it is contained in that partition");
 
 				var inner = await db.ReadAsync(tr => dl.OpenAsync(tr, FdbPath.Parse("/Outer/Foo/Inner")), this.Cancellation);
 				Assert.That(inner, Is.Not.Null);
 				Log($"- {inner} @ {inner.GetPrefixUnsafe()}");
 				Assert.That(inner.FullName, Is.EqualTo("/Outer/Foo/Inner"));
 				Assert.That(inner.Layer, Is.EqualTo("partition"));
-				Assert.That(inner.GetPrefixUnsafe().StartsWith(outer.GetPrefixUnsafe()), Is.True, "Inner prefix {0} MUST starts with outer prefix {1} because it is contained in that partition", inner.GetPrefixUnsafe(), outer.GetPrefixUnsafe());
-				Assert.That(inner.GetPrefixUnsafe().StartsWith(foo.GetPrefixUnsafe()), Is.False, "Inner prefix {0} MUST NOT starts with foo prefix {1} because they are both in the same partition", inner.GetPrefixUnsafe(), foo.GetPrefixUnsafe());
+				Assert.That(inner.GetPrefixUnsafe().StartsWith(outer.GetPrefixUnsafe()), Is.True, "Inner prefix {inner.GetPrefixUnsafe()} MUST starts with outer prefix {outer.GetPrefixUnsafe()} because it is contained in that partition");
+				Assert.That(inner.GetPrefixUnsafe().StartsWith(foo.GetPrefixUnsafe()), Is.False, "Inner prefix {inner.GetPrefixUnsafe()} MUST NOT starts with foo prefix {foo.GetPrefixUnsafe()} because they are both in the same partition");
 
 				var bar = await db.ReadAsync(tr => dl.OpenAsync(tr, FdbPath.Parse("/Outer/Foo/Inner/Bar")), this.Cancellation);
 				Assert.That(bar, Is.Not.Null);
 				Log($"- {bar} @ {bar.GetPrefixUnsafe()}");
 				Assert.That(bar.FullName, Is.EqualTo("/Outer/Foo/Inner/Bar"));
 				Assert.That(bar.Layer, Is.EqualTo("BarLayer"));
-				Assert.That(bar.GetPrefixUnsafe().StartsWith(inner.GetPrefixUnsafe()), Is.True, "Bar prefix {0} MUST starts with inner prefix {1} because it is contained in that partition", bar.GetPrefixUnsafe(), inner.GetPrefixUnsafe());
+				Assert.That(bar.GetPrefixUnsafe().StartsWith(inner.GetPrefixUnsafe()), Is.True, $"Bar prefix {bar.GetPrefixUnsafe()} MUST starts with inner prefix {inner.GetPrefixUnsafe()} because it is contained in that partition");
 
 				var baz = await db.ReadAsync(tr => dl.OpenAsync(tr, FdbPath.Parse("/Outer/Foo/Inner/Bar/Baz")), this.Cancellation);
 				Assert.That(baz, Is.Not.Null);
 				Log($"- {baz} @ {baz.GetPrefixUnsafe()}");
 				Assert.That(baz.FullName, Is.EqualTo("/Outer/Foo/Inner/Bar/Baz"));
 				Assert.That(baz.Layer, Is.EqualTo("BazLayer"));
-				Assert.That(baz.GetPrefixUnsafe().StartsWith(inner.GetPrefixUnsafe()), Is.True, "Baz prefix {0} MUST starts with inner prefix {1} because it is contained in that partition", baz.GetPrefixUnsafe(), inner.GetPrefixUnsafe());
-				Assert.That(baz.GetPrefixUnsafe().StartsWith(bar.GetPrefixUnsafe()), Is.False, "Baz prefix {0} MUST NOT starts with Bar prefix {1} because they are both in the same partition", baz.GetPrefixUnsafe(), bar.GetPrefixUnsafe());
+				Assert.That(baz.GetPrefixUnsafe().StartsWith(inner.GetPrefixUnsafe()), Is.True, $"Baz prefix {baz.GetPrefixUnsafe()} MUST starts with inner prefix {inner.GetPrefixUnsafe()} because it is contained in that partition");
+				Assert.That(baz.GetPrefixUnsafe().StartsWith(bar.GetPrefixUnsafe()), Is.False, $"Baz prefix {baz.GetPrefixUnsafe()} MUST NOT starts with Bar prefix {bar.GetPrefixUnsafe()} because they are both in the same partition");
 
 #if ENABLE_LOGGING
 				foreach (var log in list)
@@ -750,8 +750,8 @@ namespace FoundationDB.Client.Tests
 					await DumpSubspace(tr, location);
 					Assert.That(bar, Is.InstanceOf<FdbDirectorySubspace>());
 					Assert.That(bar.Path, Is.EqualTo(FdbPath.Absolute(segFoo, FdbPathSegment.Create("Bar"))), "Path of directories under a partition should be absolute");
-					Assert.That(bar.GetPrefix(), Is.Not.EqualTo(partitionKey), "{0} should be located under {1}", bar, partition);
-					Assert.That(bar.GetPrefix().StartsWith(partitionKey), Is.True, "{0} should be located under {1}", bar, partition);
+					Assert.That(bar.GetPrefix(), Is.Not.EqualTo(partitionKey), $"{bar} should be located under {partition}");
+					Assert.That(bar.GetPrefix().StartsWith(partitionKey), Is.True, $"{bar} should be located under {partition}");
 
 					Log("Creating sub-directory /Foo$/Baz starting from the root...");
 					var baz = await dl.CreateAsync(tr, FdbPath.Absolute(segFoo, FdbPathSegment.Create("Baz")));
@@ -760,8 +760,8 @@ namespace FoundationDB.Client.Tests
 					Assert.That(baz, Is.InstanceOf<FdbDirectorySubspace>());
 					Assert.That(baz.FullName, Is.EqualTo("/Foo$/Baz"));
 					Assert.That(baz.Path, Is.EqualTo(FdbPath.Absolute(segFoo, FdbPathSegment.Create("Baz"))), "Path of directories under a partition should be absolute");
-					Assert.That(baz.GetPrefix(), Is.Not.EqualTo(partitionKey), "{0} should be located under {1}", baz, partition);
-					Assert.That(baz.GetPrefix().StartsWith(partitionKey), Is.True, "{0} should be located under {1}", baz, partition);
+					Assert.That(baz.GetPrefix(), Is.Not.EqualTo(partitionKey), $"{baz} should be located under {partition}");
+					Assert.That(baz.GetPrefix().StartsWith(partitionKey), Is.True, $"{baz} should be located under {partition}");
 
 					// Rename 'Bar' to 'BarBar'
 					Log("Renaming /Foo$/Bar to /Foo$/BarBar...");

--- a/FoundationDB.Tests/RangeQueryFacts.cs
+++ b/FoundationDB.Tests/RangeQueryFacts.cs
@@ -52,14 +52,14 @@ namespace FoundationDB.Client.Tests
 			{
 				for (int i = 0; i < chunk.Count; i++)
 				{
-					Assert.That(chunk[i].Key, Is.EqualTo(expected[offset + i].Key), "[{0}].Key", i);
-					Assert.That(chunk[i].Value, Is.EqualTo(expected[offset + i].Value), "[{0}].Value", i);
+					Assert.That(chunk[i].Key, Is.EqualTo(expected[offset + i].Key), $"[{i}].Key");
+					Assert.That(chunk[i].Value, Is.EqualTo(expected[offset + i].Value), $"[{i}].Value");
 
-					Assert.That(chunk.Items[i].Key, Is.EqualTo(expected[offset + i].Key), "Items[{0}].Key", i);
-					Assert.That(chunk.Items[i].Value, Is.EqualTo(expected[offset + i].Value), "Items[{0}].Value", i);
+					Assert.That(chunk.Items[i].Key, Is.EqualTo(expected[offset + i].Key), $"Items[{i}].Key");
+					Assert.That(chunk.Items[i].Value, Is.EqualTo(expected[offset + i].Value), $"Items[{i}].Value");
 
-					Assert.That(chunk.Keys[i], Is.EqualTo(expected[offset + i].Key), "Keys[{0}]", i);
-					Assert.That(chunk.Values[i], Is.EqualTo(expected[offset + i].Value), "Values[{0}]", i);
+					Assert.That(chunk.Keys[i], Is.EqualTo(expected[offset + i].Key), $"Keys[{i}]");
+					Assert.That(chunk.Values[i], Is.EqualTo(expected[offset + i].Value), $"Values[{i}]");
 				}
 
 				Assert.That(chunk.First, Is.EqualTo(expected[offset].Key));
@@ -79,6 +79,7 @@ namespace FoundationDB.Client.Tests
 				var data = await db.ReadWriteAsync(async tr =>
 				{
 					var subspace = await location.Resolve(tr);
+					Assert.That(subspace, Is.Not.Null);
 					var items = Enumerable.Range(0, N).Select(i => new KeyValuePair<Slice, Slice>(subspace.Encode(i), Slice.FromInt32(i))).ToArray();
 					tr.SetValues(items);
 					return items;
@@ -92,6 +93,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					Log("Getting range (WantAll)...");
 					var ts = Stopwatch.StartNew();
@@ -119,6 +121,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					Log("Getting range (Iterator)...");
 					var ts = Stopwatch.StartNew();
@@ -165,6 +168,7 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -179,6 +183,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.Encode(0), folder.Encode(N));
 					Assert.That(query, Is.Not.Null);
@@ -241,6 +246,8 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
+
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -252,6 +259,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var chunk = await tr.GetRangeAsync(
 						folder.Encode(0),
@@ -284,6 +292,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.Encode(0), folder.Encode(N), new FdbRangeOptions { Read = FdbReadMode.Keys });
 					Assert.That(query.Read, Is.EqualTo(FdbReadMode.Keys));
@@ -312,6 +321,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRangeKeys(folder.Encode(0), folder.Encode(N));
 
@@ -335,6 +345,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr
 						.GetRange(folder.Encode(0), folder.Encode(N))
@@ -375,6 +386,7 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -385,6 +397,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var chunk = await tr.GetRangeAsync(
 						folder.Encode(0),
@@ -416,6 +429,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(
 						folder.Encode(0),
@@ -447,6 +461,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRangeValues(folder.Encode(0), folder.Encode(N));
 
@@ -469,6 +484,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr
 						.GetRange(folder.Encode(0), folder.Encode(N))
@@ -493,6 +509,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRangeValues(
 						folder.Encode(0),
@@ -536,6 +553,7 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -547,6 +565,7 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(
 						folder.Encode(0),
@@ -588,7 +607,9 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async (tr) =>
 				{
 					var fa = await a.Resolve(tr);
+					Assert.That(fa, Is.Not.Null);
 					var fb = await b.Resolve(tr);
+					Assert.That(fb, Is.Not.Null);
 					for (int i = 0; i < 10; i++)
 					{
 						tr.Set(fa.Encode(i), Slice.FromInt32(i));
@@ -602,6 +623,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
+					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange());
 
@@ -636,6 +658,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fb = await b.Resolve(tr);
+					Assert.That(fb, Is.Not.Null);
 
 					var query = tr.GetRange(fb.ToRange());
 
@@ -674,6 +697,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fc = await c.Resolve(tr);
+					Assert.That(fc, Is.Not.Null);
 
 					var query = tr.GetRange(fc.ToRange());
 
@@ -706,6 +730,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
+					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Take(5);
 
@@ -724,6 +749,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
+					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Skip(5);
 
@@ -757,14 +783,16 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var f = await location.Resolve(tr);
+					Assert.That(f, Is.Not.Null);
 					var fa = await a.Resolve(tr);
+					Assert.That(fa, Is.Not.Null);
 					for (int i = 0; i < 10; i++)
 					{
 						tr.Set(fa.Encode(i), Slice.FromInt32(i));
 					}
 					// add guard keys
 					tr.Set(f.GetPrefix(), Slice.FromInt32(-1));
-					tr.Set(f.GetPrefix() + (byte)255, Slice.FromInt32(-1));
+					tr.Set(f.GetPrefix() + 0xFF, Slice.FromInt32(-1));
 				}, this.Cancellation);
 
 				// Take(5) should return the first 5 items
@@ -772,6 +800,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
+					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Take(5);
 					Assert.That(query, Is.Not.Null);
@@ -792,6 +821,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
+					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Take(12);
 					Assert.That(query, Is.Not.Null);
@@ -812,6 +842,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
+					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Take(0);
 					Assert.That(query, Is.Not.Null);
@@ -840,7 +871,8 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					foreach((var k, var v) in dataSet)
+					Assert.That(folder, Is.Not.Null);
+					foreach(var (k, v) in dataSet)
 					{
 						tr.Set(folder.Encode(k), v);
 					}
@@ -850,9 +882,10 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToArray();
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.ToRange());
+					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToArray();
 
 					// |>>>>>>>>>>>>(50---------->99)|
 					var res = await query.Skip(50).ToListAsync();
@@ -880,9 +913,10 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToArray();
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.ToRange());
+					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToArray();
 
 					// |(0 <--------- 49)<<<<<<<<<<<<<|
 					var res = await query.Reverse().Skip(50).ToListAsync();
@@ -910,9 +944,10 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToArray();
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.ToRange());
+					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToArray();
 
 					// |>>>>>>>>>(25<------------74)<<<<<<<<|
 					var res = await query.Skip(25).Reverse().Skip(25).ToListAsync();
@@ -940,7 +975,8 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					foreach ((var k, var v) in dataSet)
+					Assert.That(folder, Is.Not.Null);
+					foreach (var (k, v) in dataSet)
 					{
 						tr.Set(folder.Encode(k), v);
 					}
@@ -949,6 +985,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr
 						.GetRange(folder.Encode(10), folder.Encode(20)) // 10 -> 19
@@ -964,6 +1001,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var query = tr
 						.GetRange(folder.Encode(10), folder.Encode(20)) // 10 -> 19
@@ -1020,6 +1058,7 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
 
 					var lists = Enumerable.Range(0, K).Select(k => GetList(folder, k)).ToArray();
 
@@ -1097,6 +1136,8 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
+
 					var lists = Enumerable.Range(0, K).Select(k => GetList(folder, k)).ToArray();
 
 					var merge = tr.Intersect(
@@ -1175,6 +1216,8 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
+					Assert.That(folder, Is.Not.Null);
+
 					var lists = Enumerable.Range(0, K).Select(k => GetList(folder, k)).ToArray();
 
 					var merge = tr.Except(
@@ -1220,7 +1263,9 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var items = await locItems.Resolve(tr);
+					Assert.That(items, Is.Not.Null);
 					var processed = await locProcessed.Resolve(tr);
+					Assert.That(processed, Is.Not.Null);
 
 					// Items
 					tr.Set(items["userA", 10093], Slice.Empty);
@@ -1237,7 +1282,9 @@ namespace FoundationDB.Client.Tests
 				var results = await db.QueryAsync(async tr =>
 				{
 					var items = await locItems.Resolve(tr);
+					Assert.That(items, Is.Not.Null);
 					var processed = await locProcessed.Resolve(tr);
+					Assert.That(processed, Is.Not.Null);
 
 					var query = tr.Except(
 						new[] { items.ToRange(), processed.ToRange() },
@@ -1267,7 +1314,9 @@ namespace FoundationDB.Client.Tests
 				results = await db.QueryAsync(async tr =>
 				{
 					var items = await locItems.Resolve(tr);
+					Assert.That(items, Is.Not.Null);
 					var processed = await locProcessed.Resolve(tr);
+					Assert.That(processed, Is.Not.Null);
 
 					var resItems = tr
 						.GetRange(items.ToRange())

--- a/FoundationDB.Tests/TenantFacts.cs
+++ b/FoundationDB.Tests/TenantFacts.cs
@@ -79,9 +79,9 @@ namespace FoundationDB.Client.Tests
 			{ // Create
 				var name = FdbTenantName.Create(Literal("Hello, there!"));
 				Log($"> {name} ({name.Value:X})");
-				Assert.That(name.IsValid, Is.True, "{0}.IsValid", name);
-				Assert.That(name.ToSlice(), Is.EqualTo(Literal("Hello, there!")), "{0}.ToSlice()", name);
-				Assert.That(name.ToString(), Is.EqualTo("'Hello, there!'"), "{0}.ToString()", name);
+				Assert.That(name.IsValid, Is.True, $"{name}.IsValid");
+				Assert.That(name.ToSlice(), Is.EqualTo(Literal("Hello, there!")), $"{name}.ToSlice()");
+				Assert.That(name.ToString(), Is.EqualTo("'Hello, there!'"), $"{name}.ToString()");
 
 				Assert.That(name.TryGetTuple(out _), Is.False, "Name is not a valid tuple!");
 
@@ -93,18 +93,18 @@ namespace FoundationDB.Client.Tests
 			{ // From Parts
 				var name = FdbTenantName.FromParts("Hello", "There");
 				Log($"> {name} ({name.Value:X})");
-				Assert.That(name.IsValid, Is.True, "{0}.IsValid", name);
-				Assert.That(name.ToSlice(), Is.EqualTo(TuPack.EncodeKey("Hello", "There")), "{0}.ToSlice()", name);
-				Assert.That(name.ToString(), Is.EqualTo("(\"Hello\", \"There\")"), "{0}.ToString()", name);
+				Assert.That(name.IsValid, Is.True, $"{name}.IsValid");
+				Assert.That(name.ToSlice(), Is.EqualTo(TuPack.EncodeKey("Hello", "There")), $"{name}.ToSlice()");
+				Assert.That(name.ToString(), Is.EqualTo("(\"Hello\", \"There\")"), $"{name}.ToString()");
 				Assert.That(name.TryGetTuple(out var tuple), Is.True, "Name is a valid tuple!");
 				Assert.That(tuple, Is.Not.Null.And.EqualTo(("Hello", "There")));
 			}
 			{ // From Tuple
 				var name = FdbTenantName.FromTuple(("Hello", "There"));
 				Log($"> {name} ({name.Value:X})");
-				Assert.That(name.IsValid, Is.True, "{0}.IsValid", name);
-				Assert.That(name.ToSlice(), Is.EqualTo(TuPack.EncodeKey("Hello", "There")), "{0}.ToSlice()", name);
-				Assert.That(name.ToString(), Is.EqualTo("(\"Hello\", \"There\")"), "{0}.ToString()", name);
+				Assert.That(name.IsValid, Is.True, $"{name}.IsValid");
+				Assert.That(name.ToSlice(), Is.EqualTo(TuPack.EncodeKey("Hello", "There")), $"{name}.ToSlice()");
+				Assert.That(name.ToString(), Is.EqualTo("(\"Hello\", \"There\")"), $"{name}.ToString()");
 				Assert.That(name.TryGetTuple(out var tuple), Is.True, "Name is a valid tuple!");
 				Assert.That(tuple, Is.Not.Null.And.EqualTo(("Hello", "There")));
 
@@ -169,8 +169,8 @@ namespace FoundationDB.Client.Tests
 
 			// it is possible that there are other tenants from other tests, we will ensure we can find both in the list
 
-			Assert.That(tenants, Does.ContainKey(acme.Name), "Should have found tenant {0} in the list", acme.Name);
-			Assert.That(tenants, Does.ContainKey(contoso.Name), "Should have found tenant {0} in the list", contoso.Name);
+			Assert.That(tenants, Does.ContainKey(acme.Name), $"Should have found tenant {acme.Name} in the list");
+			Assert.That(tenants, Does.ContainKey(contoso.Name), $"Should have found tenant {contoso.Name} in the list");
 
 			Assert.That(tenants[acme.Name], Is.EqualTo(acme));
 			Assert.That(tenants[contoso.Name], Is.EqualTo(contoso));
@@ -194,7 +194,7 @@ namespace FoundationDB.Client.Tests
 				Assert.That(tr.Tenant, Is.Not.Null, "tr.Tenant should not be null");
 				Assert.That(tr.Tenant.Name, Is.EqualTo(acme.Name), "tr.Tenant.Name should be valid");
 				Assert.That(tr.Database, Is.Not.Null.And.SameAs(this.Db), "tr.Database should be the same db objet that was used to create the tenant");
-				Assert.That(tr.Context.Mode.HasFlag(FdbTransactionMode.UseTenant), Is.True, "tr.Mode flag UseTenant should be set, but was {0}", tr.Context.Mode);
+				Assert.That(tr.Context.Mode.HasFlag(FdbTransactionMode.UseTenant), Is.True, $"tr.Mode flag UseTenant should be set, but was {tr.Context.Mode}");
 
 				Log("Read a key from this transaction...");
 				var value = await tr.GetAsync(Pack(("tests", "hello")));
@@ -249,7 +249,7 @@ namespace FoundationDB.Client.Tests
 				Log($"> Append({key:K}) => {encoded}");
 
 				var expected = subspace.Metadata.Prefix + key;
-				Assert.That(encoded, Is.EqualTo(expected), "Key '{0}' does not match expected encoding in tenant subspace {1}", key, subspace.Name);
+				Assert.That(encoded, Is.EqualTo(expected), $"Key '{key}' does not match expected encoding in tenant subspace {subspace.Name}");
 
 				var decoded = subspace.ExtractKey(encoded);
 				Assert.That(decoded, Is.EqualTo(key), "Key does not extract back to the original in tenant subspace");
@@ -264,7 +264,7 @@ namespace FoundationDB.Client.Tests
 				Log($"> Pack({key}) => {encoded}");
 
 				var expected = subspace.Metadata.Prefix + raw;
-				Assert.That(encoded, Is.EqualTo(expected), "Key '{0}' does not match expected encoding in tenant subspace {1}", key, subspace.Name);
+				Assert.That(encoded, Is.EqualTo(expected), $"Key '{key}' does not match expected encoding in tenant subspace {subspace.Name}");
 
 				var decoded = subspace.Unpack(encoded);
 				Assert.That(decoded, Is.EqualTo(key), "Key does not unpack to the original in tenant subspace");
@@ -277,8 +277,8 @@ namespace FoundationDB.Client.Tests
 				await GlobalVerify(async tr =>
 				{
 					var metadata = await Fdb.Tenants.GetTenantMetadata(tr, tenant.Name);
-					Assert.That(metadata, Is.Not.Null, "Tenant {0} should exist!", tenant.Name);
-					Assert.That(metadata.Prefix.Count, Is.GreaterThan(0), "Tenant {0} should have a non-empty prefix!", tenant.Name);
+					Assert.That(metadata, Is.Not.Null, $"Tenant {tenant.Name} should exist!");
+					Assert.That(metadata.Prefix.Count, Is.GreaterThan(0), $"Tenant {tenant.Name} should have a non-empty prefix!");
 
 					var subspace = metadata.GetSubspace();
 					Assert.That(subspace, Is.Not.Null);
@@ -312,7 +312,7 @@ namespace FoundationDB.Client.Tests
 			{ // clear this tenant
 
 				Assume.That(tenant.Name, Is.EqualTo(name));
-				Assume.That(tenant.Prefix.Count, Is.EqualTo(8), "Prefix of tenants should be exactly 8 bytes: {0}", tenant.Prefix); //note: as of version 7.x !
+				Assume.That(tenant.Prefix.Count, Is.EqualTo(8), $"Prefix of tenants should be exactly 8 bytes: {tenant.Prefix}"); //note: as of version 7.x !
 				//Log($"Found test tenant {name} with id #{tenant.Id} and prefix {tenant.Prefix}");
 				await this.Db.WriteAsync(async tr =>
 				{
@@ -330,7 +330,7 @@ namespace FoundationDB.Client.Tests
 				await this.Db.WriteAsync(tr => Fdb.Tenants.CreateTenant(tr, name), this.Cancellation);
 
 				tenant = await this.Db.ReadAsync(tr => Fdb.Tenants.GetTenantMetadata(tr, name), this.Cancellation);
-				Assume.That(tenant, Is.Not.Null, "Could not create test tenant {0}", name);
+				Assume.That(tenant, Is.Not.Null, $"Could not create test tenant {name}");
 			}
 
 			return tenant;

--- a/FoundationDB.Tests/TestHelpers.cs
+++ b/FoundationDB.Tests/TestHelpers.cs
@@ -195,17 +195,17 @@ namespace FoundationDB.Client.Tests
 				FdbTest.Log("> Found " + count + " values");
 		}
 
-		public static async Task AssertThrowsFdbErrorAsync(Func<Task> asyncTest, FdbError expectedCode, string message = null, object[] args = null)
+		public static async Task AssertThrowsFdbErrorAsync(Func<Task> asyncTest, FdbError expectedCode, string message, params object[] args)
 		{
 			try
 			{
 				await asyncTest();
-				Assert.Fail(message, args);
+				Assert.Fail(string.Format(message, args));
 			}
 			catch (AssertionException) { throw; }
 			catch (Exception e)
 			{
-				Assert.That(e, Is.InstanceOf<FdbException>().With.Property("Code").EqualTo(expectedCode), message, args);
+				Assert.That(e, Is.InstanceOf<FdbException>().With.Property("Code").EqualTo(expectedCode), string.Format(message, args));
 			}
 		}
 

--- a/FoundationDB.Tests/TransactionFacts.cs
+++ b/FoundationDB.Tests/TransactionFacts.cs
@@ -705,8 +705,8 @@ namespace FoundationDB.Client.Tests
 					Log($"Check {key} == {expected} ?");
 					var res = await tr.CheckValueAsync(key, expected);
 					Log($"> [{res.Result}], {res.Actual:V}");
-					Assert.That(res.Actual, Is.EqualTo(actual), "Check({0} == {1}) => ({2}, {3}).Actual was {4}", key, expected, result, actual, res.Actual);
-					Assert.That(res.Result, Is.EqualTo(result), "Check({0} == {1}) => ({2}, {3}).Result was {4}", key, expected, result, actual, res.Result);
+					Assert.That(res.Actual, Is.EqualTo(actual), $"Check({key} == {expected}) => ({result}, {actual}).Actual was {res.Actual}");
+					Assert.That(res.Result, Is.EqualTo(result), $"Check({key} == {expected}) => ({result}, {actual}).Result was {res.Result}");
 				}
 
 				// hello should only be equal to 'World!', not any other value, empty or nil
@@ -799,7 +799,7 @@ namespace FoundationDB.Client.Tests
 				var data = await tr.GetAsync(key);
 				Assert.That(data.Count, Is.EqualTo(4), "data.Count");
 
-				Assert.That(data.ToInt32(), Is.EqualTo(expected), "0x{0:X8} {1} 0x{2:X8} = 0x{3:X8}", x, type, y, expected);
+				Assert.That(data.ToInt32(), Is.EqualTo(expected), $"0x{x:X8} {type} 0x{y:X8} = 0x{expected:X8}");
 			}
 		}
 


### PR DESCRIPTION
Upgrade from NUnit 3.x to 4.x (see #130)

The most frequent issue is converting the message formatting in assertion from "string.format"-like into a `FormattableString`.

Removed some old logic to run tests from the command line, as well as old async task helpers (from back in the day of the Async CTP) that don't seem to be called by anyone.

