### PR TITLE
Resolve vs TryResolve in subspace locations

### DIFF
--- a/FdbShell/Commands/BasicCommands.cs
+++ b/FdbShell/Commands/BasicCommands.cs
@@ -59,7 +59,7 @@ namespace FdbShell
 			var location = new FdbDirectorySubspaceLocation(path);
 			if (location.Path.Count != 0)
 			{
-				var subspace = await location.Resolve(tr);
+				var subspace = await location.TryResolve(tr);
 				return (subspace, subspace, subspace?.Copy().GetPrefix() ?? Slice.Nil);
 			}
 			else
@@ -778,7 +778,7 @@ namespace FdbShell
 
 			var dirLayer = path.Count > 0 ? folder.DirectoryLayer : db.DirectoryLayer;
 			// note: this may break in future versions of the DL! Maybe we need a custom API to get a flat list of all directories in a DL that span a specific range ?
-			var span = await db.ReadAsync(async tr => (await dirLayer.Content.Resolve(tr))!.ToRange(), ct);
+			var span = await db.ReadAsync(async tr => (await dirLayer.Content.Resolve(tr)).ToRange(), ct);
 
 			var shards = await Fdb.System.GetChunksAsync(db, span, ct);
 			int totalShards = shards.Count;

--- a/FoundationDB.Client/Fdb.Bulk.cs
+++ b/FoundationDB.Client/Fdb.Bulk.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -1535,7 +1535,7 @@ namespace FoundationDB.Client
 					// should export be lower priority? TODO: make if configurable!
 					tr.Options.WithPriorityBatch();
 
-					var folder = await path.Resolve(tr).ConfigureAwait(false);
+					var folder = await path.TryResolve(tr).ConfigureAwait(false);
 					if (previous.IsNull)
 					{
 						if (folder == null) throw new InvalidOperationException($"Failed to export the content of subspace {path} because it was not found.");

--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
@@ -190,9 +190,7 @@ namespace FoundationDB.Client
 			return (await metadata.CreateOrOpenInternalAsync(null, trans, location, prefix: Slice.Nil, allowCreate: true, allowOpen: false, throwOnError: true).ConfigureAwait(false))!;
 		}
 
-		/// <summary>Attempts to open the directory with the given <paramref name="path"/>.</summary>
-		/// <param name="trans">Transaction to use for the operation</param>
-		/// <param name="path">Path of the directory to open.</param>
+		/// <inheritdoc />
 		public async Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans);
@@ -203,6 +201,7 @@ namespace FoundationDB.Client
 			return (await metadata.CreateOrOpenInternalAsync(trans, null, location, prefix: Slice.Nil, allowCreate: false, allowOpen: true, throwOnError: false).ConfigureAwait(false))!;
 		}
 
+		/// <inheritdoc />
 		public async ValueTask<FdbDirectorySubspace?> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, FdbPath path)
 		{
 			Contract.NotNull(trans);
@@ -211,6 +210,7 @@ namespace FoundationDB.Client
 			return await metadata.OpenCachedInternalAsync(trans, path, throwOnError: false).ConfigureAwait(false);
 		}
 
+		/// <inheritdoc />
 		public async ValueTask<FdbDirectorySubspace?[]> TryOpenCachedAsync(IFdbReadOnlyTransaction trans, IEnumerable<FdbPath> paths)
 		{
 			Contract.NotNull(trans);

--- a/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectoryLayer.cs
@@ -480,7 +480,7 @@ namespace FoundationDB.Client
 
 		private async ValueTask<State> ResolveMetadata(IFdbReadOnlyTransaction tr)
 		{
-			var content = await this.Content.Resolve(tr).ConfigureAwait(false);
+			var content = await this.Content.TryResolve(tr).ConfigureAwait(false);
 			if (content == null) throw new InvalidOperationException("Directory Layer content subspace was not found");
 
 			var partition = new PartitionDescriptor(this.Path, content, null);

--- a/FoundationDB.Client/Layers/Directories/FdbDirectorySubspaceLocation.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbDirectorySubspaceLocation.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ namespace FoundationDB.Client
 
 		FdbDirectorySubspaceLocation IFdbDirectory.Location => this;
 
-		/// <summary>Create a new location that points to the Directory Subspace at the given path.</summary>
+		/// <summary>Creates a new location that points to the Directory Subspace at the given path.</summary>
 		/// <param name="path">Absolute path of the target Directory Subspace</param>
 		public FdbDirectorySubspaceLocation(FdbPath path)
 		{
@@ -66,6 +66,7 @@ namespace FoundationDB.Client
 			return await Resolve(tr, directory).ConfigureAwait(false);
 		}
 
+		/// <inheritdoc />
 		public ValueTask<FdbDirectorySubspace?> Resolve(IFdbReadOnlyTransaction tr, FdbDirectoryLayer? directory = null)
 		{
 			Contract.NotNull(tr);
@@ -92,58 +93,49 @@ namespace FoundationDB.Client
 			}
 		}
 
-		public override string ToString()
-		{
-			return this.Path.ToString();
-		}
+		/// <inheritdoc />
+		public override string ToString() => this.Path.ToString();
 
-		public override int GetHashCode()
-		{
-			return HashCode.Combine(this.Path.GetHashCode(), this.Layer.GetHashCode());
-		}
+		/// <inheritdoc />
+		public override int GetHashCode() => HashCode.Combine(this.Path.GetHashCode(), this.Layer.GetHashCode());
 
-		public override bool Equals(object? obj)
-		{
-			return obj is FdbDirectorySubspaceLocation loc && Equals(loc);
-		}
+		/// <inheritdoc />
+		public override bool Equals(object? obj) => obj is FdbDirectorySubspaceLocation loc && Equals(loc);
 
-		public bool Equals(ISubspaceLocation? other)
-		{
-			return other != null && other.Path == this.Path && other.Prefix.Count == 0;
-		}
+		/// <inheritdoc />
+		public bool Equals(ISubspaceLocation? other) => other != null && other.Path == this.Path && other.Prefix.Count == 0;
 
 		internal FdbPath GetSafePath()
-		{
-			if (this.IsPartition && this.Path.Count != 0) throw ThrowHelper.InvalidOperationException($"Cannot create a binary subspace under the root of directory partition '{this.Path}'.");
-			return this.Path;
-		}
+			=> !this.IsPartition || this.Path.Count == 0
+				? this.Path
+				: throw ThrowHelper.InvalidOperationException($"Cannot create a binary subspace under the root of directory partition '{this.Path}'.");
 
-		/// <summary>Append a segment to the current path</summary>
+		/// <summary>Appends a segment to the current path</summary>
 		public FdbDirectorySubspaceLocation this[FdbPathSegment segment] => new(this.Path.Add(segment));
 
-		/// <summary>Append one or more segments to the current path</summary>
-		public FdbDirectorySubspaceLocation this[ReadOnlySpan<FdbPathSegment> segments] => segments.Length != 0 ? new FdbDirectorySubspaceLocation(this.Path.Add(segments)) : this;
+		/// <summary>Appends one or more segments to the current path</summary>
+		public FdbDirectorySubspaceLocation this[ReadOnlySpan<FdbPathSegment> segments] => segments.Length != 0 ? new(this.Path.Add(segments)) : this;
 
-		/// <summary>Append a segment to the current path</summary>
+		/// <summary>Appends a segment to the current path</summary>
 		/// <param name="name">Name of the segment</param>
 		/// <remarks>The new segment will not have a layer id.</remarks>
 		public FdbDirectorySubspaceLocation this[string name] => new(this.Path.Add(FdbPathSegment.Create(name)));
 
-		/// <summary>Append a segment - composed of a name and layer id - to the current path</summary>
+		/// <summary>Appends a segment - composed of a name and layer id - to the current path</summary>
 		/// <param name="name">Name of the segment</param>
 		/// <param name="layerId">Layer Id of the segment</param>
 		public FdbDirectorySubspaceLocation this[string name, string layerId] => new(this.Path.Add(new FdbPathSegment(name, layerId)));
 
-		/// <summary>Append a relative path to the current path</summary>
-		public FdbDirectorySubspaceLocation this[FdbPath relativePath] => !relativePath.IsEmpty ? new FdbDirectorySubspaceLocation(this.Path.Add(relativePath)) : this;
+		/// <summary>Appends a relative path to the current path</summary>
+		public FdbDirectorySubspaceLocation this[FdbPath relativePath] => !relativePath.IsEmpty ? new(this.Path.Add(relativePath)) : this;
 
-		/// <summary>Append an encoded key to the prefix of the current location</summary>
+		/// <summary>Appends an encoded key to the prefix of the current location</summary>
 		/// <typeparam name="T1">Type of the key</typeparam>
 		/// <param name="item1">Key that will be appended to the current location's binary prefix</param>
 		/// <returns>A new subspace location with an additional binary suffix</returns>
 		public DynamicKeySubspaceLocation ByKey<T1>(T1 item1) => new(GetSafePath(), TuPack.EncodeKey(item1), TuPack.Encoding.GetDynamicKeyEncoder());
 
-		/// <summary>Append a pair encoded keys to the prefix of the current location</summary>
+		/// <summary>Appends a pair encoded keys to the prefix of the current location</summary>
 		/// <typeparam name="T1">Type of the first key</typeparam>
 		/// <typeparam name="T2">Type of the second key</typeparam>
 		/// <param name="item1">Key that will be appended first to the current location's binary prefix</param>

--- a/FoundationDB.Client/Layers/Directories/FdbHighContentionAllocator.cs
+++ b/FoundationDB.Client/Layers/Directories/FdbHighContentionAllocator.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -52,7 +52,7 @@ namespace FoundationDB.Layers.Allocators
 
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
 		{
-			var subspace = await this.Location.Resolve(tr).ConfigureAwait(false);
+			var subspace = await this.Location.TryResolve(tr).ConfigureAwait(false);
 			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location}' referenced by this high contention allocator was not found.");
 			return new State(subspace, m_rnd);
 		}

--- a/FoundationDB.Client/Layers/Directories/IFdbDirectory.cs
+++ b/FoundationDB.Client/Layers/Directories/IFdbDirectory.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -65,13 +65,13 @@ namespace FoundationDB.Client
 		/// <param name="path">Relative path of the subdirectory to open</param>
 		Task<FdbDirectorySubspace> OpenAsync(IFdbReadOnlyTransaction trans, FdbPath path);
 
-		/// <summary>Opens a subdirectory with the given <paramref name="path"/>.</summary>
+		/// <summary>Attempts to open the directory with the given <paramref name="path"/>.</summary>
 		/// <param name="trans">Transaction to use for the operation</param>
 		/// <param name="path">Relative path of the subdirectory to open</param>
-		/// <returns>Returns the directory if it exists, or null if it was not found</returns>
+		/// <returns>Returns the directory if it exists, or <c>null</c> if it was not found</returns>
 		Task<FdbDirectorySubspace?> TryOpenAsync(IFdbReadOnlyTransaction trans, FdbPath path);
 
-		/// <summary>Opens a subdirectory with the given <paramref name="path"/>, using the partition's cache context.</summary>
+		/// <summary>Attempts to open a subdirectory with the given <paramref name="path"/>, using the partition's cache context.</summary>
 		/// <returns>Returns the directory if it exists, or null if it was not found</returns>
 		/// <remarks>The instance returned MUST NOT be stored or kept outside the context of the transaction!
 		/// You must call <see cref="TryOpenCachedAsync(IFdbReadOnlyTransaction, FdbPath)"/> on every new transaction to obtain either the previously cached instance, or a new instance.
@@ -95,7 +95,7 @@ namespace FoundationDB.Client
 		/// <param name="subPath">Relative path of the subdirectory to create</param>
 		Task<FdbDirectorySubspace> CreateAsync(IFdbTransaction trans, FdbPath subPath);
 
-		/// <summary>Creates a subdirectory with the given <paramref name="subPath"/> (creating intermediate subdirectories if necessary).
+		/// <summary>Creates a subdirectory with the given <paramref name="subPath"/> (creating intermediate subdirectories if necessary), unless it already exists.
 		/// An exception is thrown if the given subdirectory already exists.
 		/// </summary>
 		/// <param name="trans">Transaction to use for the operation</param>

--- a/FoundationDB.Client/Query/FqlQuery.cs
+++ b/FoundationDB.Client/Query/FqlQuery.cs
@@ -135,7 +135,7 @@ namespace FoundationDB.Client
 				if (this.Directory.TryGetPath(out FdbPath path))
 				{ // this is a fixed path, ex: "/foo/bar/baz", we can open it directly
 
-					subspace = await root[path].Resolve(tr).ConfigureAwait(false);
+					subspace = await root[path].TryResolve(tr).ConfigureAwait(false);
 					if (subspace != null)
 					{
 						await channel.WriteAsync(subspace).ConfigureAwait(false);

--- a/FoundationDB.Client/Subspaces/IKeySubspace.cs
+++ b/FoundationDB.Client/Subspaces/IKeySubspace.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,7 @@ namespace FoundationDB.Client
 	/// A "vanilla" data subspace does not imply any encoding scheme by default, but can be wrapped into a more complex subspace which includes Key Codec.
 	/// </remarks>
 	/// 
-	/// <example>In pseudo code, and given a 'MySubspaceImpl' that implement <see cref="IKeySubspace"/>:
+	/// <example>In pseudocode, and given a 'MySubspaceImpl' that implement <see cref="IKeySubspace"/>:
 	/// <code>
 	/// subspace = new MySubspaceImpl({ABC})
 	/// subspace.ConcatKey({123}) => {ABC123}

--- a/FoundationDB.Client/Subspaces/KeySubspace.cs
+++ b/FoundationDB.Client/Subspaces/KeySubspace.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,7 @@ namespace FoundationDB.Client
 	using Doxense.Collections.Tuples;
 	using Doxense.Serialization.Encoders;
 
-	/// <summary>Adds a prefix on every keys, to group them inside a common subspace</summary>
+	/// <summary>Adds a prefix on every key, to group them inside a common subspace</summary>
 	[PublicAPI]
 	[DebuggerDisplay("{ToString(),nq}")]
 	public class KeySubspace : IKeySubspace, IEquatable<IKeySubspace>, IComparable<IKeySubspace>
@@ -231,7 +231,7 @@ namespace FoundationDB.Client
 		/// <summary>Remove the subspace prefix from a binary key, and only return the tail, or <see cref="Slice.Nil"/> if the key does not fit inside the namespace</summary>
 		/// <param name="absoluteKey">Complete key that contains the current subspace prefix, and a binary suffix</param>
 		/// <param name="boundCheck">If true, verify that <paramref name="absoluteKey"/> is inside the bounds of the subspace</param>
-		/// <returns>Binary suffix of the key (or <see cref="Slice.Empty"/> is the key is exactly equal to the subspace prefix). If the key is outside of the subspace, returns <see cref="Slice.Nil"/></returns>
+		/// <returns>Binary suffix of the key (or <see cref="Slice.Empty"/> is the key is exactly equal to the subspace prefix). If the key is outside the subspace, returns <see cref="Slice.Nil"/></returns>
 		/// <remarks>This is the inverse operation of <see cref="P:FoundationDB.Client.IKeySubspace.Item(Slice)"/></remarks>
 		/// <exception cref="System.ArgumentException">If <paramref name="boundCheck"/> is true and <paramref name="absoluteKey"/> is outside the current subspace.</exception>
 		public virtual Slice ExtractKey(Slice absoluteKey, bool boundCheck = false)
@@ -250,7 +250,7 @@ namespace FoundationDB.Client
 		/// <summary>Remove the subspace prefix from a binary key, and only return the tail, or <see cref="Slice.Nil"/> if the key does not fit inside the namespace</summary>
 		/// <param name="absoluteKey">Complete key that contains the current subspace prefix, and a binary suffix</param>
 		/// <param name="boundCheck">If true, verify that <paramref name="absoluteKey"/> is inside the bounds of the subspace</param>
-		/// <returns>Binary suffix of the key (or <see cref="Slice.Empty"/> is the key is exactly equal to the subspace prefix). If the key is outside of the subspace, returns <see cref="Slice.Nil"/></returns>
+		/// <returns>Binary suffix of the key (or <see cref="Slice.Empty"/> is the key is exactly equal to the subspace prefix). If the key is outside the subspace, returns <see cref="Slice.Nil"/></returns>
 		/// <remarks>This is the inverse operation of <see cref="P:FoundationDB.Client.IKeySubspace.Item(Slice)"/></remarks>
 		/// <exception cref="System.ArgumentException">If <paramref name="boundCheck"/> is true and <paramref name="absoluteKey"/> is outside the current subspace.</exception>
 		public virtual ReadOnlySpan<byte> ExtractKey(ReadOnlySpan<byte> absoluteKey, bool boundCheck = false)

--- a/FoundationDB.Client/Subspaces/SubspaceContext.cs
+++ b/FoundationDB.Client/Subspaces/SubspaceContext.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,7 @@ namespace FoundationDB.Client
 	}
 
 	/// <summary>Context for key subspaces that are always valid</summary>
-	public class SubspaceContext : ISubspaceContext
+	public sealed class SubspaceContext : ISubspaceContext
 	{
 		private SubspaceContext() { }
 
@@ -52,6 +52,7 @@ namespace FoundationDB.Client
 		}
 
 		public string Name => string.Empty;
+
 	}
 
 }

--- a/FoundationDB.Client/Subspaces/SubspaceLocation.cs
+++ b/FoundationDB.Client/Subspaces/SubspaceLocation.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -71,10 +71,10 @@ namespace FoundationDB.Client
 	public interface ISubspaceLocation<TSubspace> : ISubspaceLocation
 		where TSubspace : class, IKeySubspace
 	{
-		/// <summary>Return the actual subspace that corresponds to this location</summary>
+		/// <summary>Returns the actual subspace that corresponds to this location, if it exists.</summary>
 		/// <param name="tr">Current transaction</param>
 		/// <param name="directory"><see cref="FdbDirectoryLayer">DirectoryLayer</see> instance to use for the resolve. If null, uses the default database directory layer.</param>
-		/// <returns>Key subspace using the resolved key prefix of this location in the context of the current transaction, or null if the directory does not exist</returns>
+		/// <returns>Key subspace using the resolved key prefix of this location in the context of the current transaction, or <c>null</c> if the directory does not exist</returns>
 		/// <remarks>
 		/// The instance resolved for this transaction SHOULD NOT be used in the context of a different transaction, because its location in the Directory Layer may have been changed concurrently!
 		/// Re-using cached subspace instances MAY lead to DATA CORRUPTION if not used carefully! The best practice is to re-<see cref="Resolve"/>() the subspace again in each new transaction opened.
@@ -261,21 +261,22 @@ namespace FoundationDB.Client
 			return this.Prefix.Count == 0 ? folder : new DynamicKeySubspace(folder.GetPrefix() + this.Prefix, folder.KeyEncoder, folder.Context);
 		}
 
-		public DynamicKeySubspaceLocation this[Slice prefix] => prefix.Count != 0 ? new DynamicKeySubspaceLocation(this.Path, this.Prefix + prefix, this.Encoder) : this;
+		public DynamicKeySubspaceLocation this[Slice prefix] => prefix.Count != 0 ? new(this.Path, this.Prefix + prefix, this.Encoder) : this;
 
 		public DynamicKeySubspaceLocation this[byte[] prefix] => this[prefix.AsSlice()];
 
-		public DynamicKeySubspaceLocation this[ReadOnlySpan<byte> prefix] => prefix.Length != 0 ? new DynamicKeySubspaceLocation(this.Path, this.Prefix.Concat(prefix), this.Encoder) : this;
+		public DynamicKeySubspaceLocation this[ReadOnlySpan<byte> prefix] => prefix.Length != 0 ? new(this.Path, this.Prefix.Concat(prefix), this.Encoder) : this;
 
-		public DynamicKeySubspaceLocation this[IVarTuple tuple] => new DynamicKeySubspaceLocation(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, tuple), this.Encoder);
+		public DynamicKeySubspaceLocation this[IVarTuple tuple] => new(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, tuple), this.Encoder);
 
-		public DynamicKeySubspaceLocation ByKey<T1>(T1 item1) => new DynamicKeySubspaceLocation(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, STuple.Create(item1)), this.Encoder);
+		public DynamicKeySubspaceLocation ByKey<T1>(T1 item1) => new(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, STuple.Create(item1)), this.Encoder);
 
-		public DynamicKeySubspaceLocation ByKey<T1, T2>(T1 item1, T2 item2) => new DynamicKeySubspaceLocation(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, STuple.Create(item1, item2)), this.Encoder);
+		public DynamicKeySubspaceLocation ByKey<T1, T2>(T1 item1, T2 item2) => new(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, STuple.Create(item1, item2)), this.Encoder);
 
-		public DynamicKeySubspaceLocation ByKey<T1, T2, T3>(T1 item1, T2 item2, T3 item3) => new DynamicKeySubspaceLocation(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, STuple.Create(item1, item2, item3)), this.Encoder);
+		public DynamicKeySubspaceLocation ByKey<T1, T2, T3>(T1 item1, T2 item2, T3 item3) => new(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, STuple.Create(item1, item2, item3)), this.Encoder);
 
-		//TODO: more?
+		public DynamicKeySubspaceLocation ByKey<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4) => new(this.Path, this.Encoding.GetDynamicKeyEncoder().Pack(this.Prefix, STuple.Create(item1, item2, item3, item4)), this.Encoder);
+
 	}
 
 	/// <summary>Path to a subspace that can represent keys of a specific type</summary>
@@ -392,7 +393,7 @@ namespace FoundationDB.Client
 			return new TypedKeySubspace<T1, T2>(folder.GetPrefix() + this.Prefix, this.Encoder, folder.Context);
 		}
 
-		public TypedKeySubspaceLocation<T2> this[T1 item1] => new TypedKeySubspaceLocation<T2>(this.Path, this.Encoder.EncodePartialKey(this.Prefix, item1), this.Encoding.GetKeyEncoder<T2>());
+		public TypedKeySubspaceLocation<T2> this[T1 item1] => new(this.Path, this.Encoder.EncodePartialKey(this.Prefix, item1), this.Encoding.GetKeyEncoder<T2>());
 
 	}
 
@@ -704,10 +705,10 @@ namespace FoundationDB.Client
 	{
 
 		/// <summary>Represent the root directory of the Directory Layer</summary>
-		public static readonly DynamicKeySubspaceLocation Root = new DynamicKeySubspaceLocation(FdbPath.Root, Slice.Empty, TuPack.Encoding.GetDynamicKeyEncoder());
+		public static readonly DynamicKeySubspaceLocation Root = new(FdbPath.Root, Slice.Empty, TuPack.Encoding.GetDynamicKeyEncoder());
 
 		/// <summary>Represent a location without any prefix, and outside the jurisdiction of the Directory Layer</summary>
-		public static readonly DynamicKeySubspaceLocation Empty = new DynamicKeySubspaceLocation(Slice.Empty, TuPack.Encoding.GetDynamicKeyEncoder());
+		public static readonly DynamicKeySubspaceLocation Empty = new(Slice.Empty, TuPack.Encoding.GetDynamicKeyEncoder());
 
 		#region FromPath...
 

--- a/FoundationDB.Client/Subspaces/TypedKeySubspace`1.cs
+++ b/FoundationDB.Client/Subspaces/TypedKeySubspace`1.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -140,7 +140,7 @@ namespace FoundationDB.Client
 		#region Ranges...
 
 		/// <summary>Return the range of all legal keys in this subspace, that start with the specified value</summary>
-		/// <returns>Range that encompass all keys that start with (tuple.Item1, ..)</returns>
+		/// <returns>Range that encompass all keys that start with (tuple.Item1, ...)</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static KeyRange PackRange<T1>(this ITypedKeySubspace<T1> self, STuple<T1> tuple)
 		{
@@ -148,7 +148,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return the range of all legal keys in this subspace, that start with the specified value</summary>
-		/// <returns>Range that encompass all keys that start with (tuple.Item1, ..)</returns>
+		/// <returns>Range that encompass all keys that start with (tuple.Item1, ...)</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static KeyRange PackRange<T1>(this ITypedKeySubspace<T1> self, ValueTuple<T1> tuple)
 		{

--- a/FoundationDB.Client/Subspaces/TypedKeySubspace`2.cs
+++ b/FoundationDB.Client/Subspaces/TypedKeySubspace`2.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -183,7 +183,7 @@ namespace FoundationDB.Client
 		#region Ranges
 
 		/// <summary>Return the range of all legal keys in this subspace, that start with the specified pair of values</summary>
-		/// <returns>Range that encompass all keys that start with (item1, item2, ..)</returns>
+		/// <returns>Range that encompass all keys that start with (item1, item2, ...)</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static KeyRange EncodeRange<T1, T2>(this ITypedKeySubspace<T1, T2> self, T1? item1, T2? item2)
 		{
@@ -192,7 +192,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return the range of all legal keys in this subspace, that start with the specified pair of values</summary>
-		/// <returns>Range that encompass all keys that start with (tuple.Item1, tuple.Item2, ..)</returns>
+		/// <returns>Range that encompass all keys that start with (tuple.Item1, tuple.Item2, ...)</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static KeyRange PackRange<T1, T2>(this ITypedKeySubspace<T1, T2> self, (T1?, T2?) tuple)
 		{
@@ -200,7 +200,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return the range of all legal keys in this subspace, that start with the specified pair of values</summary>
-		/// <returns>Range that encompass all keys that start with (tuple.Item1, tuple.Item2, ..)</returns>
+		/// <returns>Range that encompass all keys that start with (tuple.Item1, tuple.Item2, ...)</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static KeyRange PackRange<T1, T2, TTuple>(this ITypedKeySubspace<T1, T2> self, TTuple tuple)
 			where TTuple : IVarTuple
@@ -214,7 +214,7 @@ namespace FoundationDB.Client
 		#region ToRangePartial()
 
 		/// <summary>Return the range of all legal keys in this subspace, that start with the specified first item</summary>
-		/// <returns>Range that encompass all keys that start with (item1, ..)</returns>
+		/// <returns>Range that encompass all keys that start with (item1, ...)</returns>
 		[Pure]
 		public static KeyRange EncodePartialRange<T1, T2>(this ITypedKeySubspace<T1, T2> self, T1? item1)
 		{
@@ -222,7 +222,7 @@ namespace FoundationDB.Client
 		}
 
 		/// <summary>Return the range of all legal keys in this subspace, that start with the specified first item</summary>
-		/// <returns>Range that encompass all keys that start with (tuple.Item1, ..)</returns>
+		/// <returns>Range that encompass all keys that start with (tuple.Item1, ...)</returns>
 		[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static KeyRange PackPartialRange<T1, T2>(this ITypedKeySubspace<T1, T2> self, STuple<T1> tuple)
 		{

--- a/FoundationDB.Layers.Common/Blobs/FdbBlob.cs
+++ b/FoundationDB.Layers.Common/Blobs/FdbBlob.cs
@@ -76,9 +76,7 @@ namespace FoundationDB.Layers.Blobs
 
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
 		{
-			var subspace = await this.Location.Resolve(tr);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location} referenced by Blob Layer was not found.");
-			return new State(subspace);
+			return new State(await this.Location.Resolve(tr).ConfigureAwait(false));
 		}
 
 		[PublicAPI]

--- a/FoundationDB.Layers.Common/Blobs/FdbBlob.cs
+++ b/FoundationDB.Layers.Common/Blobs/FdbBlob.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@ namespace FoundationDB.Layers.Blobs
 	using System.Globalization;
 
 	/// <summary>Represents a potentially large binary value in FoundationDB.</summary>
-	[DebuggerDisplay("Subspace={" + nameof(FdbBlob.Location) + "}")]
+	[DebuggerDisplay("Location={Location}")]
 	[PublicAPI]
 	public class FdbBlob : IFdbLayer<FdbBlob.State>
 	{
@@ -81,6 +81,8 @@ namespace FoundationDB.Layers.Blobs
 			return new State(subspace);
 		}
 
+		[PublicAPI]
+		[DebuggerDisplay("Subspace={Subspace}")]
 		public sealed class State
 		{
 
@@ -96,7 +98,7 @@ namespace FoundationDB.Layers.Blobs
 			/// <returns>123 => (subspace, 'D', "             123")</returns>
 			private Slice DataKey(long offset)
 			{
-				//note: python code uses "%16d" % offset, which pads the value with spaces.. Not sure why ?
+				//note: python code uses "%16d" % offset, which pads the value with spaces... Not sure why ?
 				return this.Subspace.Encode(DataSuffix, offset.ToString("D16", CultureInfo.InvariantCulture));
 			}
 
@@ -210,9 +212,7 @@ namespace FoundationDB.Layers.Blobs
 
 			#endregion
 
-			/// <summary>
-			/// Delete all key-value pairs associated with the blob.
-			/// </summary>
+			/// <summary>Deletes all key-value pairs associated with the blob.</summary>
 			public void Delete(IFdbTransaction trans)
 			{
 				Contract.NotNull(trans);
@@ -220,10 +220,8 @@ namespace FoundationDB.Layers.Blobs
 				trans.ClearRange(this.Subspace.ToRange());
 			}
 
-			/// <summary>
-			/// Get the size (in bytes) of the blob.
-			/// </summary>
-			/// <returns>Return null if the blob does not exists, 0 if is empty, or the size in bytes</returns>
+			/// <summary>Gets the size (in bytes) of the blob.</summary>
+			/// <returns>Return null if the blob does not exist, 0 if is empty, or the size in bytes</returns>
 			public Task<long?> GetSizeAsync(IFdbReadOnlyTransaction trans)
 			{
 				Contract.NotNull(trans);
@@ -236,7 +234,7 @@ namespace FoundationDB.Layers.Blobs
 
 				Slice value = await trans.GetAsync(SizeKey()).ConfigureAwait(false);
 
-				if (value.IsNullOrEmpty) return default(long?);
+				if (value.IsNullOrEmpty) return null;
 
 				//note: python code stores the size as a string
 				long size = long.Parse(value.ToString());
@@ -244,9 +242,7 @@ namespace FoundationDB.Layers.Blobs
 				return size;
 			}
 
-			/// <summary>
-			/// Read from the blob, starting at <paramref name="offset"/>, retrieving up to <paramref name="n"/> bytes (fewer then n bytes are returned when the end of the blob is reached).
-			/// </summary>
+			/// <summary>Reads from the blob, starting at <paramref name="offset"/>, retrieving up to <paramref name="n"/> bytes (fewer than n bytes are returned when the end of the blob is reached).</summary>
 			public async Task<Slice> ReadAsync(IFdbReadOnlyTransaction trans, long offset, int n)
 			{
 				Contract.NotNull(trans);
@@ -297,7 +293,7 @@ namespace FoundationDB.Layers.Blobs
 				return buffer.AsSlice(0, buffer.Length);
 			}
 
-			/// <summary>Write <paramref name="data"/> to the blob, starting at <paramref name="offset"/> and overwriting any existing data at that location. The length of the blob is increased if necessary.</summary>
+			/// <summary>Writes <paramref name="data"/> to the blob, starting at <paramref name="offset"/> and overwriting any existing data at that location. The length of the blob is increased if necessary.</summary>
 			public async Task WriteAsync(IFdbTransaction trans, long offset, ReadOnlyMemory<byte> data)
 			{
 				Contract.NotNull(trans);
@@ -321,15 +317,13 @@ namespace FoundationDB.Layers.Blobs
 				}
 			}
 
-			/// <summary>Write <paramref name="data"/> to the blob, starting at <paramref name="offset"/> and overwriting any existing data at that location. The length of the blob is increased if necessary.</summary>
+			/// <summary>Writes <paramref name="data"/> to the blob, starting at <paramref name="offset"/> and overwriting any existing data at that location. The length of the blob is increased if necessary.</summary>
 			public Task WriteAsync(IFdbTransaction trans, long offset, Slice data)
 			{
 				return WriteAsync(trans, offset, data.Memory);
 			}
 
-			/// <summary>
-			/// Append the contents of <paramref name="data"/> onto the end of the blob.
-			/// </summary>
+			/// <summary>Appends the contents of <paramref name="data"/> onto the end of the blob.</summary>
 			public async Task AppendAsync(IFdbTransaction trans, ReadOnlyMemory<byte> data)
 			{
 				Contract.NotNull(trans);
@@ -342,17 +336,13 @@ namespace FoundationDB.Layers.Blobs
 				SetSize(trans, oldLength + data.Length);
 			}
 
-			/// <summary>
-			/// Append the contents of <paramref name="data"/> onto the end of the blob.
-			/// </summary>
+			/// <summary>Appends the contents of <paramref name="data"/> onto the end of the blob.</summary>
 			public Task AppendAsync(IFdbTransaction trans, Slice data)
 			{
 				return AppendAsync(trans, data.Memory);
 			}
 
-			/// <summary>
-			/// Change the blob length to <paramref name="newLength"/>, erasing any data when shrinking, and filling new bytes with 0 when growing.
-			/// </summary>
+			/// <summary>Changes the blob length to <paramref name="newLength"/>, erasing any data when shrinking, and filling new bytes with 0 when growing.</summary>
 			public async Task TruncateAsync(IFdbTransaction trans, long newLength)
 			{
 				Contract.NotNull(trans);

--- a/FoundationDB.Layers.Common/Collections/FdbMap`2.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbMap`2.cs
@@ -263,7 +263,6 @@ namespace FoundationDB.Layers.Collections
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
 		{
 			var subspace = await this.Location.Resolve(tr);
-			if (subspace is null) throw new InvalidOperationException($"Location '{this.Location} referenced by Map Layer was not found.");
 
 			//TODO: store in transaction context?
 			return new State(subspace, this.ValueEncoder);

--- a/FoundationDB.Layers.Common/Collections/FdbMultimap`2.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbMultimap`2.cs
@@ -209,8 +209,6 @@ namespace FoundationDB.Layers.Collections
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
 		{
 			var subspace = await this.Location.Resolve(tr);
-			if (subspace is null) throw new InvalidOperationException($"Location '{this.Location} referenced by MultiMap Layer was not found.");
-
 			return new State(subspace, this.AllowNegativeValues);
 		}
 

--- a/FoundationDB.Layers.Common/Collections/FdbQueue`1.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbQueue`1.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,6 @@ namespace FoundationDB.Layers.Collections
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
 		{
 			var subspace = await this.Location.Resolve(tr);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location} referenced by Queue Layer was not found.");
 			return new State(subspace, this.Encoder);
 		}
 

--- a/FoundationDB.Layers.Common/Collections/FdbRankedSet.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbRankedSet.cs
@@ -36,8 +36,9 @@ namespace FoundationDB.Layers.Collections
 	[PublicAPI]
 	public class FdbRankedSet : IFdbLayer<FdbRankedSet.State>
 	{
-		// based on the lost implementation that used to be at https://github.com/FoundationDB/python-layers/blob/master/lib/rankedset.py
-		// => this version as been "lost to time", and only this c# port remains (archive.org does not have a copy)
+		// Based on the lost implementation that used to be at https://github.com/FoundationDB/python-layers/blob/master/lib/rankedset.py
+		// => this version has been "lost to time", and only this c# port remains (archive.org does not have a copy)
+		// There is also a newer implementation in Java that can be seen at https://github.com/FoundationDB/fdb-record-layer/blob/main/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
 
 		private const int MAX_LEVELS = 6;
 		private const int LEVEL_FAN_POW = 4; // 2^X per level

--- a/FoundationDB.Layers.Common/Collections/FdbRankedSet.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbRankedSet.cs
@@ -308,8 +308,6 @@ namespace FoundationDB.Layers.Collections
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
 		{
 			var subspace = await this.Location.Resolve(tr);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location} referenced by Ranked Set Layer was not found.");
-
 			return new State(subspace);
 		}
 

--- a/FoundationDB.Layers.Common/Collections/FdbVector`1.cs
+++ b/FoundationDB.Layers.Common/Collections/FdbVector`1.cs
@@ -327,7 +327,6 @@ namespace FoundationDB.Layers.Collections
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
 		{
 			var subspace = await this.Location.Resolve(tr);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location} referenced by Vector Layer was not found.");
 			return new State(subspace, this.DefaultValue, this.Encoder);
 		}
 

--- a/FoundationDB.Layers.Common/Counters/FdbHighContentionCounter.cs
+++ b/FoundationDB.Layers.Common/Counters/FdbHighContentionCounter.cs
@@ -85,7 +85,6 @@ namespace FoundationDB.Layers.Counters
 			{
 				long total = 0;
 				var subspace = await this.Location.Resolve(tr);
-				if (subspace == null) throw new InvalidOperationException($"Location '{this.Location} referenced by High Contention Counter Layer was not found.");
 
 				// read N writes from a random place in ID space
 				var loc = subspace.Encode(RandomId());
@@ -174,7 +173,7 @@ namespace FoundationDB.Layers.Counters
 		{
 			if (trans == null) throw new ArgumentNullException(nameof(trans));
 
-			var subspace = await this.Location.Resolve(trans);
+			var subspace = await this.Location.TryResolve(trans);
 			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location} referenced by High Contention Counter Layer was not found.");
 
 			trans.Set(subspace.Encode(RandomId()), this.Encoder.EncodeValue(x));

--- a/FoundationDB.Layers.Common/Counters/FdbHighContentionCounter.cs
+++ b/FoundationDB.Layers.Common/Counters/FdbHighContentionCounter.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -79,7 +79,7 @@ namespace FoundationDB.Layers.Counters
 			}
 		}
 
-		private Task Coalesce(IFdbDatabase db, int N, CancellationToken ct)
+		private Task Coalesce(IFdbDatabase db, int limit, CancellationToken ct)
 		{
 			return db.WriteAsync(async tr =>
 			{
@@ -93,8 +93,8 @@ namespace FoundationDB.Layers.Counters
 				bool right;
 				lock (this.Rng) { right = this.Rng.NextDouble() < 0.5; }
 				var query = right
-					? tr.Snapshot.GetRange(loc, subspace.ToRange().End, new FdbRangeOptions { Limit = N })
-					: tr.Snapshot.GetRange(subspace.ToRange().Begin, loc, new FdbRangeOptions { Limit = N , IsReversed = true });
+					? tr.Snapshot.GetRange(loc, subspace.ToRange().End, new() { Limit = limit })
+					: tr.Snapshot.GetRange(subspace.ToRange().Begin, loc, new() { Limit = limit , IsReversed = true });
 				var shards = await query.ToListAsync().ConfigureAwait(false);
 
 				if (shards.Count > 0)

--- a/FoundationDB.Layers.Common/Indexes/FdbIndex`2.cs
+++ b/FoundationDB.Layers.Common/Indexes/FdbIndex`2.cs
@@ -160,7 +160,6 @@ namespace FoundationDB.Layers.Indexing
 			//TODO: cache the instance on the transaction!
 
 			var subspace = await this.Location.Resolve(trans);
-			if (subspace is null) throw new InvalidOperationException($"Location '{this.Location} referenced by Index Layer was not found.");
 
 			return new State(this, subspace);
 		}

--- a/FoundationDB.Layers.Common/Interning/FdbStringIntern.cs
+++ b/FoundationDB.Layers.Common/Interning/FdbStringIntern.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -61,7 +61,7 @@ namespace FoundationDB.Layers.Interning
 
 			public bool Equals(Uid? other)
 			{
-				return !object.ReferenceEquals(other, null) && other.HashCode == this.HashCode && other.Slice.Equals(this.Slice);
+				return !ReferenceEquals(other, null) && other.HashCode == this.HashCode && other.Slice.Equals(this.Slice);
 			}
 
 			public override bool Equals(object? obj)

--- a/FoundationDB.Layers.Common/Interning/FdbStringIntern.cs
+++ b/FoundationDB.Layers.Common/Interning/FdbStringIntern.cs
@@ -96,7 +96,6 @@ namespace FoundationDB.Layers.Interning
 		public async ValueTask<State> Resolve(IFdbReadOnlyTransaction tr)
 		{
 			var subspace = await this.Location.Resolve(tr);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location} referenced by String Interning Layer was not found.");
 			return new State(this, subspace);
 		}
 

--- a/FoundationDB.Layers.Experimental/Documents/FdbDocumentCollection.cs
+++ b/FoundationDB.Layers.Experimental/Documents/FdbDocumentCollection.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -89,7 +89,6 @@ namespace FoundationDB.Layers.Documents
 			var packed = this.ValueEncoder.EncodeValue(document);
 
 			var subspace = await this.Location.Resolve(trans);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location}' referenced by Document Collection Layer was not found.");
 
 			// Key Prefix = ...(id,)
 			var key = subspace.EncodePartial(id);
@@ -128,7 +127,6 @@ namespace FoundationDB.Layers.Documents
 			Contract.NotNull(id);
 
 			var subspace = await this.Location.Resolve(trans);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location}' referenced by Document Collection Layer was not found.");
 
 			var parts = await LoadPartsAsync(subspace, trans, id).ConfigureAwait(false);
 
@@ -142,7 +140,6 @@ namespace FoundationDB.Layers.Documents
 			Contract.NotNull(ids);
 
 			var subspace = await this.Location.Resolve(trans);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location}' referenced by Document Collection Layer was not found.");
 
 			var results = await Task.WhenAll(ids.Select(id => LoadPartsAsync(subspace, trans, id)));
 
@@ -156,7 +153,6 @@ namespace FoundationDB.Layers.Documents
 			Contract.NotNull(id);
 
 			var subspace = await this.Location.Resolve(trans);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location}' referenced by Document Collection Layer was not found.");
 
 			var key = subspace.EncodePartial(id);
 			trans.ClearRange(KeyRange.StartsWith(key));
@@ -170,7 +166,6 @@ namespace FoundationDB.Layers.Documents
 			Contract.NotNull(ids);
 
 			var subspace = await this.Location.Resolve(trans);
-			if (subspace == null) throw new InvalidOperationException($"Location '{this.Location}' referenced by Document Collection Layer was not found.");
 
 			foreach (var id in ids)
 			{

--- a/FoundationDB.Testing/FdbTest.cs
+++ b/FoundationDB.Testing/FdbTest.cs
@@ -369,7 +369,7 @@ namespace FoundationDB.Client.Tests
 			{
 				tr.StopLogging();
 
-				var subspace = await path.Resolve(tr);
+				var subspace = await path.TryResolve(tr);
 				if (subspace == null)
 				{
 					Log($"Dumping content of subspace {path}:");
@@ -439,7 +439,7 @@ namespace FoundationDB.Client.Tests
 		[DebuggerStepThrough]
 		protected async Task DumpSubspace(IFdbReadOnlyTransaction tr, ISubspaceLocation location)
 		{
-			var subspace = await location.Resolve(tr);
+			var subspace = await location.TryResolve(tr);
 			if (subspace != null)
 			{
 				await DumpSubspace(tr, subspace);
@@ -481,7 +481,7 @@ namespace FoundationDB.Client.Tests
 			{
 				var indent = new string('\t', depth);
 
-				var subspace = await path.Resolve(tr);
+				var subspace = await path.TryResolve(tr);
 				if (subspace == null)
 				{
 					Log($"# {indent}- {path} => NOT FOUND");

--- a/FoundationDB.Tests/Common/MapFacts.cs
+++ b/FoundationDB.Tests/Common/MapFacts.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -105,7 +105,6 @@ namespace FoundationDB.Layers.Collections.Tests
 
 					// also check directly
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 					var data = await tr.GetAsync(folder!.Encode("Foos", "hello"));
 					Assert.That(data, Is.EqualTo(Slice.Nil));
 				}, this.Cancellation);

--- a/FoundationDB.Tests/Common/StringInternFacts.cs
+++ b/FoundationDB.Tests/Common/StringInternFacts.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -55,8 +55,7 @@ namespace FoundationDB.Layers.Interning.Tests
 					var vd = await table.InternAsync(tr, "cat");
 					var ve = await table.InternAsync(tr, "cat");
 
-					var subspace = (await dataSpace.Resolve(tr))!;
-					Assert.That(subspace, Is.Not.Null);
+					var subspace = await dataSpace.Resolve(tr);
 					tr.Set(subspace["a"], va);
 					tr.Set(subspace["b"], vb);
 					tr.Set(subspace["c"], vc);
@@ -72,8 +71,7 @@ namespace FoundationDB.Layers.Interning.Tests
 				// check the contents of the data
 				await stringTable.ReadAsync(db, async (tr, table) =>
 				{
-					var subspace = (await dataSpace.Resolve(tr))!;
-					Assert.That(subspace, Is.Not.Null);
+					var subspace = await dataSpace.Resolve(tr);
 					var uid_a = await tr.GetAsync(subspace["a"]);
 					var uid_b = await tr.GetAsync(subspace["b"]);
 					var uid_c = await tr.GetAsync(subspace["c"]);

--- a/FoundationDB.Tests/DatabaseFacts.cs
+++ b/FoundationDB.Tests/DatabaseFacts.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -266,7 +266,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 			{
-				var root = await db.Root.Resolve(tr);
+				var root = await db.Root.TryResolve(tr);
 				Assert.That(root, Is.Not.Null);
 				Assert.That(root!.Path, Is.EqualTo(db.Root.Path));
 				Assert.That(root.DirectoryLayer, Is.SameAs(dl));

--- a/FoundationDB.Tests/ExoticTestCases.cs
+++ b/FoundationDB.Tests/ExoticTestCases.cs
@@ -24,10 +24,10 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-#nullable disable
-// ReSharper disable AssignNullToNotNullAttribute
+// ReSharper disable ConvertToUsingDeclaration
+// ReSharper disable StringLiteralTypo
 
- namespace FoundationDB.Client.Tests
+namespace FoundationDB.Client.Tests
 {
 
 	[TestFixture][Ignore("These tests are not meant to be run as part of a CI build")]
@@ -84,7 +84,7 @@
 					tr.ClearRange(subspace.Encode("AAA"), Text("BBB"));
 					tr.ClearRange(subspace.Encode("BBB"), Text("CCC"));
 					tr.ClearRange(subspace.Encode("CCC"), Text("DDD"));
-					// should be merged into a single AAA..DDD
+					// should be merged into a single AAA...DDD
 					await tr.CommitAsync();
 				}
 			}

--- a/FoundationDB.Tests/ExoticTestCases.cs
+++ b/FoundationDB.Tests/ExoticTestCases.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -237,7 +237,7 @@
 					var vA = Slice.FromFixedU32BE(0xAAAAAAAA); // 10101010
 					var vC = Slice.FromFixedU32BE(0xCCCCCCCC); // 11001100
 
-					var cmds = new[]
+					var commands = new[]
 					{
 						new { Op = "SET", Left = vX, Right = vY },
 						new { Op = "ADD", Left = vX, Right = vY },
@@ -279,14 +279,14 @@
 						}
 					}
 
-					for (int i = 0; i < cmds.Length; i++)
+					for (int i = 0; i < commands.Length; i++)
 					{
-						for (int j = 0; j < cmds.Length; j++)
+						for (int j = 0; j < commands.Length; j++)
 						{
-							var key = subspace.Encode(cmds[i].Op + "_" + cmds[j].Op);
+							var key = subspace.Encode(commands[i].Op + "_" + commands[j].Op);
 							Log($"{i};{j} = {key}");
-							Apply(tr, cmds[i].Op, key, cmds[i].Left);
-							Apply(tr, cmds[j].Op, key, cmds[j].Right);
+							Apply(tr, commands[i].Op, key, commands[i].Left);
+							Apply(tr, commands[j].Op, key, commands[j].Right);
 						}
 					}
 
@@ -622,13 +622,6 @@
 			{
 				db.SetDefaultLogHandler((log) => Log(log.GetTimingsReport(true)));
 
-				//using (var tr = db.BeginTransaction(this.Cancellation))
-				//{
-				//	tr.ClearRange(subspace.Encode("K"), subspace.Encode("KZZZZZZZZZ"));
-				//	await tr.CommitAsync();
-				//}
-				//return;
-
 				// set the key
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
@@ -740,24 +733,16 @@
 				{
 					for (int i = 0; i < 20; i++)
 					{
-						//tr.Timeout = 500;
-						//try
-						//{
-						//	await tr.GetAsync(Slice.FromAscii("SomeRandomKey"));
-						//	Assert.Fail("The database must be offline !");
-						//}
-						//catch(FdbException e)
-						{
-							var code = i > 1 && i < 10 ? FdbError.TransactionTooOld : FdbError.CommitUnknownResult;
-							var sw = Stopwatch.StartNew();
-							await tr.OnErrorAsync(code).ConfigureAwait(false);
-							sw.Stop();
-							Log($"{sw.Elapsed.TotalMilliseconds:N3}");
-						}
+						var code = i is > 1 and < 10 ? FdbError.TransactionTooOld : FdbError.CommitUnknownResult;
+						var sw = Stopwatch.StartNew();
+						await tr.OnErrorAsync(code).ConfigureAwait(false);
+						sw.Stop();
+						Log($"{sw.Elapsed.TotalMilliseconds:N3}");
 					}
 				}
 			}
 		}
 
 	}
+
 }

--- a/FoundationDB.Tests/Filters/LoggingFilterFacts.cs
+++ b/FoundationDB.Tests/Filters/LoggingFilterFacts.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -47,7 +47,6 @@ namespace FoundationDB.Filters.Logging.Tests
 			await db.WriteAsync(async (tr) =>
 			{
 				var subspace = await location.Resolve(tr);
-				Assert.That(subspace, Is.Not.Null);
 
 				await tr.GetReadVersionAsync();
 				tr.Set(subspace.Encode("Warmup", 0), Slice.FromInt32(1));
@@ -60,7 +59,6 @@ namespace FoundationDB.Filters.Logging.Tests
 			await db.WriteAsync(async (tr) =>
 			{
 				var subspace = await location.Resolve(tr);
-				Assert.That(subspace, Is.Not.Null);
 
 				var rnd = new Random();
 				tr.Set(subspace.Encode("One"), Text("111111"));
@@ -108,7 +106,6 @@ namespace FoundationDB.Filters.Logging.Tests
 					Assert.That(tr.IsLogged(), Is.True);
 
 					var subspace = await location.Resolve(tr);
-					Assert.That(subspace, Is.Not.Null);
 
 					//tr.SetOption(FdbTransactionOption.CausalReadRisky);
 

--- a/FoundationDB.Tests/Layers/DirectoryFacts.cs
+++ b/FoundationDB.Tests/Layers/DirectoryFacts.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/Providers/AsyncQueryableFacts.cs
+++ b/FoundationDB.Tests/Providers/AsyncQueryableFacts.cs
@@ -44,14 +44,14 @@ namespace FoundationDB.Linq.Tests
 
 				await db.WriteAsync(async (tr) =>
 				{
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 					tr.Set(subspace.Encode("Hello"), Text("World!"));
 					tr.Set(subspace.Encode("Narf"), Text("Zort"));
 				}, this.Cancellation);
 
 				await db.ReadAsync(async tr =>
 				{
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 
 					var range = tr.Query().RangeStartsWith(subspace.GetPrefix());
 					Assert.That(range, Is.InstanceOf<FdbAsyncSequenceQuery<KeyValuePair<Slice, Slice>>>());

--- a/FoundationDB.Tests/Providers/AsyncQueryableFacts.cs
+++ b/FoundationDB.Tests/Providers/AsyncQueryableFacts.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without

--- a/FoundationDB.Tests/Query/FqlQueriesFacts.cs
+++ b/FoundationDB.Tests/Query/FqlQueriesFacts.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -94,7 +94,7 @@ namespace FoundationDB.Client.Tests
 			// create the structure of directories
 			await db.WriteAsync(async tr =>
 			{
-				var parent = (await location.Resolve(tr, createIfMissing: true))!;
+				var parent = await location.ResolveOrCreate(tr);
 
 				foreach (var path in (string[])
 				[
@@ -135,7 +135,7 @@ namespace FoundationDB.Client.Tests
 				
 				await db.WriteAsync(async tr =>
 				{
-					var subspace = (await db.Root[FdbPath.Parse($"users/{user}/documents/music")].Resolve(tr).ConfigureAwait(false))!;
+					var subspace = await db.Root[FdbPath.Parse($"users/{user}/documents/music")].Resolve(tr).ConfigureAwait(false);
 					
 					tr.SetValueString(subspace.Encode("name"), "Albums");
 					tr.SetValueInt32(subspace.Encode("count"), count);

--- a/FoundationDB.Tests/RangeQueryFacts.cs
+++ b/FoundationDB.Tests/RangeQueryFacts.cs
@@ -124,7 +124,6 @@ namespace FoundationDB.Client.Tests
 				var data = await db.ReadWriteAsync(async tr =>
 				{
 					var subspace = await location.Resolve(tr);
-					Assert.That(subspace, Is.Not.Null);
 					var items = Enumerable.Range(0, N).Select(i => (subspace.Encode(i), Slice.FromInt32(i))).ToArray();
 					tr.SetValues(items);
 					return items;
@@ -138,7 +137,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					Log("Getting range (WantAll)...");
 					var ts = Stopwatch.StartNew();
@@ -167,7 +165,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					Log("Getting range (Iterator)...");
 					var ts = Stopwatch.StartNew();
@@ -226,7 +223,7 @@ namespace FoundationDB.Client.Tests
 
 				await db.WriteAsync(async tr =>
 				{
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 					tr.SetValues(data.Select(kv => KeyValuePair.Create(subspace.Encode(kv.Key), Slice.FromStringUtf8(kv.Value))));
 				}, this.Cancellation);
 
@@ -238,7 +235,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					Log("Getting range (WantAll)...");
 					var ts = Stopwatch.StartNew();
@@ -269,7 +265,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					Log("Getting range (Iterator)...");
 					var ts = Stopwatch.StartNew();
@@ -340,7 +335,6 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -355,7 +349,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.Encode(0), folder.Encode(N));
 					Assert.That(query, Is.Not.Null);
@@ -421,7 +414,6 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -436,7 +428,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr
 						.GetRange(folder.Encode(0), folder.Encode(N))
@@ -512,7 +503,6 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					tr.SetValues(Enumerable.Range(0, N).Select(i => (folder.Encode(i), Slice.FromInt32(i))));
 				}, this.Cancellation);
@@ -522,7 +512,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var chunk = await tr.GetRangeAsync(
 						folder.Encode(0),
@@ -555,7 +544,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.Encode(0), folder.Encode(N), FdbRangeOptions.KeysOnly);
 					Assert.That(query.Fetch, Is.EqualTo(FdbFetchMode.KeysOnly));
@@ -584,7 +572,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRangeKeys(folder.Encode(0), folder.Encode(N));
 
@@ -624,7 +611,6 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -635,7 +621,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var chunk = await tr.GetRangeAsync(
 						folder.Encode(0),
@@ -667,7 +652,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(
 						folder.Encode(0),
@@ -699,7 +683,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRangeValues(folder.Encode(0), folder.Encode(N));
 
@@ -722,7 +705,6 @@ namespace FoundationDB.Client.Tests
 				await db.ReadAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRangeValues(
 						folder.Encode(0),
@@ -766,7 +748,6 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -778,7 +759,6 @@ namespace FoundationDB.Client.Tests
 					await db.ReadAsync(async tr =>
 					{
 						var folder = await location.Resolve(tr);
-						Assert.That(folder, Is.Not.Null);
 
 						var query = tr.GetRange(
 							folder.Encode(0),
@@ -807,7 +787,6 @@ namespace FoundationDB.Client.Tests
 					await db.ReadAsync(async tr =>
 					{
 						var folder = await location.Resolve(tr);
-						Assert.That(folder, Is.Not.Null);
 
 						var query = tr
 							.GetRange(
@@ -839,7 +818,6 @@ namespace FoundationDB.Client.Tests
 					await db.ReadAsync(async tr =>
 					{
 						var folder = await location.Resolve(tr);
-						Assert.That(folder, Is.Not.Null);
 
 						var query = tr
 							.GetRange(
@@ -886,9 +864,7 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async (tr) =>
 				{
 					var fa = await a.Resolve(tr);
-					Assert.That(fa, Is.Not.Null);
 					var fb = await b.Resolve(tr);
-					Assert.That(fb, Is.Not.Null);
 					for (int i = 0; i < 10; i++)
 					{
 						tr.Set(fa.Encode(i), Slice.FromInt32(i));
@@ -902,7 +878,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
-					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange());
 
@@ -937,7 +912,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fb = await b.Resolve(tr);
-					Assert.That(fb, Is.Not.Null);
 
 					var query = tr.GetRange(fb.ToRange());
 
@@ -976,7 +950,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fc = await c.Resolve(tr);
-					Assert.That(fc, Is.Not.Null);
 
 					var query = tr.GetRange(fc.ToRange());
 
@@ -1009,7 +982,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
-					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Take(5);
 
@@ -1028,7 +1000,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
-					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Skip(5);
 
@@ -1062,9 +1033,8 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var f = await location.Resolve(tr);
-					Assert.That(f, Is.Not.Null);
 					var fa = await a.Resolve(tr);
-					Assert.That(fa, Is.Not.Null);
+
 					for (int i = 0; i < 10; i++)
 					{
 						tr.Set(fa.Encode(i), Slice.FromInt32(i));
@@ -1079,7 +1049,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
-					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Take(5);
 					Assert.That(query, Is.Not.Null);
@@ -1100,7 +1069,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
-					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa.ToRange()).Take(12);
 					Assert.That(query, Is.Not.Null);
@@ -1121,7 +1089,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var fa = await a.Resolve(tr);
-					Assert.That(fa, Is.Not.Null);
 
 					var query = tr.GetRange(fa!.ToRange()).Take(0);
 					Assert.That(query, Is.Not.Null);
@@ -1150,7 +1117,6 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 					foreach(var (k, v) in dataSet)
 					{
 						tr.Set(folder!.Encode(k), v);
@@ -1161,7 +1127,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.ToRange());
 					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToArray();
@@ -1192,7 +1157,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.ToRange());
 					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToList();
@@ -1223,7 +1187,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr.GetRange(folder.ToRange());
 					var data = dataSet.Select(kv => new KeyValuePair<Slice, Slice>(folder.Encode(kv.Index), kv.Value)).ToArray();
@@ -1254,7 +1217,6 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 					foreach (var (k, v) in dataSet)
 					{
 						tr.Set(folder.Encode(k), v);
@@ -1264,7 +1226,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr
 						.GetRange(folder.Encode(10), folder.Encode(20)) // 10 -> 19
@@ -1280,7 +1241,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var query = tr
 						.GetRange(folder.Encode(10), folder.Encode(20)) // 10 -> 19
@@ -1337,7 +1297,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var lists = Enumerable.Range(0, K).Select(k => GetList(folder, k)).ToArray();
 
@@ -1415,7 +1374,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var lists = Enumerable.Range(0, K).Select(k => GetList(folder, k)).ToArray();
 
@@ -1495,7 +1453,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					var lists = Enumerable.Range(0, K).Select(k => GetList(folder, k)).ToArray();
 
@@ -1542,9 +1499,7 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var items = await locItems.Resolve(tr);
-					Assert.That(items, Is.Not.Null);
 					var processed = await locProcessed.Resolve(tr);
-					Assert.That(processed, Is.Not.Null);
 
 					// Items
 					tr.Set(items["userA", 10093], Slice.Empty);
@@ -1561,9 +1516,7 @@ namespace FoundationDB.Client.Tests
 				var results = await db.QueryAsync(async tr =>
 				{
 					var items = await locItems.Resolve(tr);
-					Assert.That(items, Is.Not.Null);
 					var processed = await locProcessed.Resolve(tr);
-					Assert.That(processed, Is.Not.Null);
 
 					var query = tr.Except(
 						[ items.ToRange(), processed.ToRange() ],
@@ -1589,9 +1542,7 @@ namespace FoundationDB.Client.Tests
 				results = await db.QueryAsync(async tr =>
 				{
 					var items = await locItems.Resolve(tr);
-					Assert.That(items, Is.Not.Null);
 					var processed = await locProcessed.Resolve(tr);
-					Assert.That(processed, Is.Not.Null);
 
 					var resItems = tr
 						.GetRange(items.ToRange())
@@ -1640,7 +1591,6 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 					foreach (int i in Enumerable.Range(0, N))
 					{
 						tr.Set(folder.Encode(i), Slice.FromInt32(i));
@@ -1655,7 +1605,6 @@ namespace FoundationDB.Client.Tests
 				using (var tr = db.BeginTransaction(this.Cancellation))
 				{
 					var folder = await location.Resolve(tr);
-					Assert.That(folder, Is.Not.Null);
 
 					Log("Visiting range ...");
 

--- a/FoundationDB.Tests/RetryableFacts.cs
+++ b/FoundationDB.Tests/RetryableFacts.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@ namespace FoundationDB.Client.Tests
 				return await tr.GetAsync(subspace.Encode("Hello"));
 			}, this.Cancellation);
 
-			Assert.That(called, Is.EqualTo(1)); // note: if this assert fails, first ensure that you did not get a transient error while running this test!
+			Assert.That(called, Is.EqualTo(1)); // note: if this assertion fails, first ensure that you did not get a transient error while running this test!
 			Assert.That(result.ToUnicode(), Is.EqualTo(secret));
 		}
 
@@ -165,7 +165,7 @@ namespace FoundationDB.Client.Tests
 			sw.Stop();
 			Log("> done in " + sw.Elapsed);
 
-			using (new Timer((_) => { Log($"WorkingSet: {Environment.WorkingSet:N0}, Managed: {GC.GetTotalMemory(false):N0}"); }, null, 1000, 1000))
+			await using (new Timer((_) => { Log($"WorkingSet: {Environment.WorkingSet:N0}, Managed: {GC.GetTotalMemory(false):N0}"); }, null, 1000, 1000))
 			{
 				try
 				{

--- a/FoundationDB.Tests/RetryableFacts.cs
+++ b/FoundationDB.Tests/RetryableFacts.cs
@@ -27,8 +27,6 @@
 // ReSharper disable PossibleMultipleEnumeration
 // ReSharper disable AccessToDisposedClosure
 // ReSharper disable ReplaceAsyncWithTaskReturn
-#pragma warning disable CS8604 // Possible null reference argument.
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
 
 namespace FoundationDB.Client.Tests
 {
@@ -238,7 +236,7 @@ namespace FoundationDB.Client.Tests
 				Assert.That(tr, Is.Not.Null);
 
 				// force the read-only into a writable interface
-				var hijack = tr as IFdbTransaction;
+				var hijack = (tr as IFdbTransaction)!;
 				Assume.That(hijack, Is.Not.Null, "This test requires the transaction to implement IFdbTransaction !");
 
 				var subspace = await location.Resolve(tr);

--- a/FoundationDB.Tests/TestHelpers.cs
+++ b/FoundationDB.Tests/TestHelpers.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
+#region Copyright (c) 2023-2024 SnowBank SAS, (c) 2005-2023 Doxense SAS
 // All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -130,7 +130,7 @@ namespace FoundationDB.Client.Tests
 			{
 				tr.StopLogging();
 
-				var subspace = await path.Resolve(tr);
+				var subspace = await path.TryResolve(tr);
 				if (subspace == null)
 				{
 					SimpleTest.Log($"Dumping content of subspace {path}:");
@@ -178,7 +178,7 @@ namespace FoundationDB.Client.Tests
 			{
 				var indent = new string('\t', depth);
 
-				var subspace = await path.Resolve(tr);
+				var subspace = await path.TryResolve(tr);
 				if (subspace == null)
 				{
 					SimpleTest.Log($"# {indent}- {path} => NOT FOUND");

--- a/FoundationDB.Tests/TransactionFacts.cs
+++ b/FoundationDB.Tests/TransactionFacts.cs
@@ -102,7 +102,7 @@ namespace FoundationDB.Client.Tests
 			using var tr = db.BeginReadOnlyTransaction(this.Cancellation);
 			Assert.That(tr, Is.Not.Null);
 
-			var subspace = (await db.Root.Resolve(tr))!;
+			var subspace = await db.Root.Resolve(tr);
 
 			// reading should not fail
 			await tr.GetAsync(subspace.Encode("Hello"));
@@ -217,7 +217,7 @@ namespace FoundationDB.Client.Tests
 			db.SetDefaultLogHandler(log => Log(log.GetTimingsReport(true)));
 
 			using var tr = db.BeginTransaction(this.Cancellation);
-			var subspace = (await location.Resolve(tr))!;
+			var subspace = await location.Resolve(tr);
 
 			tr.Set(subspace[1], Text("hello"));
 			tr.Cancel();
@@ -245,7 +245,7 @@ namespace FoundationDB.Client.Tests
 			db.SetDefaultLogHandler(log => Log(log.GetTimingsReport(true)));
 
 			using var tr = db.BeginTransaction(this.Cancellation);
-			var subspace = (await location.Resolve(tr))!;
+			var subspace = await location.Resolve(tr);
 
 			// Writes about 5 MB of stuff in 100k chunks
 			for (int i = 0; i < 50; i++)
@@ -286,7 +286,7 @@ namespace FoundationDB.Client.Tests
 
 			using var cts = new CancellationTokenSource();
 			using var tr = db.BeginTransaction(cts.Token);
-			var subspace = (await location.Resolve(tr))!;
+			var subspace = await location.Resolve(tr);
 
 			// Writes about 5 MB of stuff in 100k chunks
 			for (int i = 0; i < 50; i++)
@@ -340,7 +340,7 @@ namespace FoundationDB.Client.Tests
 			// write a bunch of keys
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				tr.Set(subspace["hello"], Text("World!"));
 				tr.Set(subspace["timestamp"], Slice.FromInt64(ticks));
@@ -355,7 +355,7 @@ namespace FoundationDB.Client.Tests
 			// read them back
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				readVersion = await tr.GetReadVersionAsync();
 				Assert.That(readVersion, Is.GreaterThan(0), "Read version should be > 0");
@@ -391,7 +391,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				// keys
 				// - (test,) + \0
@@ -413,7 +413,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				KeySelector sel;
 
@@ -540,7 +540,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				for (int i = 0; i < ids.Length; i++)
 				{
@@ -554,7 +554,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				var results = await tr.GetValuesAsync(subspace.Encode(ids));
 
@@ -583,7 +583,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				// keys
 				// - (test,) + \0
@@ -605,7 +605,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				var selectors = Enumerable
 					.Range(0, N)
@@ -643,7 +643,7 @@ namespace FoundationDB.Client.Tests
 			// write a bunch of keys
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace["hello"], Text("World!"));
 				tr.Set(subspace["foo"], Slice.Empty);
 			}, this.Cancellation);
@@ -660,7 +660,7 @@ namespace FoundationDB.Client.Tests
 			// hello should only be equal to 'World!', not any other value, empty or nil
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				// hello should only be equal to 'World!', not any other value, empty or nil
 				await Check(tr, subspace["hello"], Text("World!"), FdbValueCheckResult.Success, Text("World!"));
@@ -672,7 +672,7 @@ namespace FoundationDB.Client.Tests
 			// foo should only be equal to Empty, *not* Nil or any other value
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				await Check(tr, subspace["foo"], Slice.Empty, FdbValueCheckResult.Success, Slice.Empty);
 				await Check(tr, subspace["foo"], Text("bar"), FdbValueCheckResult.Failed, Slice.Empty);
@@ -683,7 +683,7 @@ namespace FoundationDB.Client.Tests
 			// not_found should only be equal to Nil, *not* Empty or any other value
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				await Check(tr, subspace["not_found"], Slice.Nil, FdbValueCheckResult.Success, Slice.Nil);
 				await Check(tr, subspace["not_found"], Slice.Empty, FdbValueCheckResult.Failed, Slice.Nil);
@@ -694,7 +694,7 @@ namespace FoundationDB.Client.Tests
 			// not_found should only be equal to Nil, *not* Empty or any other value
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				await Check(tr, subspace["hello"], Text("World!"), FdbValueCheckResult.Success, Text("World!"));
 				await Check(tr, subspace["not_found"], Slice.Nil, FdbValueCheckResult.Success, Slice.Nil);
@@ -728,14 +728,14 @@ namespace FoundationDB.Client.Tests
 			{
 				return db.ReadAsync<TResult>(async tr =>
 				{
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 					return await handler(tr, subspace);
 				}, this.Cancellation);
 			}
 
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				tr.Set(subspace["hello"], Text("World!"));
 				tr.Set(subspace["timestamp"], Slice.FromInt64(ticks));
@@ -826,7 +826,7 @@ namespace FoundationDB.Client.Tests
 			db.SetDefaultLogHandler(log => Log(log.GetTimingsReport(true)));
 
 			//note: we take a risk by reading the key separately, but this simplifies the rest of the code !
-			Task<Slice> ResolveKey(string name) => db.ReadAsync(async tr => (await location.Resolve(tr))!.Encode(name), this.Cancellation);
+			Task<Slice> ResolveKey(string name) => db.ReadAsync(async tr => (await location.Resolve(tr)).Encode(name), this.Cancellation);
 
 			Slice key;
 
@@ -906,7 +906,7 @@ namespace FoundationDB.Client.Tests
 			await db.WriteAsync(async (tr) =>
 			{
 				Log("resolving...");
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				Log(subspace);
 				tr.SetValueInt32(subspace["AAA"], 0);
 				tr.SetValueInt32(subspace["BBB"], 1);
@@ -921,7 +921,7 @@ namespace FoundationDB.Client.Tests
 			// execute
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.AtomicAdd32(subspace["AAA"], 1);
 				tr.AtomicAdd32(subspace["BBB"], 42);
 				tr.AtomicAdd32(subspace["CCC"], -1);
@@ -935,7 +935,7 @@ namespace FoundationDB.Client.Tests
 			// check
 			await db.ReadAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				Assert.That((await tr.GetValueInt32Async(subspace["AAA"])), Is.EqualTo(1));
 				Assert.That((await tr.GetValueInt32Async(subspace["BBB"])), Is.EqualTo(43));
 				Assert.That((await tr.GetValueInt32Async(subspace["CCC"])), Is.EqualTo(42));
@@ -959,7 +959,7 @@ namespace FoundationDB.Client.Tests
 			// setup
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.SetValueInt32(subspace["AAA"], 0);
 				tr.SetValueInt32(subspace["BBB"], 1);
 				tr.SetValueInt32(subspace["CCC"], 42);
@@ -971,7 +971,7 @@ namespace FoundationDB.Client.Tests
 			// execute
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.AtomicIncrement32(subspace["AAA"]);
 				tr.AtomicIncrement32(subspace["BBB"]);
 				tr.AtomicIncrement32(subspace["CCC"]);
@@ -983,7 +983,7 @@ namespace FoundationDB.Client.Tests
 			// check
 			await db.ReadAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				Assert.That((await tr.GetValueInt32Async(subspace["AAA"])), Is.EqualTo(1));
 				Assert.That((await tr.GetValueInt32Async(subspace["BBB"])), Is.EqualTo(2));
 				Assert.That((await tr.GetValueInt32Async(subspace["CCC"])), Is.EqualTo(43));
@@ -1005,7 +1005,7 @@ namespace FoundationDB.Client.Tests
 			// setup
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.SetValueInt64(subspace["AAA"], 0);
 				tr.SetValueInt64(subspace["BBB"], 1);
 				tr.SetValueInt64(subspace["CCC"], 43);
@@ -1019,7 +1019,7 @@ namespace FoundationDB.Client.Tests
 			// execute
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.AtomicAdd64(subspace["AAA"], 1);
 				tr.AtomicAdd64(subspace["BBB"], 42);
 				tr.AtomicAdd64(subspace["CCC"], -1);
@@ -1033,7 +1033,7 @@ namespace FoundationDB.Client.Tests
 			// check
 			await db.ReadAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				Assert.That((await tr.GetValueInt64Async(subspace["AAA"])), Is.EqualTo(1));
 				Assert.That((await tr.GetValueInt64Async(subspace["BBB"])), Is.EqualTo(43));
 				Assert.That((await tr.GetValueInt64Async(subspace["CCC"])), Is.EqualTo(42));
@@ -1057,7 +1057,7 @@ namespace FoundationDB.Client.Tests
 			// setup
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.SetValueInt64(subspace["AAA"], 0);
 				tr.SetValueInt64(subspace["BBB"], 1);
 				tr.SetValueInt64(subspace["CCC"], 42);
@@ -1069,7 +1069,7 @@ namespace FoundationDB.Client.Tests
 			// execute
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.AtomicIncrement64(subspace["AAA"]);
 				tr.AtomicIncrement64(subspace["BBB"]);
 				tr.AtomicIncrement64(subspace["CCC"]);
@@ -1081,7 +1081,7 @@ namespace FoundationDB.Client.Tests
 			// check
 			await db.ReadAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				Assert.That((await tr.GetValueInt64Async(subspace["AAA"])), Is.EqualTo(1));
 				Assert.That((await tr.GetValueInt64Async(subspace["BBB"])), Is.EqualTo(2));
 				Assert.That((await tr.GetValueInt64Async(subspace["CCC"])), Is.EqualTo(43));
@@ -1103,7 +1103,7 @@ namespace FoundationDB.Client.Tests
 			// setup
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.SetValueInt32(subspace["AAA"], 0);
 				tr.SetValueInt32(subspace["BBB"], 1);
 				tr.SetValueInt32(subspace["CCC"], 42);
@@ -1115,7 +1115,7 @@ namespace FoundationDB.Client.Tests
 			// execute
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.AtomicCompareAndClear(subspace["AAA"], Slice.FromFixed32(0));  // should be cleared
 				tr.AtomicCompareAndClear(subspace["BBB"], Slice.FromFixed32(0));  // should not be touched
 				tr.AtomicCompareAndClear(subspace["CCC"], Slice.FromFixed32(42)); // should be cleared
@@ -1127,7 +1127,7 @@ namespace FoundationDB.Client.Tests
 			// check
 			await db.ReadAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				Assert.That((await tr.GetValueInt32Async(subspace["AAA"])), Is.Null);
 				Assert.That((await tr.GetValueInt32Async(subspace["BBB"])), Is.EqualTo(1));
 				Assert.That((await tr.GetValueInt32Async(subspace["CCC"])), Is.Null);
@@ -1147,7 +1147,7 @@ namespace FoundationDB.Client.Tests
 			// setup
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace["AAA"], Slice.Empty);
 				tr.Set(subspace["BBB"], Slice.Repeat('B', 10));
 				tr.Set(subspace["CCC"], Slice.Repeat('C', 90_000));
@@ -1160,7 +1160,7 @@ namespace FoundationDB.Client.Tests
 			// execute
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.AtomicAppendIfFits(subspace["AAA"], Text("Hello, World!"));
 				tr.AtomicAppendIfFits(subspace["BBB"], Text("Hello"));
 				tr.AtomicAppendIfFits(subspace["BBB"], Text(", World!"));
@@ -1172,7 +1172,7 @@ namespace FoundationDB.Client.Tests
 			// check
 			await db.ReadAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				Assert.That((await tr.GetAsync(subspace["AAA"])).ToString(), Is.EqualTo("Hello, World!"));
 				Assert.That((await tr.GetAsync(subspace["BBB"])).ToString(), Is.EqualTo("BBBBBBBBBBHello, World!"));
 				Assert.That((await tr.GetAsync(subspace["CCC"])), Is.EqualTo(Slice.Repeat('C', 90_000) + Slice.Repeat('c', 10_000)));
@@ -1193,7 +1193,7 @@ namespace FoundationDB.Client.Tests
 			// write a bunch of keys
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace["hello"], Text("World!"));
 				tr.Set(subspace["foo"], Text("bar"));
 			}, this.Cancellation);
@@ -1201,7 +1201,7 @@ namespace FoundationDB.Client.Tests
 			// read them using snapshot
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				Slice bytes;
 
@@ -1224,7 +1224,7 @@ namespace FoundationDB.Client.Tests
 			long ver = tr.GetCommittedVersion();
 			Assert.That(ver, Is.EqualTo(-1), "Initial committed version");
 
-			var subspace = (await db.Root.Resolve(tr))!;
+			var subspace = await db.Root.Resolve(tr);
 			_ = await tr.GetAsync(subspace.Encode("foo"));
 
 			// until the transaction commits, the committed version will stay -1
@@ -1253,7 +1253,7 @@ namespace FoundationDB.Client.Tests
 			long ver = tr.GetCommittedVersion();
 			Assert.That(ver, Is.EqualTo(-1), "Initial committed version");
 
-			var subspace = (await db.Root.Resolve(tr))!;
+			var subspace = await db.Root.Resolve(tr);
 			tr.Set(subspace.Encode("foo"), Text("bar"));
 
 			// until the transaction commits, the committed version should still be -1
@@ -1279,7 +1279,7 @@ namespace FoundationDB.Client.Tests
 			// take the read version (to compare with the committed version below)
 			long rv1 = await tr.GetReadVersionAsync();
 
-			var subspace = (await db.Root.Resolve(tr))!;
+			var subspace = await db.Root.Resolve(tr);
 
 			// do something and commit
 			tr.Set(subspace.Encode("foo"), Text("bar"));
@@ -1316,7 +1316,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace["foo"], Text("foo"));
 			}, this.Cancellation);
 
@@ -1325,8 +1325,8 @@ namespace FoundationDB.Client.Tests
 			using var trA = db.BeginTransaction(this.Cancellation);
 			using var trB = db.BeginTransaction(this.Cancellation);
 
-			var subspaceA = (await location.Resolve(trA))!;
-			var subspaceB = (await location.Resolve(trB))!;
+			var subspaceA = await location.Resolve(trA);
+			var subspaceB = await location.Resolve(trB);
 
 			// regular read
 			_ = await trA.GetAsync(subspaceA["foo"]);
@@ -1357,15 +1357,15 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace["foo"], Text("foo"));
 			}, this.Cancellation);
 
 			using var trA = db.BeginTransaction(this.Cancellation);
 			using var trB = db.BeginTransaction(this.Cancellation);
 
-			var subspaceA = (await location.Resolve(trA))!;
-			var subspaceB = (await location.Resolve(trB))!;
+			var subspaceA = await location.Resolve(trA);
+			var subspaceB = await location.Resolve(trB);
 
 			// reading with snapshot mode should not conflict
 			_ = await trA.Snapshot.GetAsync(subspaceA["foo"]);
@@ -1388,7 +1388,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("foo", 50), Text("fifty"));
 			}, this.Cancellation);
 
@@ -1400,7 +1400,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 
 				// [0, 100) limit 1 => 50
 				var kvp = await tr1
@@ -1411,7 +1411,7 @@ namespace FoundationDB.Client.Tests
 				// 42 < 50 > conflict !!!
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 					tr2.Set(subspace2.Encode("foo", 42), Text("forty-two"));
 					await tr2.CommitAsync();
 				}
@@ -1428,14 +1428,14 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.ClearRange(subspace);
 				tr.Set(subspace.Encode("foo", 50), Text("fifty"));
 			}, this.Cancellation);
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 
 				// [0, 100) limit 1 => 50
 				var kvp = await tr1
@@ -1446,7 +1446,7 @@ namespace FoundationDB.Client.Tests
 				// 77 > 50 => no conflict
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 					tr2.Set(subspace2.Encode("foo", 77), Text("docm"));
 					await tr2.CommitAsync();
 				}
@@ -1468,7 +1468,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.ClearRange(subspace);
 				tr.Set(subspace.Encode("foo", 50), Text("fifty"));
 			}, this.Cancellation);
@@ -1479,7 +1479,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 				var foo = subspace.Encode("foo", 0);
 				// fGE{0} => 50
 				var key = await tr1.GetKeyAsync(KeySelector.FirstGreaterOrEqual(foo));
@@ -1488,7 +1488,7 @@ namespace FoundationDB.Client.Tests
 				// 42 < 50 => conflict !!!
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 					tr2.Set(subspace2.Encode("foo", 42), Text("forty-two"));
 					await tr2.CommitAsync();
 				}
@@ -1503,14 +1503,14 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.ClearRange(subspace);
 				tr.Set(subspace.Encode("foo", 50), Text("fifty"));
 			}, this.Cancellation);
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 				// fGE{0} => 50
 				var key = await tr1.GetKeyAsync(KeySelector.FirstGreaterOrEqual(subspace.Encode("foo", 0)));
 				Assert.That(key, Is.EqualTo(subspace.Encode("foo", 50)));
@@ -1518,7 +1518,7 @@ namespace FoundationDB.Client.Tests
 				// 77 > 50 => no conflict
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 					tr2.Set(subspace2.Encode("foo", 77), Text("docm"));
 					await tr2.CommitAsync();
 				}
@@ -1534,7 +1534,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.ClearRange(subspace);
 				tr.Set(subspace.Encode("foo", 50), Text("fifty"));
 				tr.Set(subspace.Encode("foo", 100), Text("one hundred"));
@@ -1542,7 +1542,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 
 				// fGE{50} + 1 => 100
 				var key = await tr1.GetKeyAsync(KeySelector.FirstGreaterOrEqual(subspace.Encode("foo", 50)) + 1);
@@ -1551,7 +1551,7 @@ namespace FoundationDB.Client.Tests
 				// 77 between 50 and 100 => conflict !!!
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 					tr2.Set(subspace2.Encode("foo", 77), Text("docm"));
 					await tr2.CommitAsync();
 				}
@@ -1567,7 +1567,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.ClearRange(subspace);
 				tr.Set(subspace.Encode("foo", 50), Text("fifty"));
 				tr.Set(subspace.Encode("foo", 100), Text("one hundred"));
@@ -1575,7 +1575,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 				// fGT{50} => 100
 				var key = await tr1.GetKeyAsync(KeySelector.FirstGreaterThan(subspace.Encode("foo", 50)));
 				Assert.That(key, Is.EqualTo(subspace.Encode("foo", 100)));
@@ -1583,7 +1583,7 @@ namespace FoundationDB.Client.Tests
 				// another transaction changes the VALUE of 50 and 100 (but does not change the fact that they exist nor add keys in between)
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 					tr2.Set(subspace2.Encode("foo", 100), Text("cent"));
 					await tr2.CommitAsync();
 				}
@@ -1599,7 +1599,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.ClearRange(subspace);
 				tr.Set(subspace.Encode("foo", 50), Text("fifty"));
 				tr.Set(subspace.Encode("foo", 100), Text("one hundred"));
@@ -1607,7 +1607,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 				// lLT{100} => 50
 				var key = await tr1.GetKeyAsync(KeySelector.LastLessThan(subspace.Encode("foo", 100)));
 				Assert.That(key, Is.EqualTo(subspace.Encode("foo", 50)));
@@ -1615,7 +1615,7 @@ namespace FoundationDB.Client.Tests
 				// another transaction changes the VALUE of 50 and 100 (but does not change the fact that they exist nor add keys in between)
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 					tr2.Clear(subspace2.Encode("foo", 100));
 					await tr2.CommitAsync();
 				}
@@ -1650,7 +1650,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await db.Root.Resolve(tr))!;
+				var subspace = await db.Root.Resolve(tr);
 				tr.Set(subspace.Encode("test", "A"), Slice.FromInt32(1));
 			}, this.Cancellation);
 			using(var tr1 = db.BeginTransaction(this.Cancellation))
@@ -1659,7 +1659,7 @@ namespace FoundationDB.Client.Tests
 				await tr1.GetReadVersionAsync();
 				//T1 should be locked to a specific version of the db
 
-				var subspace1 = (await db.Root.Resolve(tr1))!;
+				var subspace1 = await db.Root.Resolve(tr1);
 				var key = subspace1.Encode("test", "A");
 
 				// change the value in T2
@@ -1688,7 +1688,7 @@ namespace FoundationDB.Client.Tests
 			// T1 should see A == 2, because in reality, it was started after T2
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await db.Root.Resolve(tr))!;
+				var subspace = await db.Root.Resolve(tr);
 				tr.Set(subspace.Encode("test", "A"), Slice.FromInt32(1));
 			}, this.Cancellation);
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
@@ -1698,13 +1698,13 @@ namespace FoundationDB.Client.Tests
 				// change the value in T2
 				await db.WriteAsync(async (tr2) =>
 				{
-					var subspace2 = (await db.Root.Resolve(tr2))!;
+					var subspace2 = await db.Root.Resolve(tr2);
 					tr2.Set(subspace2.Encode("test", "A"), Slice.FromInt32(2));
 				}, this.Cancellation);
 
 
 				// read the value in T1 and commits
-				var subspace1 = (await db.Root.Resolve(tr1))!;
+				var subspace1 = await db.Root.Resolve(tr1);
 				var value = await tr1.GetAsync(subspace1.Encode("test", "A"));
 
 				Assert.That(value, Is.Not.Null);
@@ -1735,7 +1735,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace["A"], Text("a"));
 				tr.Set(subspace["B"], Text("b"));
 				tr.Set(subspace["C"], Text("c"));
@@ -1749,7 +1749,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				// check initial state
 				Assert.That((await tr.GetAsync(subspace["A"])).ToStringUtf8(), Is.EqualTo("a"));
@@ -1797,7 +1797,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace["A"], Text("a"));
 				tr.Set(subspace["B"], Text("b"));
 				tr.Set(subspace["C"], Text("c"));
@@ -1809,7 +1809,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				tr.Options.WithSnapshotReadYourWritesDisable();
 
@@ -1854,7 +1854,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("a"), Text("a"));
 				tr.Set(subspace.Encode("b", 10), Text("PRINT \"HELLO\""));
 				tr.Set(subspace.Encode("b", 20), Text("GOTO 10"));
@@ -1862,7 +1862,7 @@ namespace FoundationDB.Client.Tests
 
 			using(var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				var data = await tr.GetAsync(subspace.Encode("a"));
 				Assert.That(data.ToUnicode(), Is.EqualTo("a"));
@@ -1897,7 +1897,7 @@ namespace FoundationDB.Client.Tests
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
 				// resolve the subspace in a witness transaction
-				var subspace = (await location.Resolve(trSubspace))!;
+				var subspace = await location.Resolve(trSubspace);
 				tr.SetReadVersion(await trSubspace.GetReadVersionAsync());
 
 				tr.Options.WithReadYourWritesDisable();
@@ -1940,7 +1940,7 @@ namespace FoundationDB.Client.Tests
 			// create first version
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 				tr1.Set(subspace["concurrent"], Slice.FromByte(1));
 				await tr1.CommitAsync();
 
@@ -1951,7 +1951,7 @@ namespace FoundationDB.Client.Tests
 			// mutate in another transaction
 			using (var tr2 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr2))!;
+				var subspace = await location.Resolve(tr2);
 				tr2.Set(subspace["concurrent"], Slice.FromByte(2));
 				await tr2.CommitAsync();
 			}
@@ -1964,7 +1964,7 @@ namespace FoundationDB.Client.Tests
 				long ver = await tr3.GetReadVersionAsync();
 				Assert.That(ver, Is.EqualTo(committedVersion), "GetReadVersion should return the same value as SetReadVersion!");
 
-				var subspace = (await location.Resolve(tr3))!;
+				var subspace = await location.Resolve(tr3);
 
 				var bytes = await tr3.GetAsync(subspace["concurrent"]);
 
@@ -2079,7 +2079,7 @@ namespace FoundationDB.Client.Tests
 						Assert.That(tr2.Options.MaxRetryDelay, Is.EqualTo(700), "tr2.Options.MaxRetryDelay");
 						Assert.That(tr2.Options.Tracing, Is.EqualTo(FdbTracingOptions.RecordApiCalls | FdbTracingOptions.RecordSteps), "tr2.Options.Tracing");
 
-						// original tr should not be affected
+						// original transaction should not be affected
 						Assert.That(tr.Options.Timeout, Is.EqualTo(500), "tr.Options.Timeout");
 						Assert.That(tr.Options.RetryLimit, Is.EqualTo(3), "tr.Options.RetryLimit");
 						Assert.That(tr.Options.MaxRetryDelay, Is.EqualTo(600), "tr.Options.MaxRetryDelay");
@@ -2087,7 +2087,7 @@ namespace FoundationDB.Client.Tests
 					});
 				}
 
-				// resetting tr should use the new database settings
+				// resetting the transaction should use the new database settings
 				tr.Reset();
 
 				Assert.Multiple(() =>
@@ -2167,7 +2167,7 @@ namespace FoundationDB.Client.Tests
 				await tr.OnErrorAsync(FdbError.TransactionTooOld);
 				Assert.That(tr.Options.RetryLimit, Is.Zero, "Retry limit should be reset");
 
-				// we still haven't failed 10 times..
+				// we still haven't failed 10 times...
 				tr.Options.RetryLimit = 10;
 				await tr.OnErrorAsync(FdbError.TransactionTooOld);
 				Assert.That(tr.Options.RetryLimit, Is.Zero, "Retry limit should be reset");
@@ -2189,7 +2189,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 
 				await tr1.GetAsync(subspace[1]);
 				// tr1 writes to one key
@@ -2199,7 +2199,7 @@ namespace FoundationDB.Client.Tests
 
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 
 					// tr2 writes to the second key
 					tr2.Set(subspace2[2], Text("world"));
@@ -2228,7 +2228,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr1 = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr1))!;
+				var subspace = await location.Resolve(tr1);
 
 				// tr1 reads the conflicting key
 				await tr1.GetAsync(subspace.Encode(0));
@@ -2237,7 +2237,7 @@ namespace FoundationDB.Client.Tests
 
 				using (var tr2 = db.BeginTransaction(this.Cancellation))
 				{
-					var subspace2 = (await location.Resolve(tr2))!;
+					var subspace2 = await location.Resolve(tr2);
 
 					// tr2 changes key2, but adds a conflict range on the conflicting key
 					tr2.Set(subspace2.Encode(2), Text("world"));
@@ -2268,7 +2268,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("watched"), Text("some value"));
 				tr.Set(subspace.Encode("witness"), Text("some other value"));
 			}, this.Cancellation);
@@ -2280,7 +2280,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				w1 = tr.Watch(subspace.Encode("watched"), cts.Token);
 				w2 = tr.Watch(subspace.Encode("witness"), cts.Token);
 				Assert.That(w1, Is.Not.Null);
@@ -2297,7 +2297,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("watched"), Text("some new value"));
 			}, this.Cancellation);
 
@@ -2324,7 +2324,7 @@ namespace FoundationDB.Client.Tests
 
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				var key = subspace.Encode("watched");
 
 				Assert.That(() => tr.Watch(key, tr.Cancellation), Throws.Exception, "Watch(...) should reject the transaction's own cancellation");
@@ -2359,14 +2359,14 @@ namespace FoundationDB.Client.Tests
 			Log("Set to initial value...");
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("watched"), Text("initial value"));
 			}, this.Cancellation);
 
 			Log("Create watch...");
 			var w = await db.ReadWriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				return tr.Watch(subspace.Encode("watched"), this.Cancellation);
 			}, this.Cancellation);
 			Assert.That(w.IsAlive, Is.True, "Watch should still be alive");
@@ -2376,7 +2376,7 @@ namespace FoundationDB.Client.Tests
 			Log("Set to same value...");
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("watched"), Text("initial value"));
 			}, this.Cancellation);
 
@@ -2391,7 +2391,7 @@ namespace FoundationDB.Client.Tests
 			Log("Set to a different value...");
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("watched"), Text("new value"));
 			}, this.Cancellation);
 
@@ -2420,7 +2420,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("watched"), Text("some value"));
 			}, this.Cancellation);
 
@@ -2432,7 +2432,7 @@ namespace FoundationDB.Client.Tests
 			Log("Setup a watch on a key that will not be changed...");
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				watch = tr.Watch(subspace.Encode("watched"), this.Cancellation);
 				Assert.That(watch, Is.Not.Null);
 
@@ -2472,7 +2472,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode("watched"), Text("some value"));
 			}, this.Cancellation);
 
@@ -2482,7 +2482,7 @@ namespace FoundationDB.Client.Tests
 			Log("Setup a watch on a key that will not be changed...");
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				watch = tr.Watch(subspace.Encode("watched"), this.Cancellation);
 				Assert.That(watch, Is.Not.Null);
 
@@ -2517,7 +2517,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				tr.Set(subspace.Encode(1), Text("one"));
 			}, this.Cancellation);
 
@@ -2526,7 +2526,7 @@ namespace FoundationDB.Client.Tests
 			// look for the address of key1
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				var addresses = await tr.GetAddressesForKeyAsync(subspace.Encode(1));
 				Assert.That(addresses, Is.Not.Null);
@@ -2553,7 +2553,7 @@ namespace FoundationDB.Client.Tests
 			// do the same but for a key that does not exist
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				var addresses = await tr.GetAddressesForKeyAsync(subspace.Encode(404));
 				Assert.That(addresses, Is.Not.Null);
@@ -2736,7 +2736,7 @@ namespace FoundationDB.Client.Tests
 			Log("Inserting keys with version stamps:");
 			using (var tr = db.BeginTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				// should return an 80-bit incomplete stamp, using a random token
 				var vs = tr.CreateVersionStamp();
@@ -2775,7 +2775,7 @@ namespace FoundationDB.Client.Tests
 			Log("Checking database content:");
 			using (var tr = db.BeginReadOnlyTransaction(this.Cancellation))
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 				{
 					var foo = await tr.GetRange(subspace.EncodeRange("foo")).SingleAsync();
 					Log("> Found 1 result under (foo,)");
@@ -2919,24 +2919,24 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await db.Root.Resolve(tr))!;
+				var subspace = await db.Root.Resolve(tr);
 				tr.TouchMetadataVersionKey(subspace.Encode(FOO));
 			}, this.Cancellation);
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await db.Root.Resolve(tr))!;
+				var subspace = await db.Root.Resolve(tr);
 				tr.TouchMetadataVersionKey(subspace.Encode(BAR));
 			}, this.Cancellation);
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await db.Root.Resolve(tr))!;
+				var subspace = await db.Root.Resolve(tr);
 				tr.Clear(subspace.Encode(BAZ));
 			}, this.Cancellation);
 
 			// changing the metadata version and then reading it back from the same transaction CANNOT WORK!
 			await db.WriteAsync(async tr =>
 			{
-				var subspace = (await db.Root.Resolve(tr))!;
+				var subspace = await db.Root.Resolve(tr);
 
 				// We can read the version before
 				var before1 = await tr.GetMetadataVersionKeyAsync(subspace.Encode(FOO));
@@ -2993,7 +2993,7 @@ namespace FoundationDB.Client.Tests
 
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await db.Root.Resolve(tr))!;
+				var subspace = await db.Root.Resolve(tr);
 				for (int i = 0; i < R; i++)
 				{
 					tr.Set(subspace.Encode("Fuzzer", i), Slice.FromInt32(i));
@@ -3062,7 +3062,7 @@ namespace FoundationDB.Client.Tests
 						int x = rnd.Next(R);
 						try
 						{
-							var subspace = (await db.Root.Resolve(tr))!; //TODO: cache subspace instance alongside transaction?
+							var subspace = await db.Root.Resolve(tr); //TODO: cache subspace instance alongside transaction?
 							_ = await tr.GetAsync(subspace.Encode("Fuzzer", x));
 						}
 						catch (FdbException)
@@ -3082,7 +3082,7 @@ namespace FoundationDB.Client.Tests
 						var tr = alive[p];
 
 						int x = rnd.Next(R);
-						var subspace = (await db.Root.Resolve(tr))!; //TODO: cache subspace instance alongside transaction?
+						var subspace = await db.Root.Resolve(tr); //TODO: cache subspace instance alongside transaction?
 						_ = tr.GetAsync(subspace.Encode("Fuzzer", x)).ContinueWith((_) => sb.Append('!') /*BUGBUG: locking ?*/, TaskContinuationOptions.NotOnRanToCompletion);
 						// => t is not stored
 						break;
@@ -3134,7 +3134,7 @@ namespace FoundationDB.Client.Tests
 				await db.WriteAsync(async tr =>
 				{
 					tr.StopLogging();
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 
 					tr.ClearRange(subspace.ToRange());
 					tr.Set(subspace.Encode("AAA"), initialA);
@@ -3155,7 +3155,7 @@ namespace FoundationDB.Client.Tests
 
 					if (!test(tr)) return;
 
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 					await handler(tr, subspace);
 					tr.Set(subspace.Encode("Witness"), Slice.FromStringAscii("New witness value"));
 				}, this.Cancellation);
@@ -3165,7 +3165,7 @@ namespace FoundationDB.Client.Tests
 				var actual = await db.ReadAsync(async tr =>
 				{
 					tr.StopLogging();
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 					return await tr.GetAsync(subspace.Encode("Witness"));
 				}, this.Cancellation);
 
@@ -3498,7 +3498,7 @@ namespace FoundationDB.Client.Tests
 
 					await db.WriteAsync(async tr =>
 					{
-						var subspace = (await location.Resolve(tr))!;
+						var subspace = await location.Resolve(tr);
 						tr.Set(subspace.Encode("Foo"), Slice.FromStringAscii("NotReady"));
 						// Bar does not exist
 					}, this.Cancellation);
@@ -3507,7 +3507,7 @@ namespace FoundationDB.Client.Tests
 				var task = db.ReadWriteAsync(async tr =>
 				{
 					//note: this subspace does not use the DL so it does not introduce any value checks!
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 
 					if (tr.Context.TestValueCheckFromPreviousAttempt("foo") == FdbValueCheckResult.Failed)
 					{
@@ -3738,7 +3738,7 @@ namespace FoundationDB.Client.Tests
 			{
 				await db.WriteAsync(async (tr) =>
 				{
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 
 					// fill the db with keys from (0,) = XXX to (N-1,) = XXX
 					for (int j = 0; j < BATCH_SIZE && i + j < values.Length; j++)
@@ -3753,7 +3753,7 @@ namespace FoundationDB.Client.Tests
 			Log($"Get split points for chunks of {CHUNK_SIZE:N0} bytes...");
 			var keys = await db.ReadAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				var begin = subspace.Encode(0);
 				var end = subspace.Encode(values.Length);
@@ -3781,7 +3781,7 @@ namespace FoundationDB.Client.Tests
 			{
 				var (chunk, begin, end) = await db.ReadAsync(async tr => 
 				{
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 
 					// we will get all the keys in between and dump some statistics
 					var range = KeyRange.Create(keys[i], keys[i + 1]);
@@ -3819,7 +3819,7 @@ namespace FoundationDB.Client.Tests
 			Log($"Creating {values.Length:N0} keys ({VALUE_SIZE:N0} bytes per key) with {NUM_ITEMS * VALUE_SIZE:N0} total bytes");
 			await db.WriteAsync(async (tr) =>
 			{
-				var subspace = (await location.Resolve(tr))!;
+				var subspace = await location.Resolve(tr);
 
 				// fill the db with keys from (0,) = XXX to (N-1,) = XXX
 				for (int i = 0; i < values.Length; i++)
@@ -3833,7 +3833,7 @@ namespace FoundationDB.Client.Tests
 			{
 				await db.ReadAsync(async (tr) =>
 				{
-					var subspace = (await location.Resolve(tr))!;
+					var subspace = await location.Resolve(tr);
 
 					int x = rnd.Next(NUM_ITEMS);
 					int y = rnd.Next(NUM_ITEMS);

--- a/FoundationDB.Tests/TransactionFacts.cs
+++ b/FoundationDB.Tests/TransactionFacts.cs
@@ -32,6 +32,8 @@
 // ReSharper disable JoinDeclarationAndInitializer
 // ReSharper disable TooWideLocalVariableScope
 // ReSharper disable StringLiteralTypo
+// ReSharper disable ConvertToUsingDeclaration
+// ReSharper disable MethodHasAsyncOverload
 
 namespace FoundationDB.Client.Tests
 {
@@ -1528,7 +1530,7 @@ namespace FoundationDB.Client.Tests
 				await tr1.CommitAsync();
 			}
 
-			// but if we have an large offset in the key selector, and another transaction insert something inside the offset window, the result would be different, and it should conflict
+			// but if we have a large offset in the key selector, and another transaction insert something inside the offset window, the result would be different, and it should conflict
 
 			await db.WriteAsync(async (tr) =>
 			{
@@ -1866,7 +1868,7 @@ namespace FoundationDB.Client.Tests
 				Assert.That(data.ToUnicode(), Is.EqualTo("a"));
 					
 				var res = await tr.GetRange(subspace.EncodeRange("b")).Select(kvp => kvp.Value.ToString()).ToArrayAsync();
-				Assert.That(res, Is.EqualTo(new [] { "PRINT \"HELLO\"", "GOTO 10" }));
+				Assert.That(res, Is.EqualTo([ "PRINT \"HELLO\"", "GOTO 10" ]));
 
 				tr.Set(subspace.Encode("a"), Text("aa"));
 				tr.Set(subspace.Encode("b", 15), Text("PRINT \"WORLD\""));
@@ -1874,7 +1876,7 @@ namespace FoundationDB.Client.Tests
 				data = await tr.GetAsync(subspace.Encode("a"));
 				Assert.That(data.ToUnicode(), Is.EqualTo("aa"), "The transaction own writes should be visible by default");
 				res = await tr.GetRange(subspace.EncodeRange("b")).Select(kvp => kvp.Value.ToString()).ToArrayAsync();
-				Assert.That(res, Is.EqualTo(new[] { "PRINT \"HELLO\"", "PRINT \"WORLD\"", "GOTO 10" }), "The transaction own writes should be visible by default");
+				Assert.That(res, Is.EqualTo([ "PRINT \"HELLO\"", "PRINT \"WORLD\"", "GOTO 10" ]), "The transaction own writes should be visible by default");
 
 				//note: don't commit
 			}
@@ -1903,7 +1905,7 @@ namespace FoundationDB.Client.Tests
 				var data = await tr.GetAsync(subspace.Encode("a"));
 				Assert.That(data.ToUnicode(), Is.EqualTo("a"));
 				var res = await tr.GetRange(subspace.EncodeRange("b")).Select(kvp => kvp.Value.ToString()).ToArrayAsync();
-				Assert.That(res, Is.EqualTo(new[] { "PRINT \"HELLO\"", "GOTO 10" }));
+				Assert.That(res, Is.EqualTo([ "PRINT \"HELLO\"", "GOTO 10" ]));
 
 				tr.Set(subspace.Encode("a"), Text("aa"));
 				tr.Set(subspace.Encode("b", 15), Text("PRINT \"WORLD\""));
@@ -1911,9 +1913,9 @@ namespace FoundationDB.Client.Tests
 				data = await tr.GetAsync(subspace.Encode("a"));
 				Assert.That(data.ToUnicode(), Is.EqualTo("a"), "The transaction own writes should not be seen with ReadYourWritesDisable option enabled");
 				res = await tr.GetRange(subspace.EncodeRange("b")).Select(kvp => kvp.Value.ToString()).ToArrayAsync();
-				Assert.That(res, Is.EqualTo(new[] { "PRINT \"HELLO\"", "GOTO 10" }), "The transaction own writes should not be seen with ReadYourWritesDisable option enabled");
+				Assert.That(res, Is.EqualTo([ "PRINT \"HELLO\"", "GOTO 10" ]), "The transaction own writes should not be seen with ReadYourWritesDisable option enabled");
 
-				//note: don't commit
+				//note: don't commit!
 			}
 
 			#endregion
@@ -2474,7 +2476,7 @@ namespace FoundationDB.Client.Tests
 				tr.Set(subspace.Encode("watched"), Text("some value"));
 			}, this.Cancellation);
 
-			// setup the watch
+			// configure the watch
 			FdbWatch watch;
 
 			Log("Setup a watch on a key that will not be changed...");
@@ -2536,13 +2538,12 @@ namespace FoundationDB.Client.Tests
 				// it will most probably be 127.0.0.1 unless you have customized the Test DB settings to point to somewhere else
 				// either way, it should look like a valid IP address (IPv4 or v6?)
 
-				for (int i = 0; i < addresses.Length; i++)
+				foreach (var address in addresses)
 				{
-					var addr = addresses[i];
-					Log($"- {addr}");
+					Log($"- {address}");
 					// we expect "IP:PORT" or "IP:PORT:tls"
-					Assert.That(addr, Is.Not.Null.Or.Empty);
-					Assert.That(FdbEndPoint.TryParse(addr, out var ep), Is.True, $"Result address '{addr}' is invalid");
+					Assert.That(address, Is.Not.Null.Or.Empty);
+					Assert.That(FdbEndPoint.TryParse(address, out var ep), Is.True, $"Result address '{address}' is invalid");
 					Assert.That(ep!.IsValid(), Is.True);
 					Assert.That(ep.Address, Is.Not.Null);
 					Assert.That(ep.Port, Is.GreaterThan(0));
@@ -2560,16 +2561,15 @@ namespace FoundationDB.Client.Tests
 
 				// the API still return a list of addresses, probably of servers that would store this value if you would call Set(...)
 
-				for (int i = 0; i < addresses.Length; i++)
+				foreach (var address in addresses)
 				{
-					var addr = addresses[i];
-					Log($"- {addr}");
+					Log($"- {address}");
 					// we expect "IP:PORT"
-					Assert.That(addr, Is.Not.Null.Or.Empty);
-					Assert.That(addr, Does.Contain(':'), "Result address '{0}' should contain a port number", addr);
-					int p = addr.IndexOf(':');
-					Assert.That(System.Net.IPAddress.TryParse(addr.AsSpan(0, p), out _), Is.True, "Result address '{0}' does not seem to have a valid IP address '{1}'", addr, addr.Substring(0, p));
-					Assert.That(int.TryParse(addr.AsSpan(p + 1), out _), Is.True, "Result address '{0}' does not seem to have a valid port number '{1}'", addr, addr.Substring(p + 1));
+					Assert.That(address, Is.Not.Null.Or.Empty);
+					Assert.That(address, Does.Contain(':'), "Result address '{0}' should contain a port number", address);
+					int p = address.IndexOf(':');
+					Assert.That(System.Net.IPAddress.TryParse(address.AsSpan(0, p), out _), Is.True, "Result address '{0}' does not seem to have a valid IP address '{1}'", address, address.Substring(0, p));
+					Assert.That(int.TryParse(address.AsSpan(p + 1), out _), Is.True, "Result address '{0}' does not seem to have a valid port number '{1}'", address, address[(p + 1)..]);
 				}
 
 			}
@@ -2611,7 +2611,7 @@ namespace FoundationDB.Client.Tests
 					.ToListAsync();
 				Log($"Key Servers: {shards.Count} shard(s)");
 
-				HashSet<string> distinctNodes = new HashSet<string>(StringComparer.Ordinal);
+				var distinctNodes = new HashSet<string>(StringComparer.Ordinal);
 				int replicationFactor = 0;
 				string[]? ids = null;
 				foreach (var key in shards)
@@ -3762,7 +3762,7 @@ namespace FoundationDB.Client.Tests
 				Assert.That(keys, Is.Not.Null.Or.Empty);
 				Log($"Found {keys.Length} split points");
 
-				// looking at the implementation, it guarantess that the first and last "split points" will be the bounds of the range repeated (even if the keys do not exist)
+				// looking at the implementation, it guarantees that the first and last "split points" will be the bounds of the range repeated (even if the keys do not exist)
 				Assert.That(keys, Has.Length.GreaterThan(2), "We expect at least 1 split point between the bounds of the range!");
 				Assert.That(keys[0], Is.EqualTo(begin), "First key should be the start of the range");
 				Assert.That(keys[^1], Is.EqualTo(end), "Last key should be the end of the range");


### PR DESCRIPTION
The current behavior of `ISubspaceLocation.Resolve` is to return `null` if the subspace does not exists, which causes a lot of inconsistencies in audited application code:
- Force callers to add a lot of `!` to hide the warnings
- Completely ignore the case where it could return null, causing a lot of nullref when starting the application on a database that is not initialized (or if the path is invalid, typo, ...)
- Add a check that is not really useful: the method called usually is in some business logic, and it cannot do anything about that (it is not its role to initialize the database!)

Looking at the code, only a handful of instances really need to handle the null case, mostly inside the binding itself, or in some test infrastructure, or database boostraper, most of the rest can simply be changed to a "required" semantic (ie: the method would throw with an appropriate error message).

This PR does the following:
- change the existing `Resolve()` method signature to return `ValueTask<TSubspace>` (non nullable), and throw an `InvalidOperationException` if the location does not exist (or is invalid in some way)
- add a new `TryResolve()` method with the old behavior (returns `null` if missing).
- rename the weird `Resolve(..., bool createIfMissing)` into `ResolveOrCreate(...)`.

What does it change in existing code?
- Hopefully nothing. Any code that was simply using '!' or a null-check to make the warning "go away" will still work fine in the normal case, apart for maybe extra warning (since now the return value is non-null)
- Only code that **MUST** know if the folder is missing have to be changed to call `TryResolve()`.
- Code that just wants the location to be auto-created should call `ResolveOrCreate()`.

### How to resolve a subspace in regular business logic code

Example before:
```c#
var subspace = (await tr.Resolve(location))!; // '!' used to mute the nullability warning
var key = subspace.Encode(/*.... */);
```
Example after:
```c#
var subspace = await tr.Resolve(location); // either throws or return a non-null subspace
var key = subspace.Encode(/*.... */);
```

### How to detect the case when a subspace is missing

Example before:
```c#
var subspace = await tr.Resolve(location);
if (subspace == null)
{
    // handle missing case
}
else
{
    // handle existing case
}
```
Example after:
```c#
var subspace = await tr.TryResolve(location); // use "TryResolve" instead
if (subspace == null)
{
    // handle missing case
}
else
{
    // handle existing case
}
```

### How to automatically create the subspace if it is missing

_note: This is not a good practice! You should probably have some bootstraper code that will initialize everything properly, and let normal business logic fail if something is not right_

Example before:
```c#
var subspace = await tr.Resolve(location, createIfMissing: true);
var key = subspace.Encode(/*.... */);
```
Example after:
```c#
var subspace = await tr.ResolveOrCreate(location);
var key = subspace.Encode(/*.... */);
```

